### PR TITLE
Added Astlib interface for location types.

### DIFF
--- a/ast_versioned/cinaps/gen_versions.ml
+++ b/ast_versioned/cinaps/gen_versions.ml
@@ -9,8 +9,8 @@ module Render (Config : sig val internal : bool end) = struct
     | Char -> "char"
     | Int -> "int"
     | String -> "string"
-    | Location -> "Location.t"
-    | Loc ty -> string_of_ty ty ^ " Location.loc"
+    | Location -> "Astlib.Location.t"
+    | Loc ty -> string_of_ty ty ^ " Astlib.Loc.t"
     | List ty -> string_of_ty ty ^ " list"
     | Option ty -> string_of_ty ty ^ " option"
     | Tuple tuple -> string_of_tuple_type tuple

--- a/ast_versioned/data.ml
+++ b/ast_versioned/data.ml
@@ -22,16 +22,10 @@ module Helpers = struct
       loop list []
   end
 
-  module Loc = struct
-    type 'a t = 'a Location.loc
-
-    let map ({ loc; txt } : _ t) ~f = ({ loc; txt = f txt } : _ t)
-  end
-
   module Optional = struct
     module Loc = struct
-      let map (loc : _ Loc.t) ~f =
-        Option.map (f loc.txt) ~f:(fun txt -> { loc with txt })
+      let map (loc : _ Astlib.Loc.t) ~f =
+        Option.map (f (Astlib.Loc.txt loc)) ~f:(fun txt -> Astlib.Loc.update_txt loc ~txt)
     end
 
     module List = struct
@@ -58,7 +52,7 @@ let of_char x : t = Char x
 let of_int x : t = Int x
 let of_string x : t = String x
 let of_location x : t = Location x
-let of_loc x ~f : t = Loc (Helpers.Loc.map x ~f)
+let of_loc x ~f : t = Loc (Astlib.Loc.map x ~f)
 let of_list x ~f : t = List (List.map x ~f)
 let of_option x ~f : t = Option (Helpers.Option.map x ~f)
 let of_tuple2 (x1, x2) ~f1 ~f2 : t = Tuple [|f1 x1; f2 x2|]

--- a/ast_versioned/data.mli
+++ b/ast_versioned/data.mli
@@ -1,5 +1,3 @@
-open Ocaml_common
-
 type t = Node.t Astlib.Ast.data
 
 val of_node : Node.t -> t
@@ -7,8 +5,8 @@ val of_bool : bool -> t
 val of_char : char -> t
 val of_int : int -> t
 val of_string : string -> t
-val of_location : Location.t -> t
-val of_loc : 'a Location.loc -> f:('a -> t) -> t
+val of_location : Astlib.Location.t -> t
+val of_loc : 'a Astlib.Loc.t -> f:('a -> t) -> t
 val of_list : 'a list -> f:('a -> t) -> t
 val of_option : 'a option -> f:('a -> t) -> t
 
@@ -28,8 +26,8 @@ val to_bool : t -> bool option
 val to_char : t -> char option
 val to_int : t -> int option
 val to_string : t -> string option
-val to_location : t -> Location.t option
-val to_loc : t -> f:(t -> 'a option) -> 'a Location.loc option
+val to_location : t -> Astlib.Location.t option
+val to_loc : t -> f:(t -> 'a option) -> 'a Astlib.Loc.t option
 val to_list : t -> f:(t -> 'a option) -> 'a list option
 val to_option : t -> f:(t -> 'a option) -> 'a option option
 

--- a/ast_versioned/versions.ml
+++ b/ast_versioned/versions.ml
@@ -1,5 +1,3 @@
-open Ocaml_common
-
 module Helpers = struct
   module Option = struct
     let bind option ~f =
@@ -85,7 +83,7 @@ module V4_07 = struct
   module Longident_loc = struct
     type t = Node.t
 
-    type concrete = Node.t Location.loc
+    type concrete = Node.t Astlib.Loc.t
 
     let create =
       let data = (Data.of_loc ~f:Data.of_node) in
@@ -495,7 +493,7 @@ module V4_07 = struct
   module Attribute = struct
     type t = Node.t
 
-    type concrete = (string Location.loc * Node.t)
+    type concrete = (string Astlib.Loc.t * Node.t)
 
     let create =
       let data = (Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node) in
@@ -512,7 +510,7 @@ module V4_07 = struct
   module Extension = struct
     type t = Node.t
 
-    type concrete = (string Location.loc * Node.t)
+    type concrete = (string Astlib.Loc.t * Node.t)
 
     let create =
       let data = (Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node) in
@@ -629,7 +627,7 @@ module V4_07 = struct
 
     type concrete =
       { ptyp_desc : Node.t
-      ; ptyp_loc : Location.t
+      ; ptyp_loc : Astlib.Location.t
       ; ptyp_attributes : Node.t
       }
 
@@ -671,7 +669,7 @@ module V4_07 = struct
       | Ptyp_class of Node.t * Node.t list
       | Ptyp_alias of Node.t * string
       | Ptyp_variant of Node.t list * Node.t * Node.t list option
-      | Ptyp_poly of string Location.loc list * Node.t
+      | Ptyp_poly of string Astlib.Loc.t list * Node.t
       | Ptyp_package of Node.t
       | Ptyp_extension of Node.t
 
@@ -886,7 +884,7 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      | Rtag of Node.t Location.loc * Node.t * bool * Node.t list
+      | Rtag of Node.t Astlib.Loc.t * Node.t * bool * Node.t list
       | Rinherit of Node.t
 
     let rtag x1 x2 x3 x4 =
@@ -941,7 +939,7 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      | Otag of Node.t Location.loc * Node.t * Node.t
+      | Otag of Node.t Astlib.Loc.t * Node.t * Node.t
       | Oinherit of Node.t
 
     let otag x1 x2 x3 =
@@ -995,7 +993,7 @@ module V4_07 = struct
 
     type concrete =
       { ppat_desc : Node.t
-      ; ppat_loc : Location.t
+      ; ppat_loc : Astlib.Location.t
       ; ppat_attributes : Node.t
       }
 
@@ -1029,8 +1027,8 @@ module V4_07 = struct
 
     type concrete =
       | Ppat_any
-      | Ppat_var of string Location.loc
-      | Ppat_alias of Node.t * string Location.loc
+      | Ppat_var of string Astlib.Loc.t
+      | Ppat_alias of Node.t * string Astlib.Loc.t
       | Ppat_constant of Node.t
       | Ppat_interval of Node.t * Node.t
       | Ppat_tuple of Node.t list
@@ -1042,7 +1040,7 @@ module V4_07 = struct
       | Ppat_constraint of Node.t * Node.t
       | Ppat_type of Node.t
       | Ppat_lazy of Node.t
-      | Ppat_unpack of string Location.loc
+      | Ppat_unpack of string Astlib.Loc.t
       | Ppat_exception of Node.t
       | Ppat_extension of Node.t
       | Ppat_open of Node.t * Node.t
@@ -1324,7 +1322,7 @@ module V4_07 = struct
 
     type concrete =
       { pexp_desc : Node.t
-      ; pexp_loc : Location.t
+      ; pexp_loc : Astlib.Location.t
       ; pexp_attributes : Node.t
       }
 
@@ -1378,17 +1376,17 @@ module V4_07 = struct
       | Pexp_for of Node.t * Node.t * Node.t * Node.t * Node.t
       | Pexp_constraint of Node.t * Node.t
       | Pexp_coerce of Node.t * Node.t option * Node.t
-      | Pexp_send of Node.t * Node.t Location.loc
+      | Pexp_send of Node.t * Node.t Astlib.Loc.t
       | Pexp_new of Node.t
-      | Pexp_setinstvar of Node.t Location.loc * Node.t
-      | Pexp_override of (Node.t Location.loc * Node.t) list
-      | Pexp_letmodule of string Location.loc * Node.t * Node.t
+      | Pexp_setinstvar of Node.t Astlib.Loc.t * Node.t
+      | Pexp_override of (Node.t Astlib.Loc.t * Node.t) list
+      | Pexp_letmodule of string Astlib.Loc.t * Node.t * Node.t
       | Pexp_letexception of Node.t * Node.t
       | Pexp_assert of Node.t
       | Pexp_lazy of Node.t
       | Pexp_poly of Node.t * Node.t option
       | Pexp_object of Node.t
-      | Pexp_newtype of string Location.loc * Node.t
+      | Pexp_newtype of string Astlib.Loc.t * Node.t
       | Pexp_pack of Node.t
       | Pexp_open of Node.t * Node.t * Node.t
       | Pexp_extension of Node.t
@@ -2008,11 +2006,11 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      { pval_name : string Location.loc
+      { pval_name : string Astlib.Loc.t
       ; pval_type : Node.t
       ; pval_prim : string list
       ; pval_attributes : Node.t
-      ; pval_loc : Location.t
+      ; pval_loc : Astlib.Location.t
       }
 
     let create ~pval_name ~pval_type ~pval_prim ~pval_attributes ~pval_loc =
@@ -2048,14 +2046,14 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      { ptype_name : string Location.loc
+      { ptype_name : string Astlib.Loc.t
       ; ptype_params : (Node.t * Node.t) list
-      ; ptype_cstrs : (Node.t * Node.t * Location.t) list
+      ; ptype_cstrs : (Node.t * Node.t * Astlib.Location.t) list
       ; ptype_kind : Node.t
       ; ptype_private : Node.t
       ; ptype_manifest : Node.t option
       ; ptype_attributes : Node.t
-      ; ptype_loc : Location.t
+      ; ptype_loc : Astlib.Location.t
       }
 
     let create ~ptype_name ~ptype_params ~ptype_cstrs ~ptype_kind ~ptype_private ~ptype_manifest ~ptype_attributes ~ptype_loc =
@@ -2156,10 +2154,10 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      { pld_name : string Location.loc
+      { pld_name : string Astlib.Loc.t
       ; pld_mutable : Node.t
       ; pld_type : Node.t
-      ; pld_loc : Location.t
+      ; pld_loc : Astlib.Location.t
       ; pld_attributes : Node.t
       }
 
@@ -2196,10 +2194,10 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      { pcd_name : string Location.loc
+      { pcd_name : string Astlib.Loc.t
       ; pcd_args : Node.t
       ; pcd_res : Node.t option
-      ; pcd_loc : Location.t
+      ; pcd_loc : Astlib.Location.t
       ; pcd_attributes : Node.t
       }
 
@@ -2325,9 +2323,9 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      { pext_name : string Location.loc
+      { pext_name : string Astlib.Loc.t
       ; pext_kind : Node.t
-      ; pext_loc : Location.t
+      ; pext_loc : Astlib.Location.t
       ; pext_attributes : Node.t
       }
 
@@ -2414,7 +2412,7 @@ module V4_07 = struct
 
     type concrete =
       { pcty_desc : Node.t
-      ; pcty_loc : Location.t
+      ; pcty_loc : Astlib.Location.t
       ; pcty_attributes : Node.t
       }
 
@@ -2583,7 +2581,7 @@ module V4_07 = struct
 
     type concrete =
       { pctf_desc : Node.t
-      ; pctf_loc : Location.t
+      ; pctf_loc : Astlib.Location.t
       ; pctf_attributes : Node.t
       }
 
@@ -2617,8 +2615,8 @@ module V4_07 = struct
 
     type concrete =
       | Pctf_inherit of Node.t
-      | Pctf_val of (Node.t Location.loc * Node.t * Node.t * Node.t)
-      | Pctf_method of (Node.t Location.loc * Node.t * Node.t * Node.t)
+      | Pctf_val of (Node.t Astlib.Loc.t * Node.t * Node.t * Node.t)
+      | Pctf_method of (Node.t Astlib.Loc.t * Node.t * Node.t * Node.t)
       | Pctf_constraint of (Node.t * Node.t)
       | Pctf_attribute of Node.t
       | Pctf_extension of Node.t
@@ -2727,9 +2725,9 @@ module V4_07 = struct
     type 'a concrete =
       { pci_virt : Node.t
       ; pci_params : (Node.t * Node.t) list
-      ; pci_name : string Location.loc
+      ; pci_name : string Astlib.Loc.t
       ; pci_expr : 'a
-      ; pci_loc : Location.t
+      ; pci_loc : Astlib.Location.t
       ; pci_attributes : Node.t
       }
 
@@ -2827,7 +2825,7 @@ module V4_07 = struct
 
     type concrete =
       { pcl_desc : Node.t
-      ; pcl_loc : Location.t
+      ; pcl_loc : Astlib.Location.t
       ; pcl_attributes : Node.t
       }
 
@@ -3051,7 +3049,7 @@ module V4_07 = struct
 
     type concrete =
       { pcf_desc : Node.t
-      ; pcf_loc : Location.t
+      ; pcf_loc : Astlib.Location.t
       ; pcf_attributes : Node.t
       }
 
@@ -3084,9 +3082,9 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      | Pcf_inherit of Node.t * Node.t * string Location.loc option
-      | Pcf_val of (Node.t Location.loc * Node.t * Node.t)
-      | Pcf_method of (Node.t Location.loc * Node.t * Node.t)
+      | Pcf_inherit of Node.t * Node.t * string Astlib.Loc.t option
+      | Pcf_val of (Node.t Astlib.Loc.t * Node.t * Node.t)
+      | Pcf_method of (Node.t Astlib.Loc.t * Node.t * Node.t)
       | Pcf_constraint of (Node.t * Node.t)
       | Pcf_initializer of Node.t
       | Pcf_attribute of Node.t
@@ -3281,7 +3279,7 @@ module V4_07 = struct
 
     type concrete =
       { pmty_desc : Node.t
-      ; pmty_loc : Location.t
+      ; pmty_loc : Astlib.Location.t
       ; pmty_attributes : Node.t
       }
 
@@ -3316,7 +3314,7 @@ module V4_07 = struct
     type concrete =
       | Pmty_ident of Node.t
       | Pmty_signature of Node.t
-      | Pmty_functor of string Location.loc * Node.t option * Node.t
+      | Pmty_functor of string Astlib.Loc.t * Node.t option * Node.t
       | Pmty_with of Node.t * Node.t list
       | Pmty_typeof of Node.t
       | Pmty_extension of Node.t
@@ -3462,7 +3460,7 @@ module V4_07 = struct
 
     type concrete =
       { psig_desc : Node.t
-      ; psig_loc : Location.t
+      ; psig_loc : Astlib.Location.t
       }
 
     let create ~psig_desc ~psig_loc =
@@ -3710,10 +3708,10 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      { pmd_name : string Location.loc
+      { pmd_name : string Astlib.Loc.t
       ; pmd_type : Node.t
       ; pmd_attributes : Node.t
-      ; pmd_loc : Location.t
+      ; pmd_loc : Astlib.Location.t
       }
 
     let create ~pmd_name ~pmd_type ~pmd_attributes ~pmd_loc =
@@ -3747,10 +3745,10 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      { pmtd_name : string Location.loc
+      { pmtd_name : string Astlib.Loc.t
       ; pmtd_type : Node.t option
       ; pmtd_attributes : Node.t
-      ; pmtd_loc : Location.t
+      ; pmtd_loc : Astlib.Location.t
       }
 
     let create ~pmtd_name ~pmtd_type ~pmtd_attributes ~pmtd_loc =
@@ -3786,7 +3784,7 @@ module V4_07 = struct
     type concrete =
       { popen_lid : Node.t
       ; popen_override : Node.t
-      ; popen_loc : Location.t
+      ; popen_loc : Astlib.Location.t
       ; popen_attributes : Node.t
       }
 
@@ -3822,7 +3820,7 @@ module V4_07 = struct
 
     type 'a concrete =
       { pincl_mod : 'a
-      ; pincl_loc : Location.t
+      ; pincl_loc : Astlib.Location.t
       ; pincl_attributes : Node.t
       }
 
@@ -4001,7 +3999,7 @@ module V4_07 = struct
 
     type concrete =
       { pmod_desc : Node.t
-      ; pmod_loc : Location.t
+      ; pmod_loc : Astlib.Location.t
       ; pmod_attributes : Node.t
       }
 
@@ -4036,7 +4034,7 @@ module V4_07 = struct
     type concrete =
       | Pmod_ident of Node.t
       | Pmod_structure of Node.t
-      | Pmod_functor of string Location.loc * Node.t option * Node.t
+      | Pmod_functor of string Astlib.Loc.t * Node.t option * Node.t
       | Pmod_apply of Node.t * Node.t
       | Pmod_constraint of Node.t * Node.t
       | Pmod_unpack of Node.t
@@ -4184,7 +4182,7 @@ module V4_07 = struct
 
     type concrete =
       { pstr_desc : Node.t
-      ; pstr_loc : Location.t
+      ; pstr_loc : Astlib.Location.t
       }
 
     let create ~pstr_desc ~pstr_loc =
@@ -4469,7 +4467,7 @@ module V4_07 = struct
       { pvb_pat : Node.t
       ; pvb_expr : Node.t
       ; pvb_attributes : Node.t
-      ; pvb_loc : Location.t
+      ; pvb_loc : Astlib.Location.t
       }
 
     let create ~pvb_pat ~pvb_expr ~pvb_attributes ~pvb_loc =
@@ -4503,10 +4501,10 @@ module V4_07 = struct
     type t = Node.t
 
     type concrete =
-      { pmb_name : string Location.loc
+      { pmb_name : string Astlib.Loc.t
       ; pmb_expr : Node.t
       ; pmb_attributes : Node.t
-      ; pmb_loc : Location.t
+      ; pmb_loc : Astlib.Location.t
       }
 
     let create ~pmb_name ~pmb_expr ~pmb_attributes ~pmb_loc =
@@ -4749,7 +4747,7 @@ module V4_06 = struct
   module Longident_loc = struct
     type t = Node.t
 
-    type concrete = Node.t Location.loc
+    type concrete = Node.t Astlib.Loc.t
 
     let create =
       let data = (Data.of_loc ~f:Data.of_node) in
@@ -5159,7 +5157,7 @@ module V4_06 = struct
   module Attribute = struct
     type t = Node.t
 
-    type concrete = (string Location.loc * Node.t)
+    type concrete = (string Astlib.Loc.t * Node.t)
 
     let create =
       let data = (Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node) in
@@ -5176,7 +5174,7 @@ module V4_06 = struct
   module Extension = struct
     type t = Node.t
 
-    type concrete = (string Location.loc * Node.t)
+    type concrete = (string Astlib.Loc.t * Node.t)
 
     let create =
       let data = (Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node) in
@@ -5293,7 +5291,7 @@ module V4_06 = struct
 
     type concrete =
       { ptyp_desc : Node.t
-      ; ptyp_loc : Location.t
+      ; ptyp_loc : Astlib.Location.t
       ; ptyp_attributes : Node.t
       }
 
@@ -5335,7 +5333,7 @@ module V4_06 = struct
       | Ptyp_class of Node.t * Node.t list
       | Ptyp_alias of Node.t * string
       | Ptyp_variant of Node.t list * Node.t * Node.t list option
-      | Ptyp_poly of string Location.loc list * Node.t
+      | Ptyp_poly of string Astlib.Loc.t list * Node.t
       | Ptyp_package of Node.t
       | Ptyp_extension of Node.t
 
@@ -5550,7 +5548,7 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      | Rtag of Node.t Location.loc * Node.t * bool * Node.t list
+      | Rtag of Node.t Astlib.Loc.t * Node.t * bool * Node.t list
       | Rinherit of Node.t
 
     let rtag x1 x2 x3 x4 =
@@ -5605,7 +5603,7 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      | Otag of Node.t Location.loc * Node.t * Node.t
+      | Otag of Node.t Astlib.Loc.t * Node.t * Node.t
       | Oinherit of Node.t
 
     let otag x1 x2 x3 =
@@ -5659,7 +5657,7 @@ module V4_06 = struct
 
     type concrete =
       { ppat_desc : Node.t
-      ; ppat_loc : Location.t
+      ; ppat_loc : Astlib.Location.t
       ; ppat_attributes : Node.t
       }
 
@@ -5693,8 +5691,8 @@ module V4_06 = struct
 
     type concrete =
       | Ppat_any
-      | Ppat_var of string Location.loc
-      | Ppat_alias of Node.t * string Location.loc
+      | Ppat_var of string Astlib.Loc.t
+      | Ppat_alias of Node.t * string Astlib.Loc.t
       | Ppat_constant of Node.t
       | Ppat_interval of Node.t * Node.t
       | Ppat_tuple of Node.t list
@@ -5706,7 +5704,7 @@ module V4_06 = struct
       | Ppat_constraint of Node.t * Node.t
       | Ppat_type of Node.t
       | Ppat_lazy of Node.t
-      | Ppat_unpack of string Location.loc
+      | Ppat_unpack of string Astlib.Loc.t
       | Ppat_exception of Node.t
       | Ppat_extension of Node.t
       | Ppat_open of Node.t * Node.t
@@ -5988,7 +5986,7 @@ module V4_06 = struct
 
     type concrete =
       { pexp_desc : Node.t
-      ; pexp_loc : Location.t
+      ; pexp_loc : Astlib.Location.t
       ; pexp_attributes : Node.t
       }
 
@@ -6042,17 +6040,17 @@ module V4_06 = struct
       | Pexp_for of Node.t * Node.t * Node.t * Node.t * Node.t
       | Pexp_constraint of Node.t * Node.t
       | Pexp_coerce of Node.t * Node.t option * Node.t
-      | Pexp_send of Node.t * Node.t Location.loc
+      | Pexp_send of Node.t * Node.t Astlib.Loc.t
       | Pexp_new of Node.t
-      | Pexp_setinstvar of Node.t Location.loc * Node.t
-      | Pexp_override of (Node.t Location.loc * Node.t) list
-      | Pexp_letmodule of string Location.loc * Node.t * Node.t
+      | Pexp_setinstvar of Node.t Astlib.Loc.t * Node.t
+      | Pexp_override of (Node.t Astlib.Loc.t * Node.t) list
+      | Pexp_letmodule of string Astlib.Loc.t * Node.t * Node.t
       | Pexp_letexception of Node.t * Node.t
       | Pexp_assert of Node.t
       | Pexp_lazy of Node.t
       | Pexp_poly of Node.t * Node.t option
       | Pexp_object of Node.t
-      | Pexp_newtype of string Location.loc * Node.t
+      | Pexp_newtype of string Astlib.Loc.t * Node.t
       | Pexp_pack of Node.t
       | Pexp_open of Node.t * Node.t * Node.t
       | Pexp_extension of Node.t
@@ -6672,11 +6670,11 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      { pval_name : string Location.loc
+      { pval_name : string Astlib.Loc.t
       ; pval_type : Node.t
       ; pval_prim : string list
       ; pval_attributes : Node.t
-      ; pval_loc : Location.t
+      ; pval_loc : Astlib.Location.t
       }
 
     let create ~pval_name ~pval_type ~pval_prim ~pval_attributes ~pval_loc =
@@ -6712,14 +6710,14 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      { ptype_name : string Location.loc
+      { ptype_name : string Astlib.Loc.t
       ; ptype_params : (Node.t * Node.t) list
-      ; ptype_cstrs : (Node.t * Node.t * Location.t) list
+      ; ptype_cstrs : (Node.t * Node.t * Astlib.Location.t) list
       ; ptype_kind : Node.t
       ; ptype_private : Node.t
       ; ptype_manifest : Node.t option
       ; ptype_attributes : Node.t
-      ; ptype_loc : Location.t
+      ; ptype_loc : Astlib.Location.t
       }
 
     let create ~ptype_name ~ptype_params ~ptype_cstrs ~ptype_kind ~ptype_private ~ptype_manifest ~ptype_attributes ~ptype_loc =
@@ -6820,10 +6818,10 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      { pld_name : string Location.loc
+      { pld_name : string Astlib.Loc.t
       ; pld_mutable : Node.t
       ; pld_type : Node.t
-      ; pld_loc : Location.t
+      ; pld_loc : Astlib.Location.t
       ; pld_attributes : Node.t
       }
 
@@ -6860,10 +6858,10 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      { pcd_name : string Location.loc
+      { pcd_name : string Astlib.Loc.t
       ; pcd_args : Node.t
       ; pcd_res : Node.t option
-      ; pcd_loc : Location.t
+      ; pcd_loc : Astlib.Location.t
       ; pcd_attributes : Node.t
       }
 
@@ -6989,9 +6987,9 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      { pext_name : string Location.loc
+      { pext_name : string Astlib.Loc.t
       ; pext_kind : Node.t
-      ; pext_loc : Location.t
+      ; pext_loc : Astlib.Location.t
       ; pext_attributes : Node.t
       }
 
@@ -7078,7 +7076,7 @@ module V4_06 = struct
 
     type concrete =
       { pcty_desc : Node.t
-      ; pcty_loc : Location.t
+      ; pcty_loc : Astlib.Location.t
       ; pcty_attributes : Node.t
       }
 
@@ -7247,7 +7245,7 @@ module V4_06 = struct
 
     type concrete =
       { pctf_desc : Node.t
-      ; pctf_loc : Location.t
+      ; pctf_loc : Astlib.Location.t
       ; pctf_attributes : Node.t
       }
 
@@ -7281,8 +7279,8 @@ module V4_06 = struct
 
     type concrete =
       | Pctf_inherit of Node.t
-      | Pctf_val of (Node.t Location.loc * Node.t * Node.t * Node.t)
-      | Pctf_method of (Node.t Location.loc * Node.t * Node.t * Node.t)
+      | Pctf_val of (Node.t Astlib.Loc.t * Node.t * Node.t * Node.t)
+      | Pctf_method of (Node.t Astlib.Loc.t * Node.t * Node.t * Node.t)
       | Pctf_constraint of (Node.t * Node.t)
       | Pctf_attribute of Node.t
       | Pctf_extension of Node.t
@@ -7391,9 +7389,9 @@ module V4_06 = struct
     type 'a concrete =
       { pci_virt : Node.t
       ; pci_params : (Node.t * Node.t) list
-      ; pci_name : string Location.loc
+      ; pci_name : string Astlib.Loc.t
       ; pci_expr : 'a
-      ; pci_loc : Location.t
+      ; pci_loc : Astlib.Location.t
       ; pci_attributes : Node.t
       }
 
@@ -7491,7 +7489,7 @@ module V4_06 = struct
 
     type concrete =
       { pcl_desc : Node.t
-      ; pcl_loc : Location.t
+      ; pcl_loc : Astlib.Location.t
       ; pcl_attributes : Node.t
       }
 
@@ -7715,7 +7713,7 @@ module V4_06 = struct
 
     type concrete =
       { pcf_desc : Node.t
-      ; pcf_loc : Location.t
+      ; pcf_loc : Astlib.Location.t
       ; pcf_attributes : Node.t
       }
 
@@ -7748,9 +7746,9 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      | Pcf_inherit of Node.t * Node.t * string Location.loc option
-      | Pcf_val of (Node.t Location.loc * Node.t * Node.t)
-      | Pcf_method of (Node.t Location.loc * Node.t * Node.t)
+      | Pcf_inherit of Node.t * Node.t * string Astlib.Loc.t option
+      | Pcf_val of (Node.t Astlib.Loc.t * Node.t * Node.t)
+      | Pcf_method of (Node.t Astlib.Loc.t * Node.t * Node.t)
       | Pcf_constraint of (Node.t * Node.t)
       | Pcf_initializer of Node.t
       | Pcf_attribute of Node.t
@@ -7945,7 +7943,7 @@ module V4_06 = struct
 
     type concrete =
       { pmty_desc : Node.t
-      ; pmty_loc : Location.t
+      ; pmty_loc : Astlib.Location.t
       ; pmty_attributes : Node.t
       }
 
@@ -7980,7 +7978,7 @@ module V4_06 = struct
     type concrete =
       | Pmty_ident of Node.t
       | Pmty_signature of Node.t
-      | Pmty_functor of string Location.loc * Node.t option * Node.t
+      | Pmty_functor of string Astlib.Loc.t * Node.t option * Node.t
       | Pmty_with of Node.t * Node.t list
       | Pmty_typeof of Node.t
       | Pmty_extension of Node.t
@@ -8126,7 +8124,7 @@ module V4_06 = struct
 
     type concrete =
       { psig_desc : Node.t
-      ; psig_loc : Location.t
+      ; psig_loc : Astlib.Location.t
       }
 
     let create ~psig_desc ~psig_loc =
@@ -8374,10 +8372,10 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      { pmd_name : string Location.loc
+      { pmd_name : string Astlib.Loc.t
       ; pmd_type : Node.t
       ; pmd_attributes : Node.t
-      ; pmd_loc : Location.t
+      ; pmd_loc : Astlib.Location.t
       }
 
     let create ~pmd_name ~pmd_type ~pmd_attributes ~pmd_loc =
@@ -8411,10 +8409,10 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      { pmtd_name : string Location.loc
+      { pmtd_name : string Astlib.Loc.t
       ; pmtd_type : Node.t option
       ; pmtd_attributes : Node.t
-      ; pmtd_loc : Location.t
+      ; pmtd_loc : Astlib.Location.t
       }
 
     let create ~pmtd_name ~pmtd_type ~pmtd_attributes ~pmtd_loc =
@@ -8450,7 +8448,7 @@ module V4_06 = struct
     type concrete =
       { popen_lid : Node.t
       ; popen_override : Node.t
-      ; popen_loc : Location.t
+      ; popen_loc : Astlib.Location.t
       ; popen_attributes : Node.t
       }
 
@@ -8486,7 +8484,7 @@ module V4_06 = struct
 
     type 'a concrete =
       { pincl_mod : 'a
-      ; pincl_loc : Location.t
+      ; pincl_loc : Astlib.Location.t
       ; pincl_attributes : Node.t
       }
 
@@ -8665,7 +8663,7 @@ module V4_06 = struct
 
     type concrete =
       { pmod_desc : Node.t
-      ; pmod_loc : Location.t
+      ; pmod_loc : Astlib.Location.t
       ; pmod_attributes : Node.t
       }
 
@@ -8700,7 +8698,7 @@ module V4_06 = struct
     type concrete =
       | Pmod_ident of Node.t
       | Pmod_structure of Node.t
-      | Pmod_functor of string Location.loc * Node.t option * Node.t
+      | Pmod_functor of string Astlib.Loc.t * Node.t option * Node.t
       | Pmod_apply of Node.t * Node.t
       | Pmod_constraint of Node.t * Node.t
       | Pmod_unpack of Node.t
@@ -8848,7 +8846,7 @@ module V4_06 = struct
 
     type concrete =
       { pstr_desc : Node.t
-      ; pstr_loc : Location.t
+      ; pstr_loc : Astlib.Location.t
       }
 
     let create ~pstr_desc ~pstr_loc =
@@ -9133,7 +9131,7 @@ module V4_06 = struct
       { pvb_pat : Node.t
       ; pvb_expr : Node.t
       ; pvb_attributes : Node.t
-      ; pvb_loc : Location.t
+      ; pvb_loc : Astlib.Location.t
       }
 
     let create ~pvb_pat ~pvb_expr ~pvb_attributes ~pvb_loc =
@@ -9167,10 +9165,10 @@ module V4_06 = struct
     type t = Node.t
 
     type concrete =
-      { pmb_name : string Location.loc
+      { pmb_name : string Astlib.Loc.t
       ; pmb_expr : Node.t
       ; pmb_attributes : Node.t
-      ; pmb_loc : Location.t
+      ; pmb_loc : Astlib.Location.t
       }
 
     let create ~pmb_name ~pmb_expr ~pmb_attributes ~pmb_loc =

--- a/ast_versioned/versions.mli
+++ b/ast_versioned/versions.mli
@@ -1,5 +1,3 @@
-open Ocaml_common
-
 (*$ Ppx_ast_versioned_cinaps.print_versions_mli () *)
 module V4_07 : sig
   module rec Longident : sig
@@ -29,12 +27,12 @@ module V4_07 : sig
   and Longident_loc : sig
     type t
 
-    type concrete = Longident.t Location.loc
+    type concrete = Longident.t Astlib.Loc.t
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
-    val create : Longident.t Location.loc -> t
+    val create : Longident.t Astlib.Loc.t -> t
   end
 
   and Rec_flag : sig
@@ -214,23 +212,23 @@ module V4_07 : sig
   and Attribute : sig
     type t
 
-    type concrete = (string Location.loc * Payload.t)
+    type concrete = (string Astlib.Loc.t * Payload.t)
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
-    val create : (string Location.loc * Payload.t) -> t
+    val create : (string Astlib.Loc.t * Payload.t) -> t
   end
 
   and Extension : sig
     type t
 
-    type concrete = (string Location.loc * Payload.t)
+    type concrete = (string Astlib.Loc.t * Payload.t)
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
-    val create : (string Location.loc * Payload.t) -> t
+    val create : (string Astlib.Loc.t * Payload.t) -> t
   end
 
   and Attributes : sig
@@ -276,7 +274,7 @@ module V4_07 : sig
 
     type concrete =
       { ptyp_desc : Core_type_desc.t
-      ; ptyp_loc : Location.t
+      ; ptyp_loc : Astlib.Location.t
       ; ptyp_attributes : Attributes.t
       }
 
@@ -285,7 +283,7 @@ module V4_07 : sig
 
     val create :
       ptyp_desc:Core_type_desc.t
-      -> ptyp_loc:Location.t
+      -> ptyp_loc:Astlib.Location.t
       -> ptyp_attributes:Attributes.t
       -> t
   end
@@ -303,7 +301,7 @@ module V4_07 : sig
       | Ptyp_class of Longident_loc.t * Core_type.t list
       | Ptyp_alias of Core_type.t * string
       | Ptyp_variant of Row_field.t list * Closed_flag.t * Label.t list option
-      | Ptyp_poly of string Location.loc list * Core_type.t
+      | Ptyp_poly of string Astlib.Loc.t list * Core_type.t
       | Ptyp_package of Package_type.t
       | Ptyp_extension of Extension.t
 
@@ -344,7 +342,7 @@ module V4_07 : sig
       -> Label.t list option
       -> t
     val ptyp_poly :
-      string Location.loc list
+      string Astlib.Loc.t list
       -> Core_type.t
       -> t
     val ptyp_package :
@@ -370,14 +368,14 @@ module V4_07 : sig
     type t
 
     type concrete =
-      | Rtag of Label.t Location.loc * Attributes.t * bool * Core_type.t list
+      | Rtag of Label.t Astlib.Loc.t * Attributes.t * bool * Core_type.t list
       | Rinherit of Core_type.t
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val rtag :
-      Label.t Location.loc
+      Label.t Astlib.Loc.t
       -> Attributes.t
       -> bool
       -> Core_type.t list
@@ -391,14 +389,14 @@ module V4_07 : sig
     type t
 
     type concrete =
-      | Otag of Label.t Location.loc * Attributes.t * Core_type.t
+      | Otag of Label.t Astlib.Loc.t * Attributes.t * Core_type.t
       | Oinherit of Core_type.t
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val otag :
-      Label.t Location.loc
+      Label.t Astlib.Loc.t
       -> Attributes.t
       -> Core_type.t
       -> t
@@ -412,7 +410,7 @@ module V4_07 : sig
 
     type concrete =
       { ppat_desc : Pattern_desc.t
-      ; ppat_loc : Location.t
+      ; ppat_loc : Astlib.Location.t
       ; ppat_attributes : Attributes.t
       }
 
@@ -421,7 +419,7 @@ module V4_07 : sig
 
     val create :
       ppat_desc:Pattern_desc.t
-      -> ppat_loc:Location.t
+      -> ppat_loc:Astlib.Location.t
       -> ppat_attributes:Attributes.t
       -> t
   end
@@ -431,8 +429,8 @@ module V4_07 : sig
 
     type concrete =
       | Ppat_any
-      | Ppat_var of string Location.loc
-      | Ppat_alias of Pattern.t * string Location.loc
+      | Ppat_var of string Astlib.Loc.t
+      | Ppat_alias of Pattern.t * string Astlib.Loc.t
       | Ppat_constant of Constant.t
       | Ppat_interval of Constant.t * Constant.t
       | Ppat_tuple of Pattern.t list
@@ -444,7 +442,7 @@ module V4_07 : sig
       | Ppat_constraint of Pattern.t * Core_type.t
       | Ppat_type of Longident_loc.t
       | Ppat_lazy of Pattern.t
-      | Ppat_unpack of string Location.loc
+      | Ppat_unpack of string Astlib.Loc.t
       | Ppat_exception of Pattern.t
       | Ppat_extension of Extension.t
       | Ppat_open of Longident_loc.t * Pattern.t
@@ -454,11 +452,11 @@ module V4_07 : sig
 
     val ppat_any : t
     val ppat_var :
-      string Location.loc
+      string Astlib.Loc.t
       -> t
     val ppat_alias :
       Pattern.t
-      -> string Location.loc
+      -> string Astlib.Loc.t
       -> t
     val ppat_constant :
       Constant.t
@@ -500,7 +498,7 @@ module V4_07 : sig
       Pattern.t
       -> t
     val ppat_unpack :
-      string Location.loc
+      string Astlib.Loc.t
       -> t
     val ppat_exception :
       Pattern.t
@@ -519,7 +517,7 @@ module V4_07 : sig
 
     type concrete =
       { pexp_desc : Expression_desc.t
-      ; pexp_loc : Location.t
+      ; pexp_loc : Astlib.Location.t
       ; pexp_attributes : Attributes.t
       }
 
@@ -528,7 +526,7 @@ module V4_07 : sig
 
     val create :
       pexp_desc:Expression_desc.t
-      -> pexp_loc:Location.t
+      -> pexp_loc:Astlib.Location.t
       -> pexp_attributes:Attributes.t
       -> t
   end
@@ -558,17 +556,17 @@ module V4_07 : sig
       | Pexp_for of Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t
       | Pexp_constraint of Expression.t * Core_type.t
       | Pexp_coerce of Expression.t * Core_type.t option * Core_type.t
-      | Pexp_send of Expression.t * Label.t Location.loc
+      | Pexp_send of Expression.t * Label.t Astlib.Loc.t
       | Pexp_new of Longident_loc.t
-      | Pexp_setinstvar of Label.t Location.loc * Expression.t
-      | Pexp_override of (Label.t Location.loc * Expression.t) list
-      | Pexp_letmodule of string Location.loc * Module_expr.t * Expression.t
+      | Pexp_setinstvar of Label.t Astlib.Loc.t * Expression.t
+      | Pexp_override of (Label.t Astlib.Loc.t * Expression.t) list
+      | Pexp_letmodule of string Astlib.Loc.t * Module_expr.t * Expression.t
       | Pexp_letexception of Extension_constructor.t * Expression.t
       | Pexp_assert of Expression.t
       | Pexp_lazy of Expression.t
       | Pexp_poly of Expression.t * Core_type.t option
       | Pexp_object of Class_structure.t
-      | Pexp_newtype of string Location.loc * Expression.t
+      | Pexp_newtype of string Astlib.Loc.t * Expression.t
       | Pexp_pack of Module_expr.t
       | Pexp_open of Override_flag.t * Longident_loc.t * Expression.t
       | Pexp_extension of Extension.t
@@ -667,20 +665,20 @@ module V4_07 : sig
       -> t
     val pexp_send :
       Expression.t
-      -> Label.t Location.loc
+      -> Label.t Astlib.Loc.t
       -> t
     val pexp_new :
       Longident_loc.t
       -> t
     val pexp_setinstvar :
-      Label.t Location.loc
+      Label.t Astlib.Loc.t
       -> Expression.t
       -> t
     val pexp_override :
-      (Label.t Location.loc * Expression.t) list
+      (Label.t Astlib.Loc.t * Expression.t) list
       -> t
     val pexp_letmodule :
-      string Location.loc
+      string Astlib.Loc.t
       -> Module_expr.t
       -> Expression.t
       -> t
@@ -702,7 +700,7 @@ module V4_07 : sig
       Class_structure.t
       -> t
     val pexp_newtype :
-      string Location.loc
+      string Astlib.Loc.t
       -> Expression.t
       -> t
     val pexp_pack :
@@ -742,22 +740,22 @@ module V4_07 : sig
     type t
 
     type concrete =
-      { pval_name : string Location.loc
+      { pval_name : string Astlib.Loc.t
       ; pval_type : Core_type.t
       ; pval_prim : string list
       ; pval_attributes : Attributes.t
-      ; pval_loc : Location.t
+      ; pval_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      pval_name:string Location.loc
+      pval_name:string Astlib.Loc.t
       -> pval_type:Core_type.t
       -> pval_prim:string list
       -> pval_attributes:Attributes.t
-      -> pval_loc:Location.t
+      -> pval_loc:Astlib.Location.t
       -> t
   end
 
@@ -765,28 +763,28 @@ module V4_07 : sig
     type t
 
     type concrete =
-      { ptype_name : string Location.loc
+      { ptype_name : string Astlib.Loc.t
       ; ptype_params : (Core_type.t * Variance.t) list
-      ; ptype_cstrs : (Core_type.t * Core_type.t * Location.t) list
+      ; ptype_cstrs : (Core_type.t * Core_type.t * Astlib.Location.t) list
       ; ptype_kind : Type_kind.t
       ; ptype_private : Private_flag.t
       ; ptype_manifest : Core_type.t option
       ; ptype_attributes : Attributes.t
-      ; ptype_loc : Location.t
+      ; ptype_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      ptype_name:string Location.loc
+      ptype_name:string Astlib.Loc.t
       -> ptype_params:(Core_type.t * Variance.t) list
-      -> ptype_cstrs:(Core_type.t * Core_type.t * Location.t) list
+      -> ptype_cstrs:(Core_type.t * Core_type.t * Astlib.Location.t) list
       -> ptype_kind:Type_kind.t
       -> ptype_private:Private_flag.t
       -> ptype_manifest:Core_type.t option
       -> ptype_attributes:Attributes.t
-      -> ptype_loc:Location.t
+      -> ptype_loc:Astlib.Location.t
       -> t
   end
 
@@ -816,10 +814,10 @@ module V4_07 : sig
     type t
 
     type concrete =
-      { pld_name : string Location.loc
+      { pld_name : string Astlib.Loc.t
       ; pld_mutable : Mutable_flag.t
       ; pld_type : Core_type.t
-      ; pld_loc : Location.t
+      ; pld_loc : Astlib.Location.t
       ; pld_attributes : Attributes.t
       }
 
@@ -827,10 +825,10 @@ module V4_07 : sig
     val to_concrete : t -> concrete option
 
     val create :
-      pld_name:string Location.loc
+      pld_name:string Astlib.Loc.t
       -> pld_mutable:Mutable_flag.t
       -> pld_type:Core_type.t
-      -> pld_loc:Location.t
+      -> pld_loc:Astlib.Location.t
       -> pld_attributes:Attributes.t
       -> t
   end
@@ -839,10 +837,10 @@ module V4_07 : sig
     type t
 
     type concrete =
-      { pcd_name : string Location.loc
+      { pcd_name : string Astlib.Loc.t
       ; pcd_args : Constructor_arguments.t
       ; pcd_res : Core_type.t option
-      ; pcd_loc : Location.t
+      ; pcd_loc : Astlib.Location.t
       ; pcd_attributes : Attributes.t
       }
 
@@ -850,10 +848,10 @@ module V4_07 : sig
     val to_concrete : t -> concrete option
 
     val create :
-      pcd_name:string Location.loc
+      pcd_name:string Astlib.Loc.t
       -> pcd_args:Constructor_arguments.t
       -> pcd_res:Core_type.t option
-      -> pcd_loc:Location.t
+      -> pcd_loc:Astlib.Location.t
       -> pcd_attributes:Attributes.t
       -> t
   end
@@ -903,9 +901,9 @@ module V4_07 : sig
     type t
 
     type concrete =
-      { pext_name : string Location.loc
+      { pext_name : string Astlib.Loc.t
       ; pext_kind : Extension_constructor_kind.t
-      ; pext_loc : Location.t
+      ; pext_loc : Astlib.Location.t
       ; pext_attributes : Attributes.t
       }
 
@@ -913,9 +911,9 @@ module V4_07 : sig
     val to_concrete : t -> concrete option
 
     val create :
-      pext_name:string Location.loc
+      pext_name:string Astlib.Loc.t
       -> pext_kind:Extension_constructor_kind.t
-      -> pext_loc:Location.t
+      -> pext_loc:Astlib.Location.t
       -> pext_attributes:Attributes.t
       -> t
   end
@@ -944,7 +942,7 @@ module V4_07 : sig
 
     type concrete =
       { pcty_desc : Class_type_desc.t
-      ; pcty_loc : Location.t
+      ; pcty_loc : Astlib.Location.t
       ; pcty_attributes : Attributes.t
       }
 
@@ -953,7 +951,7 @@ module V4_07 : sig
 
     val create :
       pcty_desc:Class_type_desc.t
-      -> pcty_loc:Location.t
+      -> pcty_loc:Astlib.Location.t
       -> pcty_attributes:Attributes.t
       -> t
   end
@@ -1015,7 +1013,7 @@ module V4_07 : sig
 
     type concrete =
       { pctf_desc : Class_type_field_desc.t
-      ; pctf_loc : Location.t
+      ; pctf_loc : Astlib.Location.t
       ; pctf_attributes : Attributes.t
       }
 
@@ -1024,7 +1022,7 @@ module V4_07 : sig
 
     val create :
       pctf_desc:Class_type_field_desc.t
-      -> pctf_loc:Location.t
+      -> pctf_loc:Astlib.Location.t
       -> pctf_attributes:Attributes.t
       -> t
   end
@@ -1034,8 +1032,8 @@ module V4_07 : sig
 
     type concrete =
       | Pctf_inherit of Class_type.t
-      | Pctf_val of (Label.t Location.loc * Mutable_flag.t * Virtual_flag.t * Core_type.t)
-      | Pctf_method of (Label.t Location.loc * Private_flag.t * Virtual_flag.t * Core_type.t)
+      | Pctf_val of (Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
+      | Pctf_method of (Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
       | Pctf_constraint of (Core_type.t * Core_type.t)
       | Pctf_attribute of Attribute.t
       | Pctf_extension of Extension.t
@@ -1047,10 +1045,10 @@ module V4_07 : sig
       Class_type.t
       -> t
     val pctf_val :
-      (Label.t Location.loc * Mutable_flag.t * Virtual_flag.t * Core_type.t)
+      (Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
       -> t
     val pctf_method :
-      (Label.t Location.loc * Private_flag.t * Virtual_flag.t * Core_type.t)
+      (Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
       -> t
     val pctf_constraint :
       (Core_type.t * Core_type.t)
@@ -1069,9 +1067,9 @@ module V4_07 : sig
     type 'a concrete =
       { pci_virt : Virtual_flag.t
       ; pci_params : (Core_type.t * Variance.t) list
-      ; pci_name : string Location.loc
+      ; pci_name : string Astlib.Loc.t
       ; pci_expr : 'a
-      ; pci_loc : Location.t
+      ; pci_loc : Astlib.Location.t
       ; pci_attributes : Attributes.t
       }
 
@@ -1081,9 +1079,9 @@ module V4_07 : sig
     val create_class_expr :
       pci_virt:Virtual_flag.t
       -> pci_params:(Core_type.t * Variance.t) list
-      -> pci_name:string Location.loc
+      -> pci_name:string Astlib.Loc.t
       -> pci_expr:Class_expr.t
-      -> pci_loc:Location.t
+      -> pci_loc:Astlib.Location.t
       -> pci_attributes:Attributes.t
       -> Class_expr.t t
 
@@ -1093,9 +1091,9 @@ module V4_07 : sig
     val create_class_type :
       pci_virt:Virtual_flag.t
       -> pci_params:(Core_type.t * Variance.t) list
-      -> pci_name:string Location.loc
+      -> pci_name:string Astlib.Loc.t
       -> pci_expr:Class_type.t
-      -> pci_loc:Location.t
+      -> pci_loc:Astlib.Location.t
       -> pci_attributes:Attributes.t
       -> Class_type.t t
   end
@@ -1127,7 +1125,7 @@ module V4_07 : sig
 
     type concrete =
       { pcl_desc : Class_expr_desc.t
-      ; pcl_loc : Location.t
+      ; pcl_loc : Astlib.Location.t
       ; pcl_attributes : Attributes.t
       }
 
@@ -1136,7 +1134,7 @@ module V4_07 : sig
 
     val create :
       pcl_desc:Class_expr_desc.t
-      -> pcl_loc:Location.t
+      -> pcl_loc:Astlib.Location.t
       -> pcl_attributes:Attributes.t
       -> t
   end
@@ -1215,7 +1213,7 @@ module V4_07 : sig
 
     type concrete =
       { pcf_desc : Class_field_desc.t
-      ; pcf_loc : Location.t
+      ; pcf_loc : Astlib.Location.t
       ; pcf_attributes : Attributes.t
       }
 
@@ -1224,7 +1222,7 @@ module V4_07 : sig
 
     val create :
       pcf_desc:Class_field_desc.t
-      -> pcf_loc:Location.t
+      -> pcf_loc:Astlib.Location.t
       -> pcf_attributes:Attributes.t
       -> t
   end
@@ -1233,9 +1231,9 @@ module V4_07 : sig
     type t
 
     type concrete =
-      | Pcf_inherit of Override_flag.t * Class_expr.t * string Location.loc option
-      | Pcf_val of (Label.t Location.loc * Mutable_flag.t * Class_field_kind.t)
-      | Pcf_method of (Label.t Location.loc * Private_flag.t * Class_field_kind.t)
+      | Pcf_inherit of Override_flag.t * Class_expr.t * string Astlib.Loc.t option
+      | Pcf_val of (Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
+      | Pcf_method of (Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
       | Pcf_constraint of (Core_type.t * Core_type.t)
       | Pcf_initializer of Expression.t
       | Pcf_attribute of Attribute.t
@@ -1247,13 +1245,13 @@ module V4_07 : sig
     val pcf_inherit :
       Override_flag.t
       -> Class_expr.t
-      -> string Location.loc option
+      -> string Astlib.Loc.t option
       -> t
     val pcf_val :
-      (Label.t Location.loc * Mutable_flag.t * Class_field_kind.t)
+      (Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
       -> t
     val pcf_method :
-      (Label.t Location.loc * Private_flag.t * Class_field_kind.t)
+      (Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
       -> t
     val pcf_constraint :
       (Core_type.t * Core_type.t)
@@ -1304,7 +1302,7 @@ module V4_07 : sig
 
     type concrete =
       { pmty_desc : Module_type_desc.t
-      ; pmty_loc : Location.t
+      ; pmty_loc : Astlib.Location.t
       ; pmty_attributes : Attributes.t
       }
 
@@ -1313,7 +1311,7 @@ module V4_07 : sig
 
     val create :
       pmty_desc:Module_type_desc.t
-      -> pmty_loc:Location.t
+      -> pmty_loc:Astlib.Location.t
       -> pmty_attributes:Attributes.t
       -> t
   end
@@ -1324,7 +1322,7 @@ module V4_07 : sig
     type concrete =
       | Pmty_ident of Longident_loc.t
       | Pmty_signature of Signature.t
-      | Pmty_functor of string Location.loc * Module_type.t option * Module_type.t
+      | Pmty_functor of string Astlib.Loc.t * Module_type.t option * Module_type.t
       | Pmty_with of Module_type.t * With_constraint.t list
       | Pmty_typeof of Module_expr.t
       | Pmty_extension of Extension.t
@@ -1340,7 +1338,7 @@ module V4_07 : sig
       Signature.t
       -> t
     val pmty_functor :
-      string Location.loc
+      string Astlib.Loc.t
       -> Module_type.t option
       -> Module_type.t
       -> t
@@ -1375,7 +1373,7 @@ module V4_07 : sig
 
     type concrete =
       { psig_desc : Signature_item_desc.t
-      ; psig_loc : Location.t
+      ; psig_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
@@ -1383,7 +1381,7 @@ module V4_07 : sig
 
     val create :
       psig_desc:Signature_item_desc.t
-      -> psig_loc:Location.t
+      -> psig_loc:Astlib.Location.t
       -> t
   end
 
@@ -1455,20 +1453,20 @@ module V4_07 : sig
     type t
 
     type concrete =
-      { pmd_name : string Location.loc
+      { pmd_name : string Astlib.Loc.t
       ; pmd_type : Module_type.t
       ; pmd_attributes : Attributes.t
-      ; pmd_loc : Location.t
+      ; pmd_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      pmd_name:string Location.loc
+      pmd_name:string Astlib.Loc.t
       -> pmd_type:Module_type.t
       -> pmd_attributes:Attributes.t
-      -> pmd_loc:Location.t
+      -> pmd_loc:Astlib.Location.t
       -> t
   end
 
@@ -1476,20 +1474,20 @@ module V4_07 : sig
     type t
 
     type concrete =
-      { pmtd_name : string Location.loc
+      { pmtd_name : string Astlib.Loc.t
       ; pmtd_type : Module_type.t option
       ; pmtd_attributes : Attributes.t
-      ; pmtd_loc : Location.t
+      ; pmtd_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      pmtd_name:string Location.loc
+      pmtd_name:string Astlib.Loc.t
       -> pmtd_type:Module_type.t option
       -> pmtd_attributes:Attributes.t
-      -> pmtd_loc:Location.t
+      -> pmtd_loc:Astlib.Location.t
       -> t
   end
 
@@ -1499,7 +1497,7 @@ module V4_07 : sig
     type concrete =
       { popen_lid : Longident_loc.t
       ; popen_override : Override_flag.t
-      ; popen_loc : Location.t
+      ; popen_loc : Astlib.Location.t
       ; popen_attributes : Attributes.t
       }
 
@@ -1509,7 +1507,7 @@ module V4_07 : sig
     val create :
       popen_lid:Longident_loc.t
       -> popen_override:Override_flag.t
-      -> popen_loc:Location.t
+      -> popen_loc:Astlib.Location.t
       -> popen_attributes:Attributes.t
       -> t
   end
@@ -1519,7 +1517,7 @@ module V4_07 : sig
 
     type 'a concrete =
       { pincl_mod : 'a
-      ; pincl_loc : Location.t
+      ; pincl_loc : Astlib.Location.t
       ; pincl_attributes : Attributes.t
       }
 
@@ -1528,7 +1526,7 @@ module V4_07 : sig
 
     val create_module_expr :
       pincl_mod:Module_expr.t
-      -> pincl_loc:Location.t
+      -> pincl_loc:Astlib.Location.t
       -> pincl_attributes:Attributes.t
       -> Module_expr.t t
 
@@ -1537,7 +1535,7 @@ module V4_07 : sig
 
     val create_module_type :
       pincl_mod:Module_type.t
-      -> pincl_loc:Location.t
+      -> pincl_loc:Astlib.Location.t
       -> pincl_attributes:Attributes.t
       -> Module_type.t t
   end
@@ -1599,7 +1597,7 @@ module V4_07 : sig
 
     type concrete =
       { pmod_desc : Module_expr_desc.t
-      ; pmod_loc : Location.t
+      ; pmod_loc : Astlib.Location.t
       ; pmod_attributes : Attributes.t
       }
 
@@ -1608,7 +1606,7 @@ module V4_07 : sig
 
     val create :
       pmod_desc:Module_expr_desc.t
-      -> pmod_loc:Location.t
+      -> pmod_loc:Astlib.Location.t
       -> pmod_attributes:Attributes.t
       -> t
   end
@@ -1619,7 +1617,7 @@ module V4_07 : sig
     type concrete =
       | Pmod_ident of Longident_loc.t
       | Pmod_structure of Structure.t
-      | Pmod_functor of string Location.loc * Module_type.t option * Module_expr.t
+      | Pmod_functor of string Astlib.Loc.t * Module_type.t option * Module_expr.t
       | Pmod_apply of Module_expr.t * Module_expr.t
       | Pmod_constraint of Module_expr.t * Module_type.t
       | Pmod_unpack of Expression.t
@@ -1635,7 +1633,7 @@ module V4_07 : sig
       Structure.t
       -> t
     val pmod_functor :
-      string Location.loc
+      string Astlib.Loc.t
       -> Module_type.t option
       -> Module_expr.t
       -> t
@@ -1671,7 +1669,7 @@ module V4_07 : sig
 
     type concrete =
       { pstr_desc : Structure_item_desc.t
-      ; pstr_loc : Location.t
+      ; pstr_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
@@ -1679,7 +1677,7 @@ module V4_07 : sig
 
     val create :
       pstr_desc:Structure_item_desc.t
-      -> pstr_loc:Location.t
+      -> pstr_loc:Astlib.Location.t
       -> t
   end
 
@@ -1764,7 +1762,7 @@ module V4_07 : sig
       { pvb_pat : Pattern.t
       ; pvb_expr : Expression.t
       ; pvb_attributes : Attributes.t
-      ; pvb_loc : Location.t
+      ; pvb_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
@@ -1774,7 +1772,7 @@ module V4_07 : sig
       pvb_pat:Pattern.t
       -> pvb_expr:Expression.t
       -> pvb_attributes:Attributes.t
-      -> pvb_loc:Location.t
+      -> pvb_loc:Astlib.Location.t
       -> t
   end
 
@@ -1782,20 +1780,20 @@ module V4_07 : sig
     type t
 
     type concrete =
-      { pmb_name : string Location.loc
+      { pmb_name : string Astlib.Loc.t
       ; pmb_expr : Module_expr.t
       ; pmb_attributes : Attributes.t
-      ; pmb_loc : Location.t
+      ; pmb_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      pmb_name:string Location.loc
+      pmb_name:string Astlib.Loc.t
       -> pmb_expr:Module_expr.t
       -> pmb_attributes:Attributes.t
-      -> pmb_loc:Location.t
+      -> pmb_loc:Astlib.Location.t
       -> t
   end
 
@@ -1876,12 +1874,12 @@ module V4_06 : sig
   and Longident_loc : sig
     type t
 
-    type concrete = Longident.t Location.loc
+    type concrete = Longident.t Astlib.Loc.t
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
-    val create : Longident.t Location.loc -> t
+    val create : Longident.t Astlib.Loc.t -> t
   end
 
   and Rec_flag : sig
@@ -2061,23 +2059,23 @@ module V4_06 : sig
   and Attribute : sig
     type t
 
-    type concrete = (string Location.loc * Payload.t)
+    type concrete = (string Astlib.Loc.t * Payload.t)
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
-    val create : (string Location.loc * Payload.t) -> t
+    val create : (string Astlib.Loc.t * Payload.t) -> t
   end
 
   and Extension : sig
     type t
 
-    type concrete = (string Location.loc * Payload.t)
+    type concrete = (string Astlib.Loc.t * Payload.t)
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
-    val create : (string Location.loc * Payload.t) -> t
+    val create : (string Astlib.Loc.t * Payload.t) -> t
   end
 
   and Attributes : sig
@@ -2123,7 +2121,7 @@ module V4_06 : sig
 
     type concrete =
       { ptyp_desc : Core_type_desc.t
-      ; ptyp_loc : Location.t
+      ; ptyp_loc : Astlib.Location.t
       ; ptyp_attributes : Attributes.t
       }
 
@@ -2132,7 +2130,7 @@ module V4_06 : sig
 
     val create :
       ptyp_desc:Core_type_desc.t
-      -> ptyp_loc:Location.t
+      -> ptyp_loc:Astlib.Location.t
       -> ptyp_attributes:Attributes.t
       -> t
   end
@@ -2150,7 +2148,7 @@ module V4_06 : sig
       | Ptyp_class of Longident_loc.t * Core_type.t list
       | Ptyp_alias of Core_type.t * string
       | Ptyp_variant of Row_field.t list * Closed_flag.t * Label.t list option
-      | Ptyp_poly of string Location.loc list * Core_type.t
+      | Ptyp_poly of string Astlib.Loc.t list * Core_type.t
       | Ptyp_package of Package_type.t
       | Ptyp_extension of Extension.t
 
@@ -2191,7 +2189,7 @@ module V4_06 : sig
       -> Label.t list option
       -> t
     val ptyp_poly :
-      string Location.loc list
+      string Astlib.Loc.t list
       -> Core_type.t
       -> t
     val ptyp_package :
@@ -2217,14 +2215,14 @@ module V4_06 : sig
     type t
 
     type concrete =
-      | Rtag of Label.t Location.loc * Attributes.t * bool * Core_type.t list
+      | Rtag of Label.t Astlib.Loc.t * Attributes.t * bool * Core_type.t list
       | Rinherit of Core_type.t
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val rtag :
-      Label.t Location.loc
+      Label.t Astlib.Loc.t
       -> Attributes.t
       -> bool
       -> Core_type.t list
@@ -2238,14 +2236,14 @@ module V4_06 : sig
     type t
 
     type concrete =
-      | Otag of Label.t Location.loc * Attributes.t * Core_type.t
+      | Otag of Label.t Astlib.Loc.t * Attributes.t * Core_type.t
       | Oinherit of Core_type.t
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val otag :
-      Label.t Location.loc
+      Label.t Astlib.Loc.t
       -> Attributes.t
       -> Core_type.t
       -> t
@@ -2259,7 +2257,7 @@ module V4_06 : sig
 
     type concrete =
       { ppat_desc : Pattern_desc.t
-      ; ppat_loc : Location.t
+      ; ppat_loc : Astlib.Location.t
       ; ppat_attributes : Attributes.t
       }
 
@@ -2268,7 +2266,7 @@ module V4_06 : sig
 
     val create :
       ppat_desc:Pattern_desc.t
-      -> ppat_loc:Location.t
+      -> ppat_loc:Astlib.Location.t
       -> ppat_attributes:Attributes.t
       -> t
   end
@@ -2278,8 +2276,8 @@ module V4_06 : sig
 
     type concrete =
       | Ppat_any
-      | Ppat_var of string Location.loc
-      | Ppat_alias of Pattern.t * string Location.loc
+      | Ppat_var of string Astlib.Loc.t
+      | Ppat_alias of Pattern.t * string Astlib.Loc.t
       | Ppat_constant of Constant.t
       | Ppat_interval of Constant.t * Constant.t
       | Ppat_tuple of Pattern.t list
@@ -2291,7 +2289,7 @@ module V4_06 : sig
       | Ppat_constraint of Pattern.t * Core_type.t
       | Ppat_type of Longident_loc.t
       | Ppat_lazy of Pattern.t
-      | Ppat_unpack of string Location.loc
+      | Ppat_unpack of string Astlib.Loc.t
       | Ppat_exception of Pattern.t
       | Ppat_extension of Extension.t
       | Ppat_open of Longident_loc.t * Pattern.t
@@ -2301,11 +2299,11 @@ module V4_06 : sig
 
     val ppat_any : t
     val ppat_var :
-      string Location.loc
+      string Astlib.Loc.t
       -> t
     val ppat_alias :
       Pattern.t
-      -> string Location.loc
+      -> string Astlib.Loc.t
       -> t
     val ppat_constant :
       Constant.t
@@ -2347,7 +2345,7 @@ module V4_06 : sig
       Pattern.t
       -> t
     val ppat_unpack :
-      string Location.loc
+      string Astlib.Loc.t
       -> t
     val ppat_exception :
       Pattern.t
@@ -2366,7 +2364,7 @@ module V4_06 : sig
 
     type concrete =
       { pexp_desc : Expression_desc.t
-      ; pexp_loc : Location.t
+      ; pexp_loc : Astlib.Location.t
       ; pexp_attributes : Attributes.t
       }
 
@@ -2375,7 +2373,7 @@ module V4_06 : sig
 
     val create :
       pexp_desc:Expression_desc.t
-      -> pexp_loc:Location.t
+      -> pexp_loc:Astlib.Location.t
       -> pexp_attributes:Attributes.t
       -> t
   end
@@ -2405,17 +2403,17 @@ module V4_06 : sig
       | Pexp_for of Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t
       | Pexp_constraint of Expression.t * Core_type.t
       | Pexp_coerce of Expression.t * Core_type.t option * Core_type.t
-      | Pexp_send of Expression.t * Label.t Location.loc
+      | Pexp_send of Expression.t * Label.t Astlib.Loc.t
       | Pexp_new of Longident_loc.t
-      | Pexp_setinstvar of Label.t Location.loc * Expression.t
-      | Pexp_override of (Label.t Location.loc * Expression.t) list
-      | Pexp_letmodule of string Location.loc * Module_expr.t * Expression.t
+      | Pexp_setinstvar of Label.t Astlib.Loc.t * Expression.t
+      | Pexp_override of (Label.t Astlib.Loc.t * Expression.t) list
+      | Pexp_letmodule of string Astlib.Loc.t * Module_expr.t * Expression.t
       | Pexp_letexception of Extension_constructor.t * Expression.t
       | Pexp_assert of Expression.t
       | Pexp_lazy of Expression.t
       | Pexp_poly of Expression.t * Core_type.t option
       | Pexp_object of Class_structure.t
-      | Pexp_newtype of string Location.loc * Expression.t
+      | Pexp_newtype of string Astlib.Loc.t * Expression.t
       | Pexp_pack of Module_expr.t
       | Pexp_open of Override_flag.t * Longident_loc.t * Expression.t
       | Pexp_extension of Extension.t
@@ -2514,20 +2512,20 @@ module V4_06 : sig
       -> t
     val pexp_send :
       Expression.t
-      -> Label.t Location.loc
+      -> Label.t Astlib.Loc.t
       -> t
     val pexp_new :
       Longident_loc.t
       -> t
     val pexp_setinstvar :
-      Label.t Location.loc
+      Label.t Astlib.Loc.t
       -> Expression.t
       -> t
     val pexp_override :
-      (Label.t Location.loc * Expression.t) list
+      (Label.t Astlib.Loc.t * Expression.t) list
       -> t
     val pexp_letmodule :
-      string Location.loc
+      string Astlib.Loc.t
       -> Module_expr.t
       -> Expression.t
       -> t
@@ -2549,7 +2547,7 @@ module V4_06 : sig
       Class_structure.t
       -> t
     val pexp_newtype :
-      string Location.loc
+      string Astlib.Loc.t
       -> Expression.t
       -> t
     val pexp_pack :
@@ -2589,22 +2587,22 @@ module V4_06 : sig
     type t
 
     type concrete =
-      { pval_name : string Location.loc
+      { pval_name : string Astlib.Loc.t
       ; pval_type : Core_type.t
       ; pval_prim : string list
       ; pval_attributes : Attributes.t
-      ; pval_loc : Location.t
+      ; pval_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      pval_name:string Location.loc
+      pval_name:string Astlib.Loc.t
       -> pval_type:Core_type.t
       -> pval_prim:string list
       -> pval_attributes:Attributes.t
-      -> pval_loc:Location.t
+      -> pval_loc:Astlib.Location.t
       -> t
   end
 
@@ -2612,28 +2610,28 @@ module V4_06 : sig
     type t
 
     type concrete =
-      { ptype_name : string Location.loc
+      { ptype_name : string Astlib.Loc.t
       ; ptype_params : (Core_type.t * Variance.t) list
-      ; ptype_cstrs : (Core_type.t * Core_type.t * Location.t) list
+      ; ptype_cstrs : (Core_type.t * Core_type.t * Astlib.Location.t) list
       ; ptype_kind : Type_kind.t
       ; ptype_private : Private_flag.t
       ; ptype_manifest : Core_type.t option
       ; ptype_attributes : Attributes.t
-      ; ptype_loc : Location.t
+      ; ptype_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      ptype_name:string Location.loc
+      ptype_name:string Astlib.Loc.t
       -> ptype_params:(Core_type.t * Variance.t) list
-      -> ptype_cstrs:(Core_type.t * Core_type.t * Location.t) list
+      -> ptype_cstrs:(Core_type.t * Core_type.t * Astlib.Location.t) list
       -> ptype_kind:Type_kind.t
       -> ptype_private:Private_flag.t
       -> ptype_manifest:Core_type.t option
       -> ptype_attributes:Attributes.t
-      -> ptype_loc:Location.t
+      -> ptype_loc:Astlib.Location.t
       -> t
   end
 
@@ -2663,10 +2661,10 @@ module V4_06 : sig
     type t
 
     type concrete =
-      { pld_name : string Location.loc
+      { pld_name : string Astlib.Loc.t
       ; pld_mutable : Mutable_flag.t
       ; pld_type : Core_type.t
-      ; pld_loc : Location.t
+      ; pld_loc : Astlib.Location.t
       ; pld_attributes : Attributes.t
       }
 
@@ -2674,10 +2672,10 @@ module V4_06 : sig
     val to_concrete : t -> concrete option
 
     val create :
-      pld_name:string Location.loc
+      pld_name:string Astlib.Loc.t
       -> pld_mutable:Mutable_flag.t
       -> pld_type:Core_type.t
-      -> pld_loc:Location.t
+      -> pld_loc:Astlib.Location.t
       -> pld_attributes:Attributes.t
       -> t
   end
@@ -2686,10 +2684,10 @@ module V4_06 : sig
     type t
 
     type concrete =
-      { pcd_name : string Location.loc
+      { pcd_name : string Astlib.Loc.t
       ; pcd_args : Constructor_arguments.t
       ; pcd_res : Core_type.t option
-      ; pcd_loc : Location.t
+      ; pcd_loc : Astlib.Location.t
       ; pcd_attributes : Attributes.t
       }
 
@@ -2697,10 +2695,10 @@ module V4_06 : sig
     val to_concrete : t -> concrete option
 
     val create :
-      pcd_name:string Location.loc
+      pcd_name:string Astlib.Loc.t
       -> pcd_args:Constructor_arguments.t
       -> pcd_res:Core_type.t option
-      -> pcd_loc:Location.t
+      -> pcd_loc:Astlib.Location.t
       -> pcd_attributes:Attributes.t
       -> t
   end
@@ -2750,9 +2748,9 @@ module V4_06 : sig
     type t
 
     type concrete =
-      { pext_name : string Location.loc
+      { pext_name : string Astlib.Loc.t
       ; pext_kind : Extension_constructor_kind.t
-      ; pext_loc : Location.t
+      ; pext_loc : Astlib.Location.t
       ; pext_attributes : Attributes.t
       }
 
@@ -2760,9 +2758,9 @@ module V4_06 : sig
     val to_concrete : t -> concrete option
 
     val create :
-      pext_name:string Location.loc
+      pext_name:string Astlib.Loc.t
       -> pext_kind:Extension_constructor_kind.t
-      -> pext_loc:Location.t
+      -> pext_loc:Astlib.Location.t
       -> pext_attributes:Attributes.t
       -> t
   end
@@ -2791,7 +2789,7 @@ module V4_06 : sig
 
     type concrete =
       { pcty_desc : Class_type_desc.t
-      ; pcty_loc : Location.t
+      ; pcty_loc : Astlib.Location.t
       ; pcty_attributes : Attributes.t
       }
 
@@ -2800,7 +2798,7 @@ module V4_06 : sig
 
     val create :
       pcty_desc:Class_type_desc.t
-      -> pcty_loc:Location.t
+      -> pcty_loc:Astlib.Location.t
       -> pcty_attributes:Attributes.t
       -> t
   end
@@ -2862,7 +2860,7 @@ module V4_06 : sig
 
     type concrete =
       { pctf_desc : Class_type_field_desc.t
-      ; pctf_loc : Location.t
+      ; pctf_loc : Astlib.Location.t
       ; pctf_attributes : Attributes.t
       }
 
@@ -2871,7 +2869,7 @@ module V4_06 : sig
 
     val create :
       pctf_desc:Class_type_field_desc.t
-      -> pctf_loc:Location.t
+      -> pctf_loc:Astlib.Location.t
       -> pctf_attributes:Attributes.t
       -> t
   end
@@ -2881,8 +2879,8 @@ module V4_06 : sig
 
     type concrete =
       | Pctf_inherit of Class_type.t
-      | Pctf_val of (Label.t Location.loc * Mutable_flag.t * Virtual_flag.t * Core_type.t)
-      | Pctf_method of (Label.t Location.loc * Private_flag.t * Virtual_flag.t * Core_type.t)
+      | Pctf_val of (Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
+      | Pctf_method of (Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
       | Pctf_constraint of (Core_type.t * Core_type.t)
       | Pctf_attribute of Attribute.t
       | Pctf_extension of Extension.t
@@ -2894,10 +2892,10 @@ module V4_06 : sig
       Class_type.t
       -> t
     val pctf_val :
-      (Label.t Location.loc * Mutable_flag.t * Virtual_flag.t * Core_type.t)
+      (Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
       -> t
     val pctf_method :
-      (Label.t Location.loc * Private_flag.t * Virtual_flag.t * Core_type.t)
+      (Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
       -> t
     val pctf_constraint :
       (Core_type.t * Core_type.t)
@@ -2916,9 +2914,9 @@ module V4_06 : sig
     type 'a concrete =
       { pci_virt : Virtual_flag.t
       ; pci_params : (Core_type.t * Variance.t) list
-      ; pci_name : string Location.loc
+      ; pci_name : string Astlib.Loc.t
       ; pci_expr : 'a
-      ; pci_loc : Location.t
+      ; pci_loc : Astlib.Location.t
       ; pci_attributes : Attributes.t
       }
 
@@ -2928,9 +2926,9 @@ module V4_06 : sig
     val create_class_expr :
       pci_virt:Virtual_flag.t
       -> pci_params:(Core_type.t * Variance.t) list
-      -> pci_name:string Location.loc
+      -> pci_name:string Astlib.Loc.t
       -> pci_expr:Class_expr.t
-      -> pci_loc:Location.t
+      -> pci_loc:Astlib.Location.t
       -> pci_attributes:Attributes.t
       -> Class_expr.t t
 
@@ -2940,9 +2938,9 @@ module V4_06 : sig
     val create_class_type :
       pci_virt:Virtual_flag.t
       -> pci_params:(Core_type.t * Variance.t) list
-      -> pci_name:string Location.loc
+      -> pci_name:string Astlib.Loc.t
       -> pci_expr:Class_type.t
-      -> pci_loc:Location.t
+      -> pci_loc:Astlib.Location.t
       -> pci_attributes:Attributes.t
       -> Class_type.t t
   end
@@ -2974,7 +2972,7 @@ module V4_06 : sig
 
     type concrete =
       { pcl_desc : Class_expr_desc.t
-      ; pcl_loc : Location.t
+      ; pcl_loc : Astlib.Location.t
       ; pcl_attributes : Attributes.t
       }
 
@@ -2983,7 +2981,7 @@ module V4_06 : sig
 
     val create :
       pcl_desc:Class_expr_desc.t
-      -> pcl_loc:Location.t
+      -> pcl_loc:Astlib.Location.t
       -> pcl_attributes:Attributes.t
       -> t
   end
@@ -3062,7 +3060,7 @@ module V4_06 : sig
 
     type concrete =
       { pcf_desc : Class_field_desc.t
-      ; pcf_loc : Location.t
+      ; pcf_loc : Astlib.Location.t
       ; pcf_attributes : Attributes.t
       }
 
@@ -3071,7 +3069,7 @@ module V4_06 : sig
 
     val create :
       pcf_desc:Class_field_desc.t
-      -> pcf_loc:Location.t
+      -> pcf_loc:Astlib.Location.t
       -> pcf_attributes:Attributes.t
       -> t
   end
@@ -3080,9 +3078,9 @@ module V4_06 : sig
     type t
 
     type concrete =
-      | Pcf_inherit of Override_flag.t * Class_expr.t * string Location.loc option
-      | Pcf_val of (Label.t Location.loc * Mutable_flag.t * Class_field_kind.t)
-      | Pcf_method of (Label.t Location.loc * Private_flag.t * Class_field_kind.t)
+      | Pcf_inherit of Override_flag.t * Class_expr.t * string Astlib.Loc.t option
+      | Pcf_val of (Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
+      | Pcf_method of (Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
       | Pcf_constraint of (Core_type.t * Core_type.t)
       | Pcf_initializer of Expression.t
       | Pcf_attribute of Attribute.t
@@ -3094,13 +3092,13 @@ module V4_06 : sig
     val pcf_inherit :
       Override_flag.t
       -> Class_expr.t
-      -> string Location.loc option
+      -> string Astlib.Loc.t option
       -> t
     val pcf_val :
-      (Label.t Location.loc * Mutable_flag.t * Class_field_kind.t)
+      (Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
       -> t
     val pcf_method :
-      (Label.t Location.loc * Private_flag.t * Class_field_kind.t)
+      (Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
       -> t
     val pcf_constraint :
       (Core_type.t * Core_type.t)
@@ -3151,7 +3149,7 @@ module V4_06 : sig
 
     type concrete =
       { pmty_desc : Module_type_desc.t
-      ; pmty_loc : Location.t
+      ; pmty_loc : Astlib.Location.t
       ; pmty_attributes : Attributes.t
       }
 
@@ -3160,7 +3158,7 @@ module V4_06 : sig
 
     val create :
       pmty_desc:Module_type_desc.t
-      -> pmty_loc:Location.t
+      -> pmty_loc:Astlib.Location.t
       -> pmty_attributes:Attributes.t
       -> t
   end
@@ -3171,7 +3169,7 @@ module V4_06 : sig
     type concrete =
       | Pmty_ident of Longident_loc.t
       | Pmty_signature of Signature.t
-      | Pmty_functor of string Location.loc * Module_type.t option * Module_type.t
+      | Pmty_functor of string Astlib.Loc.t * Module_type.t option * Module_type.t
       | Pmty_with of Module_type.t * With_constraint.t list
       | Pmty_typeof of Module_expr.t
       | Pmty_extension of Extension.t
@@ -3187,7 +3185,7 @@ module V4_06 : sig
       Signature.t
       -> t
     val pmty_functor :
-      string Location.loc
+      string Astlib.Loc.t
       -> Module_type.t option
       -> Module_type.t
       -> t
@@ -3222,7 +3220,7 @@ module V4_06 : sig
 
     type concrete =
       { psig_desc : Signature_item_desc.t
-      ; psig_loc : Location.t
+      ; psig_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
@@ -3230,7 +3228,7 @@ module V4_06 : sig
 
     val create :
       psig_desc:Signature_item_desc.t
-      -> psig_loc:Location.t
+      -> psig_loc:Astlib.Location.t
       -> t
   end
 
@@ -3302,20 +3300,20 @@ module V4_06 : sig
     type t
 
     type concrete =
-      { pmd_name : string Location.loc
+      { pmd_name : string Astlib.Loc.t
       ; pmd_type : Module_type.t
       ; pmd_attributes : Attributes.t
-      ; pmd_loc : Location.t
+      ; pmd_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      pmd_name:string Location.loc
+      pmd_name:string Astlib.Loc.t
       -> pmd_type:Module_type.t
       -> pmd_attributes:Attributes.t
-      -> pmd_loc:Location.t
+      -> pmd_loc:Astlib.Location.t
       -> t
   end
 
@@ -3323,20 +3321,20 @@ module V4_06 : sig
     type t
 
     type concrete =
-      { pmtd_name : string Location.loc
+      { pmtd_name : string Astlib.Loc.t
       ; pmtd_type : Module_type.t option
       ; pmtd_attributes : Attributes.t
-      ; pmtd_loc : Location.t
+      ; pmtd_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      pmtd_name:string Location.loc
+      pmtd_name:string Astlib.Loc.t
       -> pmtd_type:Module_type.t option
       -> pmtd_attributes:Attributes.t
-      -> pmtd_loc:Location.t
+      -> pmtd_loc:Astlib.Location.t
       -> t
   end
 
@@ -3346,7 +3344,7 @@ module V4_06 : sig
     type concrete =
       { popen_lid : Longident_loc.t
       ; popen_override : Override_flag.t
-      ; popen_loc : Location.t
+      ; popen_loc : Astlib.Location.t
       ; popen_attributes : Attributes.t
       }
 
@@ -3356,7 +3354,7 @@ module V4_06 : sig
     val create :
       popen_lid:Longident_loc.t
       -> popen_override:Override_flag.t
-      -> popen_loc:Location.t
+      -> popen_loc:Astlib.Location.t
       -> popen_attributes:Attributes.t
       -> t
   end
@@ -3366,7 +3364,7 @@ module V4_06 : sig
 
     type 'a concrete =
       { pincl_mod : 'a
-      ; pincl_loc : Location.t
+      ; pincl_loc : Astlib.Location.t
       ; pincl_attributes : Attributes.t
       }
 
@@ -3375,7 +3373,7 @@ module V4_06 : sig
 
     val create_module_expr :
       pincl_mod:Module_expr.t
-      -> pincl_loc:Location.t
+      -> pincl_loc:Astlib.Location.t
       -> pincl_attributes:Attributes.t
       -> Module_expr.t t
 
@@ -3384,7 +3382,7 @@ module V4_06 : sig
 
     val create_module_type :
       pincl_mod:Module_type.t
-      -> pincl_loc:Location.t
+      -> pincl_loc:Astlib.Location.t
       -> pincl_attributes:Attributes.t
       -> Module_type.t t
   end
@@ -3446,7 +3444,7 @@ module V4_06 : sig
 
     type concrete =
       { pmod_desc : Module_expr_desc.t
-      ; pmod_loc : Location.t
+      ; pmod_loc : Astlib.Location.t
       ; pmod_attributes : Attributes.t
       }
 
@@ -3455,7 +3453,7 @@ module V4_06 : sig
 
     val create :
       pmod_desc:Module_expr_desc.t
-      -> pmod_loc:Location.t
+      -> pmod_loc:Astlib.Location.t
       -> pmod_attributes:Attributes.t
       -> t
   end
@@ -3466,7 +3464,7 @@ module V4_06 : sig
     type concrete =
       | Pmod_ident of Longident_loc.t
       | Pmod_structure of Structure.t
-      | Pmod_functor of string Location.loc * Module_type.t option * Module_expr.t
+      | Pmod_functor of string Astlib.Loc.t * Module_type.t option * Module_expr.t
       | Pmod_apply of Module_expr.t * Module_expr.t
       | Pmod_constraint of Module_expr.t * Module_type.t
       | Pmod_unpack of Expression.t
@@ -3482,7 +3480,7 @@ module V4_06 : sig
       Structure.t
       -> t
     val pmod_functor :
-      string Location.loc
+      string Astlib.Loc.t
       -> Module_type.t option
       -> Module_expr.t
       -> t
@@ -3518,7 +3516,7 @@ module V4_06 : sig
 
     type concrete =
       { pstr_desc : Structure_item_desc.t
-      ; pstr_loc : Location.t
+      ; pstr_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
@@ -3526,7 +3524,7 @@ module V4_06 : sig
 
     val create :
       pstr_desc:Structure_item_desc.t
-      -> pstr_loc:Location.t
+      -> pstr_loc:Astlib.Location.t
       -> t
   end
 
@@ -3611,7 +3609,7 @@ module V4_06 : sig
       { pvb_pat : Pattern.t
       ; pvb_expr : Expression.t
       ; pvb_attributes : Attributes.t
-      ; pvb_loc : Location.t
+      ; pvb_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
@@ -3621,7 +3619,7 @@ module V4_06 : sig
       pvb_pat:Pattern.t
       -> pvb_expr:Expression.t
       -> pvb_attributes:Attributes.t
-      -> pvb_loc:Location.t
+      -> pvb_loc:Astlib.Location.t
       -> t
   end
 
@@ -3629,20 +3627,20 @@ module V4_06 : sig
     type t
 
     type concrete =
-      { pmb_name : string Location.loc
+      { pmb_name : string Astlib.Loc.t
       ; pmb_expr : Module_expr.t
       ; pmb_attributes : Attributes.t
-      ; pmb_loc : Location.t
+      ; pmb_loc : Astlib.Location.t
       }
 
     val of_concrete : concrete -> t
     val to_concrete : t -> concrete option
 
     val create :
-      pmb_name:string Location.loc
+      pmb_name:string Astlib.Loc.t
       -> pmb_expr:Module_expr.t
       -> pmb_attributes:Attributes.t
-      -> pmb_loc:Location.t
+      -> pmb_loc:Astlib.Location.t
       -> t
   end
 

--- a/astlib/ast.ml
+++ b/astlib/ast.ml
@@ -1,5 +1,3 @@
-open Ocaml_common
-
 type 'a data =
   | Node of 'a
   | Bool of bool
@@ -7,7 +5,7 @@ type 'a data =
   | Int of int
   | String of string
   | Location of Location.t
-  | Loc of 'a data Location.loc
+  | Loc of 'a data Loc.t
   | List of 'a data list
   | Option of 'a data option
   | Tuple of 'a data array

--- a/astlib/astlib.ml
+++ b/astlib/astlib.ml
@@ -1,6 +1,9 @@
 module Ast = Ast
 module Grammar = Grammar
 module History = History
+module Loc = Loc
+module Location = Location
+module Position = Position
 
 let current_version = Versions.current_version
 let history = Versions.history

--- a/astlib/astlib_intf.ml
+++ b/astlib/astlib_intf.ml
@@ -19,6 +19,9 @@ module type Astlib = sig
   module Ast = Ast
   module Grammar = Grammar
   module History : History
+  module Loc = Loc
+  module Location = Location
+  module Position = Position
 
   val current_version : string
   val history : History.t

--- a/astlib/loc.ml
+++ b/astlib/loc.ml
@@ -1,0 +1,22 @@
+type 'a t = 'a Ocaml_common.Location.loc =
+  { txt : 'a
+  ; loc : Ocaml_common.Location.t
+  }
+
+let of_loc (t : _ t) = t
+let to_loc (t : _ t) = t
+
+let txt t = t.txt
+let loc t = Location.of_location t.loc
+
+let create ~txt ~loc () = { txt; loc = Location.to_location loc }
+
+let update_internal t ?(txt = txt t) ?(loc = loc t) () = create ~txt ~loc ()
+
+let update ?txt ?loc t = update_internal t ?txt ?loc ()
+
+let update_txt_internal t ~txt ?(loc = loc t) () = create ~txt ~loc ()
+
+let update_txt ~txt ?loc t = update_txt_internal t ~txt ?loc ()
+
+let map t ~f = update_txt t ~txt:(f t.txt)

--- a/astlib/loc.mli
+++ b/astlib/loc.mli
@@ -1,0 +1,47 @@
+(** Stable interface for arbitrary values annotated with Astlib locations.
+
+    Astlib location annotations use the same representation as location annotations in the
+    compiler; however, we allow for the possibility that new fields will be added to the
+    type over time. We expose the type as [private] to discourage explicit construction,
+    and provide a [create] function that can be extended with optional arguments in a
+    backward-compatible way. *)
+
+(** {1 Type} *)
+
+(** The type equivalence with [Ocaml_common.Location.loc] is expected to stay stable. *)
+type 'a t = private 'a Ocaml_common.Location.loc
+
+(** {1 Conversions} It should always be possible to convert to/from
+    [Ocaml_common.Location.loc]. *)
+
+val of_loc : 'a Ocaml_common.Location.loc -> 'a t
+val to_loc : 'a t -> 'a Ocaml_common.Location.loc
+
+(** {1 Accessors} These should be stable. *)
+
+val txt : 'a t -> 'a
+val loc : 'a t -> Location.t
+
+(** {1 Constructors} These may have additional optional arguments added over time. Where
+    necessary, we add an unnamed [unit] argument so that optional arguments can be
+    dropped, even if there currently are none. *)
+
+val create
+  :  txt : 'a
+  -> loc : Location.t
+  -> unit
+  -> 'a t
+
+val update
+  :  ?txt : 'a
+  -> ?loc : Location.t
+  -> 'a t
+  -> 'a t
+
+val update_txt
+  :  txt : 'a
+  -> ?loc : Location.t
+  -> _ t
+  -> 'a t
+
+val map : 'a t -> f:('a -> 'b) -> 'b t

--- a/astlib/location.ml
+++ b/astlib/location.ml
@@ -1,0 +1,23 @@
+type t = Ocaml_common.Location.t =
+  { loc_start : Lexing.position
+  ; loc_end : Lexing.position
+  ; loc_ghost : bool
+  }
+
+let of_location (t : t) = t
+let to_location (t : t) = t
+
+let start t = Position.of_position t.loc_start
+let end_ t = Position.of_position t.loc_end
+let ghost t = t.loc_ghost
+
+let create ~start ~end_ ?(ghost = false) () =
+  { loc_start = Position.to_position start
+  ; loc_end = Position.to_position end_
+  ; loc_ghost = ghost
+  }
+
+let update_internal t ?(start = start t) ?(end_ = end_ t) ?(ghost = ghost t) () =
+  create ~start ~end_ ~ghost ()
+
+let update ?start ?end_ ?ghost t = update_internal t ?start ?end_ ?ghost ()

--- a/astlib/location.mli
+++ b/astlib/location.mli
@@ -1,0 +1,42 @@
+(** Stable interface for Astlib locations.
+
+    Astlib locations use the same representation as locations in the compiler; however, we
+    allow for the possibility that new fields will be added to the type over time. We
+    expose the type as [private] to discourage explicit construction, and provide a
+    [create] function that can be extended with optional arguments in a
+    backward-compatible way. *)
+
+(** {1 Type} *)
+
+(** The type equivalence with [Ocaml_common.Location] is expected to stay stable. *)
+type t = private Ocaml_common.Location.t
+
+(** {1 Conversions} It should always be possible to convert to/from
+    [Ocaml_common.Location.t]. *)
+
+val of_location : Ocaml_common.Location.t -> t
+val to_location : t -> Ocaml_common.Location.t
+
+(** {1 Accessors} These should be stable. *)
+
+val start : t -> Position.t
+val end_ : t -> Position.t
+val ghost : t -> bool
+
+(** {1 Constructors} These may have additional optional arguments added over time. Where
+    necessary, we add an unnamed [unit] argument so that optional arguments can be
+    dropped, even if there currently are none. *)
+
+val create
+  :  start : Position.t
+  -> end_ : Position.t
+  -> ?ghost : bool (** default: [false] *)
+  -> unit
+  -> t
+
+val update
+  :  ?start : Position.t
+  -> ?end_ : Position.t
+  -> ?ghost : bool
+  -> t
+  -> t

--- a/astlib/position.ml
+++ b/astlib/position.ml
@@ -1,0 +1,33 @@
+type t = Lexing.position =
+  { pos_fname : string
+  ; pos_lnum : int
+  ; pos_bol : int
+  ; pos_cnum : int
+  }
+
+let of_position (t : t) = t
+let to_position (t : t) = t
+
+let fname t = t.pos_fname
+let lnum t = t.pos_lnum
+let bol t = t.pos_bol
+let cnum t = t.pos_cnum
+
+let create ~fname ~lnum ~bol ~cnum () =
+  { pos_fname = fname
+  ; pos_lnum = lnum
+  ; pos_bol = bol
+  ; pos_cnum = cnum
+  }
+
+let update_internal
+      t
+      ?(fname = fname t)
+      ?(lnum = lnum t)
+      ?(bol = bol t)
+      ?(cnum = cnum t)
+      ()
+  =
+  create ~fname ~lnum ~bol ~cnum ()
+
+let update ?fname ?lnum ?bol ?cnum t = update_internal t ?fname ?lnum ?bol ?cnum ()

--- a/astlib/position.mli
+++ b/astlib/position.mli
@@ -1,0 +1,45 @@
+(** Stable interface for Astlib positions, which are used as the start and end of AST
+    locations.
+
+    Astlib positions use the same representation as positions in the compiler; however, we
+    allow for the possibility that new fields will be added to the type over time. We
+    expose the type as [private] to discourage explicit construction, and provide a
+    [create] function that can be extended with optional arguments in a
+    backward-compatible way. *)
+
+(** {1 Type} *)
+
+(** The type equivalence with [Lexing.position] is expected to stay stable. *)
+type t = private Lexing.position
+
+(** {1 Conversions} It should always be possible to convert to/from [Lexing.position]. *)
+
+val of_position : Lexing.position -> t
+val to_position : t -> Lexing.position
+
+(** {1 Accessors} These should be stable. *)
+
+val fname : t -> string
+val lnum : t -> int
+val bol : t -> int
+val cnum : t -> int
+
+(** {1 Constructors} These may have additional optional arguments added over time. Where
+    necessary, we add an unnamed [unit] argument so that optional arguments can be
+    dropped, even if there currently are none. *)
+
+val create
+  :  fname : string
+  -> lnum : int
+  -> bol : int
+  -> cnum : int
+  -> unit
+  -> t
+
+val update
+  :  ?fname : string
+  -> ?lnum : int
+  -> ?bol : int
+  -> ?cnum : int
+  -> t
+  -> t


### PR DESCRIPTION
Added a stable interface for location types, and made the types "private" aliases for the compiler types. Conversions should be easy, but by forcing clients to use named constructors and accessors, we have room to maintain the stable interface if these types change in the future.

Documented which aspects we plan to maintain stability of (private type equivalence, accessors, required arguments of constructors) and which may change (additional optional arguments to constructors).