### PR TITLE
Implement Longident on top of Astlib

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -6,6 +6,7 @@
   compiler-libs.common
   ocaml-compiler-libs.shadow
   ocaml-migrate-parsetree
+  astlib
   ppx.ast
   ppx.print_diff
   ppx_derivers

--- a/src/longident.ml
+++ b/src/longident.ml
@@ -56,13 +56,11 @@ let parse s =
   let invalid () =
     invalid_arg (Printf.sprintf "Ppx.Longident.parse: %S" s)
   in
-  match String.index s '(' with
-  | None -> parse_simple  s
-  | Some l -> match String.rindex_opt s ')' with
-    | None -> invalid ()
-    | Some r ->
-      if r <> String.length s - 1 then
-        invalid_arg "Ppx.Longident.parse";
+  match String.index s '(', String.rindex_opt s ')' with
+  | None, None -> parse_simple  s
+  | None, _ | _, None -> invalid ()
+  | Some l, Some r ->
+      if r <> String.length s - 1 then invalid ();
       let group = if r = l + 1 then "()" else
           String.trim (String.sub s ~pos:(l+1) ~len:(r-l-1))
       in

--- a/src/longident.ml
+++ b/src/longident.ml
@@ -53,10 +53,13 @@ let parse_simple s =
 
 (* handle ["A.B.(+.+)"] or ["Vec.(.%.()<-)"] *)
 let parse s =
+  let invalid () =
+    invalid_arg (Printf.sprintf "Ppx.Longident.parse: %S" s)
+  in
   match String.index s '(' with
   | None -> parse_simple  s
   | Some l -> match String.rindex_opt s ')' with
-    | None -> invalid_arg "Ppx.Longident.parse"
+    | None -> invalid ()
     | Some r ->
       if r <> String.length s - 1 then
         invalid_arg "Ppx.Longident.parse";
@@ -64,7 +67,7 @@ let parse s =
           String.trim (String.sub s ~pos:(l+1) ~len:(r-l-1))
       in
       if l = 0 then Lident group
-      else if s.[l - 1] <> '.' then invalid_arg "Ppx.Longident.parse"
+      else if s.[l - 1] <> '.' then invalid ()
       else
         let before = String.sub s ~pos:0 ~len:(l-1) in
         match String.split before ~on:'.' with

--- a/src/longident.ml
+++ b/src/longident.ml
@@ -58,12 +58,15 @@ let parse s =
   | Some l -> match String.rindex_opt s ')' with
     | None -> invalid_arg "Ppx.Longident.parse"
     | Some r ->
-      if not (Int.equal r (String.length s - 1)) then
+      if r <> String.length s - 1 then
         invalid_arg "Ppx.Longident.parse";
-      let group = if Int.equal r (l + 1) then "()" else
-          String.trim (String.sub s ~pos:(l+1) ~len:(r-l-1)) in
-      if Int.equal l 0 then Lident group else
+      let group = if r = l + 1 then "()" else
+          String.trim (String.sub s ~pos:(l+1) ~len:(r-l-1))
+      in
+      if l = 0 then Lident group
+      else if s.[l - 1] <> '.' then invalid_arg "Ppx.Longident.parse"
+      else
         let before = String.sub s ~pos:0 ~len:(l-1) in
         match String.split before ~on:'.' with
-        | [] -> Lident group
+        | [] -> assert false
         | s :: l -> Ldot(unflatten ~init:(Lident s) l, group)

--- a/src/longident.mli
+++ b/src/longident.mli
@@ -11,5 +11,11 @@ include Comparable.S with type t := t
 
 val flatten_exn : t -> string list
 val last_exn : t -> string
+
+(** Parses the given string as a longident, properly handling infix operators
+    which may contain '.'.
+    Note that it does not parse [Lapply _] longidents and will raise
+    [Invalid_argument _] if passed values such as ["A(B)"]. *)
 val parse : string -> t
+
 val name : t -> string

--- a/test/base/dune
+++ b/test/base/dune
@@ -6,7 +6,6 @@
  (action
   (chdir %{project_root}
    (progn
-    (setenv OCAMLRUNPARAM ""
-     (ignore-outputs
-      (run %{project_root}/test/expect/expect_test.exe %{test})))
+    (ignore-outputs
+     (run %{project_root}/test/expect/expect_test.exe %{test}))
     (diff? %{test} %{test}.corrected)))))

--- a/test/base/dune
+++ b/test/base/dune
@@ -3,8 +3,10 @@
  (deps
   (:test test.ml)
   (glob_files %{project_root}/src/.ppx.objs/byte/*.cmi))
- (action (chdir %{project_root}
-          (progn
-           (ignore-outputs
-            (run %{project_root}/test/expect/expect_test.exe %{test}))
-           (diff? %{test} %{test}.corrected)))))
+ (action
+  (chdir %{project_root}
+   (progn
+    (setenv OCAMLRUNPARAM ""
+     (ignore-outputs
+      (run %{project_root}/test/expect/expect_test.exe %{test})))
+    (diff? %{test} %{test}.corrected)))))

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -112,6 +112,11 @@ let _ = convert_longident "A.B(C)"
 Exception: Invalid_argument "Ppx.Longident.parse: \"A.B(C)\"".
 |}]
 
+let _ = convert_longident ")"
+[%%expect{|
+- : string * longident = ("( ) )", Ppx.Longident.Lident ")")
+|}]
+
 let _ = Ppx.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")
 [%%expect{|
 - : string = "dir/main.ml"

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -102,6 +102,19 @@ let _ = convert_longident "Base.( land )"
 ("Base.( land )", Ppx.Longident.Ldot (Ppx.Longident.Lident "Base", "land"))
 |}]
 
+let _ = convert_longident "A(B)"
+[%%expect{|
+- : string * longident =
+(".B", Ppx.Longident.Ldot (Ppx.Longident.Lident "", "B"))
+|}]
+
+let _ = convert_longident "A.B(C)"
+[%%expect{|
+- : string * longident =
+("A..C",
+ Ppx.Longident.Ldot (Ppx.Longident.Ldot (Ppx.Longident.Lident "A", ""), "C"))
+|}]
+
 let _ = Ppx.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")
 [%%expect{|
 - : string = "dir/main.ml"

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -104,15 +104,18 @@ let _ = convert_longident "Base.( land )"
 
 let _ = convert_longident "A(B)"
 [%%expect{|
-- : string * longident =
-(".B", Ppx.Longident.Ldot (Ppx.Longident.Lident "", "B"))
+Exception: Invalid_argument "Ppx.Longident.parse".
+Raised at file "stdlib.ml", line 34, characters 25-45
+Called from file "test/base/test.ml", line 3, characters 15-37
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
 |}]
 
 let _ = convert_longident "A.B(C)"
 [%%expect{|
-- : string * longident =
-("A..C",
- Ppx.Longident.Ldot (Ppx.Longident.Ldot (Ppx.Longident.Lident "A", ""), "C"))
+Exception: Invalid_argument "Ppx.Longident.parse".
+Raised at file "stdlib.ml", line 34, characters 25-45
+Called from file "test/base/test.ml", line 3, characters 15-37
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
 |}]
 
 let _ = Ppx.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -104,7 +104,7 @@ let _ = convert_longident "Base.( land )"
 
 let _ = convert_longident "A(B)"
 [%%expect{|
-Exception: Invalid_argument "Ppx.Longident.parse".
+Exception: Invalid_argument "Ppx.Longident.parse: \"A(B)\"".
 Raised at file "stdlib.ml", line 34, characters 25-45
 Called from file "test/base/test.ml", line 3, characters 15-37
 Called from file "toplevel/toploop.ml", line 180, characters 17-56
@@ -112,7 +112,7 @@ Called from file "toplevel/toploop.ml", line 180, characters 17-56
 
 let _ = convert_longident "A.B(C)"
 [%%expect{|
-Exception: Invalid_argument "Ppx.Longident.parse".
+Exception: Invalid_argument "Ppx.Longident.parse: \"A.B(C)\"".
 Raised at file "stdlib.ml", line 34, characters 25-45
 Called from file "test/base/test.ml", line 3, characters 15-37
 Called from file "toplevel/toploop.ml", line 180, characters 17-56

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -114,7 +114,7 @@ Exception: Invalid_argument "Ppx.Longident.parse: \"A.B(C)\"".
 
 let _ = convert_longident ")"
 [%%expect{|
-- : string * longident = ("( ) )", Ppx.Longident.Lident ")")
+Exception: Invalid_argument "Ppx.Longident.parse: \")\"".
 |}]
 
 let _ = Ppx.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -2,6 +2,8 @@
 #require "base";;
 #require "stdio";;
 
+let () = Printexc.record_backtrace false
+
 open Base
 open Stdio
 open Ppx

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -105,17 +105,11 @@ let _ = convert_longident "Base.( land )"
 let _ = convert_longident "A(B)"
 [%%expect{|
 Exception: Invalid_argument "Ppx.Longident.parse: \"A(B)\"".
-Raised at file "stdlib.ml", line 34, characters 25-45
-Called from file "test/base/test.ml", line 3, characters 15-37
-Called from file "toplevel/toploop.ml", line 180, characters 17-56
 |}]
 
 let _ = convert_longident "A.B(C)"
 [%%expect{|
 Exception: Invalid_argument "Ppx.Longident.parse: \"A.B(C)\"".
-Raised at file "stdlib.ml", line 34, characters 25-45
-Called from file "test/base/test.ml", line 3, characters 15-37
-Called from file "toplevel/toploop.ml", line 180, characters 17-56
 |}]
 
 let _ = Ppx.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")


### PR DESCRIPTION
This PR upgrades the `Longident` module to use `Astlib` instead of the `Parsetree` types directly.

Nothing special going on here but I'm just opening this as a proof of concept so we can discuss it and I make sure I'm heading in the right direction!

Entry points of the module converts from/to Parsetree so that its external API doesn't break. My intent is to do that for as much module as possible before I have to submit a huge upgrade of all the remaining code base.

You'll note the couple failwith that I inserted but that shouldn't be triggered, not sure how to best handle that currently.