### PR TITLE
Add minimal interface to report Location errors in Astlib

### DIFF
--- a/ast/cinaps/dune
+++ b/ast/cinaps/dune
@@ -1,4 +1,4 @@
 (library
  (name ppx_ast_cinaps)
- (libraries astlib stdppx)
+ (libraries astlib stdppx ocaml-compiler-libs.shadow)
  (flags (:standard -open Ocaml_shadow -safe-string)))

--- a/astlib/dune
+++ b/astlib/dune
@@ -2,6 +2,5 @@
  (name astlib)
  (public_name astlib)
  (libraries
-  ocaml-compiler-libs.common
-  ocaml-compiler-libs.shadow)
- (flags (:standard -open Ocaml_shadow -safe-string)))
+  compiler-libs.common
+  ocaml-compiler-libs.common))

--- a/astlib/location.ml
+++ b/astlib/location.ml
@@ -21,3 +21,35 @@ let update_internal t ?(start = start t) ?(end_ = end_ t) ?(ghost = ghost t) () 
   create ~start ~end_ ~ghost ()
 
 let update ?start ?end_ ?ghost t = update_internal t ?start ?end_ ?ghost ()
+
+type location = t
+
+module Error = struct
+  type nonrec t =
+    { loc : t
+    ; fmt_msg : (Format.formatter -> unit)
+    }
+
+  let make ~loc fmt_msg = {loc; fmt_msg}
+
+  let report fmt {loc; fmt_msg} =
+    let msg = Format.asprintf "%t" fmt_msg in
+    let err = Ocaml_common.Location.error ~loc msg in
+    Ocaml_common.Location.(report_exception fmt (Error err))
+
+  let to_extension {loc; fmt_msg} =
+    let msg = Format.asprintf "%t" fmt_msg in
+    let open Parsetree in
+    let ext_name = {Ocaml_common.Location.txt = "ocaml.error"; loc} in
+    let msg_item =
+      let expr =
+        { pexp_loc = loc
+        ; pexp_attributes = []
+        ; pexp_desc = Pexp_constant (Pconst_string (msg, None))
+        }
+      in
+      {pstr_loc = loc; pstr_desc = Pstr_eval (expr, [])}
+    in
+    let payload = PStr [msg_item] in
+    ext_name, payload
+end

--- a/astlib/location.mli
+++ b/astlib/location.mli
@@ -40,3 +40,24 @@ val update
   -> ?ghost : bool
   -> t
   -> t
+
+type location = t
+
+module Error : sig
+  (** The type for located errors *)
+  type t
+
+  (** [make ~loc pp_msg] returns the error located at [loc] with the message
+      formatted by [pp_msg] *)
+  val make :
+    loc: location ->
+    (Format.formatter -> unit) ->
+    t
+
+  (** Report the error on the given formatter *)
+  val report : Format.formatter -> t -> unit
+
+  (** Convert the given error to a [[%ocaml.error ...]] extension point so that
+      it can later be reported by the compiler just as [report] would. *)
+  val to_extension : t -> Parsetree.extension
+end


### PR DESCRIPTION
Given we'll need to be compatible with OCaml 4.02 and up to 4.09 and they have different interfaces even for the `raise_errorf` function I went for an abstract error type and a `raise` function so that it's easy to extend it without breaking compatibility and there is a single way to build and raise location errors.

We can then wrap this into convenience functions in `ppx` itself or in a sub library that can be shared by `ppx`, `ppx_metaquot` and `ppx_view`.

Adding optional arguments to the `make` function might not be considered strictly speaking non-breaking so we could go for a bunch of `set_x : x -> t -> t` functions.

I'm not 100% convinced by this approach so I'm happy to change it if you have any suggestions.

Let me know what you think!