### PR TITLE
update dune code in the doc of @@deriving_inline

### DIFF
--- a/doc/ppx-for-end-users.rst
+++ b/doc/ppx-for-end-users.rst
@@ -89,7 +89,7 @@ in your ``dune`` file by ``lint``. For instance:
 
           (library
            (name my_lib)
-           (lint (pps (ppx_sexp_conv))))
+           (lint (pps ppx_sexp_conv)))
 
 Then to regenerate the parts between ``[@@deriving_inline]`` and
 ``[@@@end]``, run the following command:


### PR DESCRIPTION
The syntax used for the `lint` part of the `library` stanza was not working with a recent version of dune.

Signed-off-by: Louis Roché <louis@louisroche.net>

As requested, this is the same patch than https://github.com/ocaml-ppx/ppxlib/pull/97