### PR TITLE
Extract functions to generate `t -> concrete` conversion code

### DIFF
--- a/ast/cinaps/gen_traverse.ml
+++ b/ast/cinaps/gen_traverse.ml
@@ -410,13 +410,7 @@ let traversal_classes =
   ]
 
 let print_to_concrete ~targs node_name =
-  Print.println "let concrete =";
-  let to_concrete = Name.make ["to_concrete"] targs in
-  Print.indented (fun () ->
-    Print.println "match %s.%s %s with" (Ml.module_name node_name) to_concrete (Ml.id node_name);
-    Print.println "| None -> failwith %S" node_name;
-    Print.println "| Some n -> n");
-  Print.println "in"
+  To_concrete.print_to_concrete_exn ~targs ~node_name (Ml.id node_name)
 
 let print_method_value ~traversal ~targs ~node_name decl =
   let args = traversal.args (Ml.id node_name) in
@@ -437,7 +431,7 @@ let declare_node_methods ~env_table ~signature (node_name, kind) =
       let name = Name.make [node_name] args in
       let signature = signature (node_type ~type_:T ~args node_name) in
       Ml.declare_method ~signature ~name ())
-      
+
 let define_node_methods ~env_table ~traversal (node_name, kind) =
   match (kind : Astlib.Grammar.kind) with
   | Mono decl ->
@@ -489,7 +483,9 @@ let print_virtual_traverse_ml () =
   Print.newline ();
   let grammars = Astlib.History.versioned_grammars Astlib.history in
   Ml.define_modules grammars ~f:(fun version grammar ->
-    Print.println "open Versions.%s" (Ml.module_name version);
+    let version = Ml.module_name version in
+    Print.println "open Versions.%s" version;
+    To_concrete.define_conversion_failed ~version;
     define_virtual_traversal_classes grammar)
 
 let print_virtual_traverse_mli () =

--- a/ast/cinaps/to_concrete.ml
+++ b/ast/cinaps/to_concrete.ml
@@ -1,0 +1,20 @@
+let define_conversion_failed ~version =
+  Print.newline ();
+  Print.println "let conversion_failed name =";
+  Print.indented (fun () ->
+    Print.println
+      {|let msg = Printf.sprintf "Ppx_ast: Could not convert %%s to %s" name in|}
+      version;
+    Print.println "failwith msg")
+
+let print_to_concrete_exn ~targs ~node_name expr =
+  Print.println "let concrete =";
+  Print.indented (fun () ->
+    let to_concrete = Name.make ["to_concrete"] targs in
+    Print.println "match %s.%s %s with"
+      (Ml.module_name node_name)
+      to_concrete
+      expr;
+    Print.println "| None -> conversion_failed %S" node_name;
+    Print.println "| Some n -> n");
+  Print.println "in"

--- a/ast/cinaps/to_concrete.ml
+++ b/ast/cinaps/to_concrete.ml
@@ -1,11 +1,8 @@
 let define_conversion_failed ~version =
   Print.newline ();
-  Print.println "let conversion_failed name =";
-  Print.indented (fun () ->
-    Print.println
-      {|let msg = Printf.sprintf "Ppx_ast: Could not convert %%s to %s" name in|}
-      version;
-    Print.println "failwith msg")
+  Print.println
+    "let conversion_failed name = Raise.conversion_failed ~version:%S name"
+    version
 
 let print_to_concrete_exn ?(var_name="concrete") ~targs ~node_name expr =
   Print.println "let %s =" var_name;

--- a/ast/cinaps/to_concrete.ml
+++ b/ast/cinaps/to_concrete.ml
@@ -7,8 +7,8 @@ let define_conversion_failed ~version =
       version;
     Print.println "failwith msg")
 
-let print_to_concrete_exn ~targs ~node_name expr =
-  Print.println "let concrete =";
+let print_to_concrete_exn ?(var_name="concrete") ~targs ~node_name expr =
+  Print.println "let %s =" var_name;
   Print.indented (fun () ->
     let to_concrete = Name.make ["to_concrete"] targs in
     Print.println "match %s.%s %s with"

--- a/ast/cinaps/to_concrete.mli
+++ b/ast/cinaps/to_concrete.mli
@@ -5,14 +5,20 @@
     ] *)
 val define_conversion_failed : version: string -> unit
 
-(** [
-    let concrete =
-      match X.to_concrete expr with
-      | None -> conversion_failed <node_name>
-      | Some n -> n
-    in
-    ] *)
+(** [print_to_concrete_exn ~var_name ~targs ~node_name expr] prints the code
+    that converts [expr] from the abstract to the concrete type for [node_name]
+    and binds it to [var_name] or raises if that conversion is impossible.
+    I.e. it prints something like: [let <var_name> = <conversion_code> in].
+
+    [targs] or the type arguments for the type [node_name]. If [node_name]
+    is a monomorphic type, it should be [[]].
+
+    [var_name] defaults to ["concrete"]
+
+    It relies on a [conversion_failed : string -> 'a] in the scope.
+*)
 val print_to_concrete_exn :
+  ?var_name: string ->
   targs: Astlib.Grammar.ty list ->
   node_name: string ->
   string ->

--- a/ast/cinaps/to_concrete.mli
+++ b/ast/cinaps/to_concrete.mli
@@ -1,0 +1,19 @@
+(** [
+    let conversion_failed node_name =
+      let msg = Printf.sprintf "Ppx_ast: Could not convert %s to <version>" node_name in
+      failwith msg
+    ] *)
+val define_conversion_failed : version: string -> unit
+
+(** [
+    let concrete =
+      match X.to_concrete expr with
+      | None -> conversion_failed <node_name>
+      | Some n -> n
+    in
+    ] *)
+val print_to_concrete_exn :
+  targs: Astlib.Grammar.ty list ->
+  node_name: string ->
+  string ->
+  unit

--- a/ast/raise.ml
+++ b/ast/raise.ml
@@ -1,0 +1,5 @@
+let conversion_failed ~version node_name =
+  let msg =
+    Printf.sprintf "Ppx_ast: Could not convert %s to %s" version node_name
+  in
+  failwith msg

--- a/ast/raise.mli
+++ b/ast/raise.mli
@@ -1,0 +1,3 @@
+(** [conversion_failed ~version "x"] raises an exception describing a failure
+    to convert a node of type x to the [version] AST representation. *)
+val conversion_failed : version: string -> string -> 'a

--- a/ast/virtual_traverse.ml
+++ b/ast/virtual_traverse.ml
@@ -2,6 +2,10 @@
 module V4_07 = struct
   open Versions.V4_07
 
+  let conversion_failed name =
+    let msg = Printf.sprintf "Ppx_ast: Could not convert %s to V4_07" name in
+    failwith msg
+
   class virtual map =
     object (self)
       method virtual bool : bool -> bool
@@ -16,7 +20,7 @@ module V4_07 = struct
         fun longident ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -35,7 +39,7 @@ module V4_07 = struct
         fun longident_loc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let concrete = self#loc self#longident concrete in
@@ -44,7 +48,7 @@ module V4_07 = struct
         fun rec_flag ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -56,7 +60,7 @@ module V4_07 = struct
         fun direction_flag ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -68,7 +72,7 @@ module V4_07 = struct
         fun private_flag ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -80,7 +84,7 @@ module V4_07 = struct
         fun mutable_flag ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -92,7 +96,7 @@ module V4_07 = struct
         fun virtual_flag ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -104,7 +108,7 @@ module V4_07 = struct
         fun override_flag ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -116,7 +120,7 @@ module V4_07 = struct
         fun closed_flag ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -128,7 +132,7 @@ module V4_07 = struct
         fun label ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let concrete = self#string concrete in
@@ -137,7 +141,7 @@ module V4_07 = struct
         fun arg_label ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -153,7 +157,7 @@ module V4_07 = struct
         fun variance ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -167,7 +171,7 @@ module V4_07 = struct
         fun constant ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -190,7 +194,7 @@ module V4_07 = struct
         fun attribute ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -201,7 +205,7 @@ module V4_07 = struct
         fun extension ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -212,7 +216,7 @@ module V4_07 = struct
         fun attributes ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let concrete = self#list self#attribute concrete in
@@ -221,7 +225,7 @@ module V4_07 = struct
         fun payload ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -242,7 +246,7 @@ module V4_07 = struct
         fun core_type ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -254,7 +258,7 @@ module V4_07 = struct
         fun core_type_desc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -306,7 +310,7 @@ module V4_07 = struct
         fun package_type ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -317,7 +321,7 @@ module V4_07 = struct
         fun row_field ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -334,7 +338,7 @@ module V4_07 = struct
         fun object_field ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -350,7 +354,7 @@ module V4_07 = struct
         fun pattern ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -362,7 +366,7 @@ module V4_07 = struct
         fun pattern_desc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -431,7 +435,7 @@ module V4_07 = struct
         fun expression ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -443,7 +447,7 @@ module V4_07 = struct
         fun expression_desc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -592,7 +596,7 @@ module V4_07 = struct
         fun case ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -604,7 +608,7 @@ module V4_07 = struct
         fun value_description ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -618,7 +622,7 @@ module V4_07 = struct
         fun type_declaration ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -635,7 +639,7 @@ module V4_07 = struct
         fun type_kind ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -653,7 +657,7 @@ module V4_07 = struct
         fun label_declaration ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -667,7 +671,7 @@ module V4_07 = struct
         fun constructor_declaration ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -681,7 +685,7 @@ module V4_07 = struct
         fun constructor_arguments ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -695,7 +699,7 @@ module V4_07 = struct
         fun type_extension ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -709,7 +713,7 @@ module V4_07 = struct
         fun extension_constructor ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -722,7 +726,7 @@ module V4_07 = struct
         fun extension_constructor_kind ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -737,7 +741,7 @@ module V4_07 = struct
         fun class_type ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -749,7 +753,7 @@ module V4_07 = struct
         fun class_type_desc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -777,7 +781,7 @@ module V4_07 = struct
         fun class_signature ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -788,7 +792,7 @@ module V4_07 = struct
         fun class_type_field ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -800,7 +804,7 @@ module V4_07 = struct
         fun class_type_field_desc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -826,7 +830,7 @@ module V4_07 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -841,7 +845,7 @@ module V4_07 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -856,7 +860,7 @@ module V4_07 = struct
         fun class_description ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type concrete in
@@ -865,7 +869,7 @@ module V4_07 = struct
         fun class_type_declaration ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type concrete in
@@ -874,7 +878,7 @@ module V4_07 = struct
         fun class_expr ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -886,7 +890,7 @@ module V4_07 = struct
         fun class_expr_desc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -928,7 +932,7 @@ module V4_07 = struct
         fun class_structure ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -939,7 +943,7 @@ module V4_07 = struct
         fun class_field ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -951,7 +955,7 @@ module V4_07 = struct
         fun class_field_desc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -982,7 +986,7 @@ module V4_07 = struct
         fun class_field_kind ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -997,7 +1001,7 @@ module V4_07 = struct
         fun class_declaration ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_expr concrete in
@@ -1006,7 +1010,7 @@ module V4_07 = struct
         fun module_type ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -1018,7 +1022,7 @@ module V4_07 = struct
         fun module_type_desc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -1050,7 +1054,7 @@ module V4_07 = struct
         fun signature ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let concrete = self#list self#signature_item concrete in
@@ -1059,7 +1063,7 @@ module V4_07 = struct
         fun signature_item ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -1070,7 +1074,7 @@ module V4_07 = struct
         fun signature_item_desc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -1119,7 +1123,7 @@ module V4_07 = struct
         fun module_declaration ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -1132,7 +1136,7 @@ module V4_07 = struct
         fun module_type_declaration ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -1145,7 +1149,7 @@ module V4_07 = struct
         fun open_description ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -1158,7 +1162,7 @@ module V4_07 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -1170,7 +1174,7 @@ module V4_07 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -1182,7 +1186,7 @@ module V4_07 = struct
         fun include_description ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let concrete = self#include_infos_module_type concrete in
@@ -1191,7 +1195,7 @@ module V4_07 = struct
         fun include_declaration ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let concrete = self#include_infos_module_expr concrete in
@@ -1200,7 +1204,7 @@ module V4_07 = struct
         fun with_constraint ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -1224,7 +1228,7 @@ module V4_07 = struct
         fun module_expr ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -1236,7 +1240,7 @@ module V4_07 = struct
         fun module_expr_desc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -1269,7 +1273,7 @@ module V4_07 = struct
         fun structure ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let concrete = self#list self#structure_item concrete in
@@ -1278,7 +1282,7 @@ module V4_07 = struct
         fun structure_item ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -1289,7 +1293,7 @@ module V4_07 = struct
         fun structure_item_desc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -1346,7 +1350,7 @@ module V4_07 = struct
         fun value_binding ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -1359,7 +1363,7 @@ module V4_07 = struct
         fun module_binding ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -1372,7 +1376,7 @@ module V4_07 = struct
         fun toplevel_phrase ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -1387,7 +1391,7 @@ module V4_07 = struct
         fun directive_argument ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -1422,7 +1426,7 @@ module V4_07 = struct
         fun longident ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -1438,7 +1442,7 @@ module V4_07 = struct
         fun longident_loc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           self#loc self#longident concrete
@@ -1446,7 +1450,7 @@ module V4_07 = struct
         fun rec_flag ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -1458,7 +1462,7 @@ module V4_07 = struct
         fun direction_flag ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -1470,7 +1474,7 @@ module V4_07 = struct
         fun private_flag ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -1482,7 +1486,7 @@ module V4_07 = struct
         fun mutable_flag ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -1494,7 +1498,7 @@ module V4_07 = struct
         fun virtual_flag ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -1506,7 +1510,7 @@ module V4_07 = struct
         fun override_flag ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -1518,7 +1522,7 @@ module V4_07 = struct
         fun closed_flag ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -1530,7 +1534,7 @@ module V4_07 = struct
         fun label ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           self#string concrete
@@ -1538,7 +1542,7 @@ module V4_07 = struct
         fun arg_label ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -1552,7 +1556,7 @@ module V4_07 = struct
         fun variance ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -1566,7 +1570,7 @@ module V4_07 = struct
         fun constant ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -1585,7 +1589,7 @@ module V4_07 = struct
         fun attribute ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -1595,7 +1599,7 @@ module V4_07 = struct
         fun extension ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -1605,7 +1609,7 @@ module V4_07 = struct
         fun attributes ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           self#list self#attribute concrete
@@ -1613,7 +1617,7 @@ module V4_07 = struct
         fun payload ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -1630,7 +1634,7 @@ module V4_07 = struct
         fun core_type ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -1641,7 +1645,7 @@ module V4_07 = struct
         fun core_type_desc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -1682,7 +1686,7 @@ module V4_07 = struct
         fun package_type ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -1692,7 +1696,7 @@ module V4_07 = struct
         fun row_field ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -1707,7 +1711,7 @@ module V4_07 = struct
         fun object_field ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -1721,7 +1725,7 @@ module V4_07 = struct
         fun pattern ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -1732,7 +1736,7 @@ module V4_07 = struct
         fun pattern_desc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -1784,7 +1788,7 @@ module V4_07 = struct
         fun expression ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -1795,7 +1799,7 @@ module V4_07 = struct
         fun expression_desc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -1909,7 +1913,7 @@ module V4_07 = struct
         fun case ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -1920,7 +1924,7 @@ module V4_07 = struct
         fun value_description ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -1933,7 +1937,7 @@ module V4_07 = struct
         fun type_declaration ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -1949,7 +1953,7 @@ module V4_07 = struct
         fun type_kind ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -1965,7 +1969,7 @@ module V4_07 = struct
         fun label_declaration ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -1978,7 +1982,7 @@ module V4_07 = struct
         fun constructor_declaration ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -1991,7 +1995,7 @@ module V4_07 = struct
         fun constructor_arguments ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -2003,7 +2007,7 @@ module V4_07 = struct
         fun type_extension ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -2016,7 +2020,7 @@ module V4_07 = struct
         fun extension_constructor ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -2028,7 +2032,7 @@ module V4_07 = struct
         fun extension_constructor_kind ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -2041,7 +2045,7 @@ module V4_07 = struct
         fun class_type ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -2052,7 +2056,7 @@ module V4_07 = struct
         fun class_type_desc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -2075,7 +2079,7 @@ module V4_07 = struct
         fun class_signature ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -2085,7 +2089,7 @@ module V4_07 = struct
         fun class_type_field ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -2096,7 +2100,7 @@ module V4_07 = struct
         fun class_type_field_desc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -2116,7 +2120,7 @@ module V4_07 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -2130,7 +2134,7 @@ module V4_07 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -2144,7 +2148,7 @@ module V4_07 = struct
         fun class_description ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           self#class_infos_class_type concrete
@@ -2152,7 +2156,7 @@ module V4_07 = struct
         fun class_type_declaration ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           self#class_infos_class_type concrete
@@ -2160,7 +2164,7 @@ module V4_07 = struct
         fun class_expr ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -2171,7 +2175,7 @@ module V4_07 = struct
         fun class_expr_desc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -2205,7 +2209,7 @@ module V4_07 = struct
         fun class_structure ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -2215,7 +2219,7 @@ module V4_07 = struct
         fun class_field ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -2226,7 +2230,7 @@ module V4_07 = struct
         fun class_field_desc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -2250,7 +2254,7 @@ module V4_07 = struct
         fun class_field_kind ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -2263,7 +2267,7 @@ module V4_07 = struct
         fun class_declaration ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           self#class_infos_class_expr concrete
@@ -2271,7 +2275,7 @@ module V4_07 = struct
         fun module_type ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -2282,7 +2286,7 @@ module V4_07 = struct
         fun module_type_desc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -2307,7 +2311,7 @@ module V4_07 = struct
         fun signature ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           self#list self#signature_item concrete
@@ -2315,7 +2319,7 @@ module V4_07 = struct
         fun signature_item ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -2325,7 +2329,7 @@ module V4_07 = struct
         fun signature_item_desc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -2361,7 +2365,7 @@ module V4_07 = struct
         fun module_declaration ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -2373,7 +2377,7 @@ module V4_07 = struct
         fun module_type_declaration ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -2385,7 +2389,7 @@ module V4_07 = struct
         fun open_description ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -2397,7 +2401,7 @@ module V4_07 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -2408,7 +2412,7 @@ module V4_07 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -2419,7 +2423,7 @@ module V4_07 = struct
         fun include_description ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           self#include_infos_module_type concrete
@@ -2427,7 +2431,7 @@ module V4_07 = struct
         fun include_declaration ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           self#include_infos_module_expr concrete
@@ -2435,7 +2439,7 @@ module V4_07 = struct
         fun with_constraint ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -2455,7 +2459,7 @@ module V4_07 = struct
         fun module_expr ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -2466,7 +2470,7 @@ module V4_07 = struct
         fun module_expr_desc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -2492,7 +2496,7 @@ module V4_07 = struct
         fun structure ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           self#list self#structure_item concrete
@@ -2500,7 +2504,7 @@ module V4_07 = struct
         fun structure_item ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -2510,7 +2514,7 @@ module V4_07 = struct
         fun structure_item_desc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -2552,7 +2556,7 @@ module V4_07 = struct
         fun value_binding ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -2564,7 +2568,7 @@ module V4_07 = struct
         fun module_binding ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -2576,7 +2580,7 @@ module V4_07 = struct
         fun toplevel_phrase ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -2589,7 +2593,7 @@ module V4_07 = struct
         fun directive_argument ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -2620,7 +2624,7 @@ module V4_07 = struct
         fun longident acc ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -2639,7 +2643,7 @@ module V4_07 = struct
         fun longident_loc acc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let acc = self#loc self#longident concrete acc in
@@ -2648,7 +2652,7 @@ module V4_07 = struct
         fun rec_flag acc ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -2660,7 +2664,7 @@ module V4_07 = struct
         fun direction_flag acc ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -2672,7 +2676,7 @@ module V4_07 = struct
         fun private_flag acc ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -2684,7 +2688,7 @@ module V4_07 = struct
         fun mutable_flag acc ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -2696,7 +2700,7 @@ module V4_07 = struct
         fun virtual_flag acc ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -2708,7 +2712,7 @@ module V4_07 = struct
         fun override_flag acc ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -2720,7 +2724,7 @@ module V4_07 = struct
         fun closed_flag acc ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -2732,7 +2736,7 @@ module V4_07 = struct
         fun label acc ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let acc = self#string concrete acc in
@@ -2741,7 +2745,7 @@ module V4_07 = struct
         fun arg_label acc ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -2757,7 +2761,7 @@ module V4_07 = struct
         fun variance acc ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -2771,7 +2775,7 @@ module V4_07 = struct
         fun constant acc ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -2794,7 +2798,7 @@ module V4_07 = struct
         fun attribute acc ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -2805,7 +2809,7 @@ module V4_07 = struct
         fun extension acc ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -2816,7 +2820,7 @@ module V4_07 = struct
         fun attributes acc ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let acc = self#list self#attribute concrete acc in
@@ -2825,7 +2829,7 @@ module V4_07 = struct
         fun payload acc ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -2846,7 +2850,7 @@ module V4_07 = struct
         fun core_type acc ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -2858,7 +2862,7 @@ module V4_07 = struct
         fun core_type_desc acc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -2910,7 +2914,7 @@ module V4_07 = struct
         fun package_type acc ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -2921,7 +2925,7 @@ module V4_07 = struct
         fun row_field acc ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -2938,7 +2942,7 @@ module V4_07 = struct
         fun object_field acc ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -2954,7 +2958,7 @@ module V4_07 = struct
         fun pattern acc ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -2966,7 +2970,7 @@ module V4_07 = struct
         fun pattern_desc acc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -3035,7 +3039,7 @@ module V4_07 = struct
         fun expression acc ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -3047,7 +3051,7 @@ module V4_07 = struct
         fun expression_desc acc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -3196,7 +3200,7 @@ module V4_07 = struct
         fun case acc ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -3208,7 +3212,7 @@ module V4_07 = struct
         fun value_description acc ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -3222,7 +3226,7 @@ module V4_07 = struct
         fun type_declaration acc ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -3239,7 +3243,7 @@ module V4_07 = struct
         fun type_kind acc ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -3257,7 +3261,7 @@ module V4_07 = struct
         fun label_declaration acc ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -3271,7 +3275,7 @@ module V4_07 = struct
         fun constructor_declaration acc ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -3285,7 +3289,7 @@ module V4_07 = struct
         fun constructor_arguments acc ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -3299,7 +3303,7 @@ module V4_07 = struct
         fun type_extension acc ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -3313,7 +3317,7 @@ module V4_07 = struct
         fun extension_constructor acc ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -3326,7 +3330,7 @@ module V4_07 = struct
         fun extension_constructor_kind acc ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -3341,7 +3345,7 @@ module V4_07 = struct
         fun class_type acc ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -3353,7 +3357,7 @@ module V4_07 = struct
         fun class_type_desc acc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -3381,7 +3385,7 @@ module V4_07 = struct
         fun class_signature acc ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -3392,7 +3396,7 @@ module V4_07 = struct
         fun class_type_field acc ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -3404,7 +3408,7 @@ module V4_07 = struct
         fun class_type_field_desc acc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -3430,7 +3434,7 @@ module V4_07 = struct
         fun class_infos acc ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -3445,7 +3449,7 @@ module V4_07 = struct
         fun class_infos acc ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -3460,7 +3464,7 @@ module V4_07 = struct
         fun class_description acc ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let acc = self#class_infos_class_type concrete acc in
@@ -3469,7 +3473,7 @@ module V4_07 = struct
         fun class_type_declaration acc ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let acc = self#class_infos_class_type concrete acc in
@@ -3478,7 +3482,7 @@ module V4_07 = struct
         fun class_expr acc ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -3490,7 +3494,7 @@ module V4_07 = struct
         fun class_expr_desc acc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -3532,7 +3536,7 @@ module V4_07 = struct
         fun class_structure acc ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -3543,7 +3547,7 @@ module V4_07 = struct
         fun class_field acc ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -3555,7 +3559,7 @@ module V4_07 = struct
         fun class_field_desc acc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -3586,7 +3590,7 @@ module V4_07 = struct
         fun class_field_kind acc ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -3601,7 +3605,7 @@ module V4_07 = struct
         fun class_declaration acc ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let acc = self#class_infos_class_expr concrete acc in
@@ -3610,7 +3614,7 @@ module V4_07 = struct
         fun module_type acc ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -3622,7 +3626,7 @@ module V4_07 = struct
         fun module_type_desc acc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -3654,7 +3658,7 @@ module V4_07 = struct
         fun signature acc ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let acc = self#list self#signature_item concrete acc in
@@ -3663,7 +3667,7 @@ module V4_07 = struct
         fun signature_item acc ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -3674,7 +3678,7 @@ module V4_07 = struct
         fun signature_item_desc acc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -3723,7 +3727,7 @@ module V4_07 = struct
         fun module_declaration acc ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -3736,7 +3740,7 @@ module V4_07 = struct
         fun module_type_declaration acc ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -3749,7 +3753,7 @@ module V4_07 = struct
         fun open_description acc ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -3762,7 +3766,7 @@ module V4_07 = struct
         fun include_infos acc ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -3774,7 +3778,7 @@ module V4_07 = struct
         fun include_infos acc ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -3786,7 +3790,7 @@ module V4_07 = struct
         fun include_description acc ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let acc = self#include_infos_module_type concrete acc in
@@ -3795,7 +3799,7 @@ module V4_07 = struct
         fun include_declaration acc ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let acc = self#include_infos_module_expr concrete acc in
@@ -3804,7 +3808,7 @@ module V4_07 = struct
         fun with_constraint acc ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -3828,7 +3832,7 @@ module V4_07 = struct
         fun module_expr acc ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -3840,7 +3844,7 @@ module V4_07 = struct
         fun module_expr_desc acc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -3873,7 +3877,7 @@ module V4_07 = struct
         fun structure acc ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let acc = self#list self#structure_item concrete acc in
@@ -3882,7 +3886,7 @@ module V4_07 = struct
         fun structure_item acc ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -3893,7 +3897,7 @@ module V4_07 = struct
         fun structure_item_desc acc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -3950,7 +3954,7 @@ module V4_07 = struct
         fun value_binding acc ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -3963,7 +3967,7 @@ module V4_07 = struct
         fun module_binding acc ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -3976,7 +3980,7 @@ module V4_07 = struct
         fun toplevel_phrase acc ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -3991,7 +3995,7 @@ module V4_07 = struct
         fun directive_argument acc ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -4026,7 +4030,7 @@ module V4_07 = struct
         fun longident acc ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -4045,7 +4049,7 @@ module V4_07 = struct
         fun longident_loc acc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let (concrete, acc) = self#loc self#longident concrete acc in
@@ -4054,7 +4058,7 @@ module V4_07 = struct
         fun rec_flag acc ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -4066,7 +4070,7 @@ module V4_07 = struct
         fun direction_flag acc ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -4078,7 +4082,7 @@ module V4_07 = struct
         fun private_flag acc ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -4090,7 +4094,7 @@ module V4_07 = struct
         fun mutable_flag acc ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -4102,7 +4106,7 @@ module V4_07 = struct
         fun virtual_flag acc ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -4114,7 +4118,7 @@ module V4_07 = struct
         fun override_flag acc ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -4126,7 +4130,7 @@ module V4_07 = struct
         fun closed_flag acc ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -4138,7 +4142,7 @@ module V4_07 = struct
         fun label acc ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let (concrete, acc) = self#string concrete acc in
@@ -4147,7 +4151,7 @@ module V4_07 = struct
         fun arg_label acc ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -4163,7 +4167,7 @@ module V4_07 = struct
         fun variance acc ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -4177,7 +4181,7 @@ module V4_07 = struct
         fun constant acc ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -4200,7 +4204,7 @@ module V4_07 = struct
         fun attribute acc ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -4211,7 +4215,7 @@ module V4_07 = struct
         fun extension acc ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -4222,7 +4226,7 @@ module V4_07 = struct
         fun attributes acc ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let (concrete, acc) = self#list self#attribute concrete acc in
@@ -4231,7 +4235,7 @@ module V4_07 = struct
         fun payload acc ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -4252,7 +4256,7 @@ module V4_07 = struct
         fun core_type acc ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -4264,7 +4268,7 @@ module V4_07 = struct
         fun core_type_desc acc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -4316,7 +4320,7 @@ module V4_07 = struct
         fun package_type acc ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -4327,7 +4331,7 @@ module V4_07 = struct
         fun row_field acc ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -4344,7 +4348,7 @@ module V4_07 = struct
         fun object_field acc ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -4360,7 +4364,7 @@ module V4_07 = struct
         fun pattern acc ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -4372,7 +4376,7 @@ module V4_07 = struct
         fun pattern_desc acc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -4441,7 +4445,7 @@ module V4_07 = struct
         fun expression acc ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -4453,7 +4457,7 @@ module V4_07 = struct
         fun expression_desc acc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -4602,7 +4606,7 @@ module V4_07 = struct
         fun case acc ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -4614,7 +4618,7 @@ module V4_07 = struct
         fun value_description acc ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -4628,7 +4632,7 @@ module V4_07 = struct
         fun type_declaration acc ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -4645,7 +4649,7 @@ module V4_07 = struct
         fun type_kind acc ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -4663,7 +4667,7 @@ module V4_07 = struct
         fun label_declaration acc ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -4677,7 +4681,7 @@ module V4_07 = struct
         fun constructor_declaration acc ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -4691,7 +4695,7 @@ module V4_07 = struct
         fun constructor_arguments acc ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -4705,7 +4709,7 @@ module V4_07 = struct
         fun type_extension acc ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -4719,7 +4723,7 @@ module V4_07 = struct
         fun extension_constructor acc ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -4732,7 +4736,7 @@ module V4_07 = struct
         fun extension_constructor_kind acc ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -4747,7 +4751,7 @@ module V4_07 = struct
         fun class_type acc ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -4759,7 +4763,7 @@ module V4_07 = struct
         fun class_type_desc acc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -4787,7 +4791,7 @@ module V4_07 = struct
         fun class_signature acc ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -4798,7 +4802,7 @@ module V4_07 = struct
         fun class_type_field acc ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -4810,7 +4814,7 @@ module V4_07 = struct
         fun class_type_field_desc acc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -4836,7 +4840,7 @@ module V4_07 = struct
         fun class_infos acc ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -4851,7 +4855,7 @@ module V4_07 = struct
         fun class_infos acc ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -4866,7 +4870,7 @@ module V4_07 = struct
         fun class_description acc ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let (concrete, acc) = self#class_infos_class_type concrete acc in
@@ -4875,7 +4879,7 @@ module V4_07 = struct
         fun class_type_declaration acc ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let (concrete, acc) = self#class_infos_class_type concrete acc in
@@ -4884,7 +4888,7 @@ module V4_07 = struct
         fun class_expr acc ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -4896,7 +4900,7 @@ module V4_07 = struct
         fun class_expr_desc acc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -4938,7 +4942,7 @@ module V4_07 = struct
         fun class_structure acc ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -4949,7 +4953,7 @@ module V4_07 = struct
         fun class_field acc ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -4961,7 +4965,7 @@ module V4_07 = struct
         fun class_field_desc acc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -4992,7 +4996,7 @@ module V4_07 = struct
         fun class_field_kind acc ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -5007,7 +5011,7 @@ module V4_07 = struct
         fun class_declaration acc ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let (concrete, acc) = self#class_infos_class_expr concrete acc in
@@ -5016,7 +5020,7 @@ module V4_07 = struct
         fun module_type acc ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -5028,7 +5032,7 @@ module V4_07 = struct
         fun module_type_desc acc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -5060,7 +5064,7 @@ module V4_07 = struct
         fun signature acc ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let (concrete, acc) = self#list self#signature_item concrete acc in
@@ -5069,7 +5073,7 @@ module V4_07 = struct
         fun signature_item acc ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -5080,7 +5084,7 @@ module V4_07 = struct
         fun signature_item_desc acc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -5129,7 +5133,7 @@ module V4_07 = struct
         fun module_declaration acc ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -5142,7 +5146,7 @@ module V4_07 = struct
         fun module_type_declaration acc ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -5155,7 +5159,7 @@ module V4_07 = struct
         fun open_description acc ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -5168,7 +5172,7 @@ module V4_07 = struct
         fun include_infos acc ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -5180,7 +5184,7 @@ module V4_07 = struct
         fun include_infos acc ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -5192,7 +5196,7 @@ module V4_07 = struct
         fun include_description acc ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let (concrete, acc) = self#include_infos_module_type concrete acc in
@@ -5201,7 +5205,7 @@ module V4_07 = struct
         fun include_declaration acc ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let (concrete, acc) = self#include_infos_module_expr concrete acc in
@@ -5210,7 +5214,7 @@ module V4_07 = struct
         fun with_constraint acc ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -5234,7 +5238,7 @@ module V4_07 = struct
         fun module_expr acc ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -5246,7 +5250,7 @@ module V4_07 = struct
         fun module_expr_desc acc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -5279,7 +5283,7 @@ module V4_07 = struct
         fun structure acc ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let (concrete, acc) = self#list self#structure_item concrete acc in
@@ -5288,7 +5292,7 @@ module V4_07 = struct
         fun structure_item acc ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -5299,7 +5303,7 @@ module V4_07 = struct
         fun structure_item_desc acc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -5356,7 +5360,7 @@ module V4_07 = struct
         fun value_binding acc ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -5369,7 +5373,7 @@ module V4_07 = struct
         fun module_binding acc ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -5382,7 +5386,7 @@ module V4_07 = struct
         fun toplevel_phrase acc ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -5397,7 +5401,7 @@ module V4_07 = struct
         fun directive_argument acc ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -5432,7 +5436,7 @@ module V4_07 = struct
         fun _ctx longident ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -5451,7 +5455,7 @@ module V4_07 = struct
         fun _ctx longident_loc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let concrete = self#loc self#longident _ctx concrete in
@@ -5460,7 +5464,7 @@ module V4_07 = struct
         fun _ctx rec_flag ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -5472,7 +5476,7 @@ module V4_07 = struct
         fun _ctx direction_flag ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -5484,7 +5488,7 @@ module V4_07 = struct
         fun _ctx private_flag ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -5496,7 +5500,7 @@ module V4_07 = struct
         fun _ctx mutable_flag ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -5508,7 +5512,7 @@ module V4_07 = struct
         fun _ctx virtual_flag ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -5520,7 +5524,7 @@ module V4_07 = struct
         fun _ctx override_flag ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -5532,7 +5536,7 @@ module V4_07 = struct
         fun _ctx closed_flag ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -5544,7 +5548,7 @@ module V4_07 = struct
         fun _ctx label ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let concrete = self#string _ctx concrete in
@@ -5553,7 +5557,7 @@ module V4_07 = struct
         fun _ctx arg_label ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -5569,7 +5573,7 @@ module V4_07 = struct
         fun _ctx variance ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -5583,7 +5587,7 @@ module V4_07 = struct
         fun _ctx constant ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -5606,7 +5610,7 @@ module V4_07 = struct
         fun _ctx attribute ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -5617,7 +5621,7 @@ module V4_07 = struct
         fun _ctx extension ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -5628,7 +5632,7 @@ module V4_07 = struct
         fun _ctx attributes ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let concrete = self#list self#attribute _ctx concrete in
@@ -5637,7 +5641,7 @@ module V4_07 = struct
         fun _ctx payload ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -5658,7 +5662,7 @@ module V4_07 = struct
         fun _ctx core_type ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -5670,7 +5674,7 @@ module V4_07 = struct
         fun _ctx core_type_desc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -5722,7 +5726,7 @@ module V4_07 = struct
         fun _ctx package_type ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -5733,7 +5737,7 @@ module V4_07 = struct
         fun _ctx row_field ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -5750,7 +5754,7 @@ module V4_07 = struct
         fun _ctx object_field ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -5766,7 +5770,7 @@ module V4_07 = struct
         fun _ctx pattern ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -5778,7 +5782,7 @@ module V4_07 = struct
         fun _ctx pattern_desc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -5847,7 +5851,7 @@ module V4_07 = struct
         fun _ctx expression ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -5859,7 +5863,7 @@ module V4_07 = struct
         fun _ctx expression_desc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -6008,7 +6012,7 @@ module V4_07 = struct
         fun _ctx case ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -6020,7 +6024,7 @@ module V4_07 = struct
         fun _ctx value_description ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -6034,7 +6038,7 @@ module V4_07 = struct
         fun _ctx type_declaration ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -6051,7 +6055,7 @@ module V4_07 = struct
         fun _ctx type_kind ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -6069,7 +6073,7 @@ module V4_07 = struct
         fun _ctx label_declaration ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -6083,7 +6087,7 @@ module V4_07 = struct
         fun _ctx constructor_declaration ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -6097,7 +6101,7 @@ module V4_07 = struct
         fun _ctx constructor_arguments ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -6111,7 +6115,7 @@ module V4_07 = struct
         fun _ctx type_extension ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -6125,7 +6129,7 @@ module V4_07 = struct
         fun _ctx extension_constructor ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -6138,7 +6142,7 @@ module V4_07 = struct
         fun _ctx extension_constructor_kind ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -6153,7 +6157,7 @@ module V4_07 = struct
         fun _ctx class_type ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -6165,7 +6169,7 @@ module V4_07 = struct
         fun _ctx class_type_desc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -6193,7 +6197,7 @@ module V4_07 = struct
         fun _ctx class_signature ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -6204,7 +6208,7 @@ module V4_07 = struct
         fun _ctx class_type_field ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -6216,7 +6220,7 @@ module V4_07 = struct
         fun _ctx class_type_field_desc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -6242,7 +6246,7 @@ module V4_07 = struct
         fun _ctx class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -6257,7 +6261,7 @@ module V4_07 = struct
         fun _ctx class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -6272,7 +6276,7 @@ module V4_07 = struct
         fun _ctx class_description ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type _ctx concrete in
@@ -6281,7 +6285,7 @@ module V4_07 = struct
         fun _ctx class_type_declaration ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type _ctx concrete in
@@ -6290,7 +6294,7 @@ module V4_07 = struct
         fun _ctx class_expr ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -6302,7 +6306,7 @@ module V4_07 = struct
         fun _ctx class_expr_desc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -6344,7 +6348,7 @@ module V4_07 = struct
         fun _ctx class_structure ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -6355,7 +6359,7 @@ module V4_07 = struct
         fun _ctx class_field ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -6367,7 +6371,7 @@ module V4_07 = struct
         fun _ctx class_field_desc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -6398,7 +6402,7 @@ module V4_07 = struct
         fun _ctx class_field_kind ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -6413,7 +6417,7 @@ module V4_07 = struct
         fun _ctx class_declaration ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_expr _ctx concrete in
@@ -6422,7 +6426,7 @@ module V4_07 = struct
         fun _ctx module_type ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -6434,7 +6438,7 @@ module V4_07 = struct
         fun _ctx module_type_desc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -6466,7 +6470,7 @@ module V4_07 = struct
         fun _ctx signature ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let concrete = self#list self#signature_item _ctx concrete in
@@ -6475,7 +6479,7 @@ module V4_07 = struct
         fun _ctx signature_item ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -6486,7 +6490,7 @@ module V4_07 = struct
         fun _ctx signature_item_desc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -6535,7 +6539,7 @@ module V4_07 = struct
         fun _ctx module_declaration ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -6548,7 +6552,7 @@ module V4_07 = struct
         fun _ctx module_type_declaration ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -6561,7 +6565,7 @@ module V4_07 = struct
         fun _ctx open_description ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -6574,7 +6578,7 @@ module V4_07 = struct
         fun _ctx include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -6586,7 +6590,7 @@ module V4_07 = struct
         fun _ctx include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -6598,7 +6602,7 @@ module V4_07 = struct
         fun _ctx include_description ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let concrete = self#include_infos_module_type _ctx concrete in
@@ -6607,7 +6611,7 @@ module V4_07 = struct
         fun _ctx include_declaration ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let concrete = self#include_infos_module_expr _ctx concrete in
@@ -6616,7 +6620,7 @@ module V4_07 = struct
         fun _ctx with_constraint ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -6640,7 +6644,7 @@ module V4_07 = struct
         fun _ctx module_expr ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -6652,7 +6656,7 @@ module V4_07 = struct
         fun _ctx module_expr_desc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -6685,7 +6689,7 @@ module V4_07 = struct
         fun _ctx structure ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let concrete = self#list self#structure_item _ctx concrete in
@@ -6694,7 +6698,7 @@ module V4_07 = struct
         fun _ctx structure_item ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -6705,7 +6709,7 @@ module V4_07 = struct
         fun _ctx structure_item_desc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -6762,7 +6766,7 @@ module V4_07 = struct
         fun _ctx value_binding ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -6775,7 +6779,7 @@ module V4_07 = struct
         fun _ctx module_binding ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -6788,7 +6792,7 @@ module V4_07 = struct
         fun _ctx toplevel_phrase ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -6803,7 +6807,7 @@ module V4_07 = struct
         fun _ctx directive_argument ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -6841,7 +6845,7 @@ module V4_07 = struct
         fun longident ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -6860,7 +6864,7 @@ module V4_07 = struct
         fun longident_loc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let concrete = self#loc self#longident concrete in
@@ -6869,7 +6873,7 @@ module V4_07 = struct
         fun rec_flag ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -6881,7 +6885,7 @@ module V4_07 = struct
         fun direction_flag ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -6893,7 +6897,7 @@ module V4_07 = struct
         fun private_flag ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -6905,7 +6909,7 @@ module V4_07 = struct
         fun mutable_flag ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -6917,7 +6921,7 @@ module V4_07 = struct
         fun virtual_flag ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -6929,7 +6933,7 @@ module V4_07 = struct
         fun override_flag ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -6941,7 +6945,7 @@ module V4_07 = struct
         fun closed_flag ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -6953,7 +6957,7 @@ module V4_07 = struct
         fun label ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let concrete = self#string concrete in
@@ -6962,7 +6966,7 @@ module V4_07 = struct
         fun arg_label ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -6978,7 +6982,7 @@ module V4_07 = struct
         fun variance ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -6992,7 +6996,7 @@ module V4_07 = struct
         fun constant ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -7015,7 +7019,7 @@ module V4_07 = struct
         fun attribute ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -7026,7 +7030,7 @@ module V4_07 = struct
         fun extension ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -7037,7 +7041,7 @@ module V4_07 = struct
         fun attributes ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let concrete = self#list self#attribute concrete in
@@ -7046,7 +7050,7 @@ module V4_07 = struct
         fun payload ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -7067,7 +7071,7 @@ module V4_07 = struct
         fun core_type ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -7079,7 +7083,7 @@ module V4_07 = struct
         fun core_type_desc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -7131,7 +7135,7 @@ module V4_07 = struct
         fun package_type ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -7142,7 +7146,7 @@ module V4_07 = struct
         fun row_field ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -7159,7 +7163,7 @@ module V4_07 = struct
         fun object_field ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -7175,7 +7179,7 @@ module V4_07 = struct
         fun pattern ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -7187,7 +7191,7 @@ module V4_07 = struct
         fun pattern_desc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -7256,7 +7260,7 @@ module V4_07 = struct
         fun expression ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -7268,7 +7272,7 @@ module V4_07 = struct
         fun expression_desc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -7417,7 +7421,7 @@ module V4_07 = struct
         fun case ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -7429,7 +7433,7 @@ module V4_07 = struct
         fun value_description ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -7443,7 +7447,7 @@ module V4_07 = struct
         fun type_declaration ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -7460,7 +7464,7 @@ module V4_07 = struct
         fun type_kind ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -7478,7 +7482,7 @@ module V4_07 = struct
         fun label_declaration ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -7492,7 +7496,7 @@ module V4_07 = struct
         fun constructor_declaration ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -7506,7 +7510,7 @@ module V4_07 = struct
         fun constructor_arguments ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -7520,7 +7524,7 @@ module V4_07 = struct
         fun type_extension ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -7534,7 +7538,7 @@ module V4_07 = struct
         fun extension_constructor ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -7547,7 +7551,7 @@ module V4_07 = struct
         fun extension_constructor_kind ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -7562,7 +7566,7 @@ module V4_07 = struct
         fun class_type ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -7574,7 +7578,7 @@ module V4_07 = struct
         fun class_type_desc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -7602,7 +7606,7 @@ module V4_07 = struct
         fun class_signature ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -7613,7 +7617,7 @@ module V4_07 = struct
         fun class_type_field ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -7625,7 +7629,7 @@ module V4_07 = struct
         fun class_type_field_desc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -7651,7 +7655,7 @@ module V4_07 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -7666,7 +7670,7 @@ module V4_07 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -7681,7 +7685,7 @@ module V4_07 = struct
         fun class_description ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type concrete in
@@ -7690,7 +7694,7 @@ module V4_07 = struct
         fun class_type_declaration ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type concrete in
@@ -7699,7 +7703,7 @@ module V4_07 = struct
         fun class_expr ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -7711,7 +7715,7 @@ module V4_07 = struct
         fun class_expr_desc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -7753,7 +7757,7 @@ module V4_07 = struct
         fun class_structure ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -7764,7 +7768,7 @@ module V4_07 = struct
         fun class_field ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -7776,7 +7780,7 @@ module V4_07 = struct
         fun class_field_desc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -7807,7 +7811,7 @@ module V4_07 = struct
         fun class_field_kind ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -7822,7 +7826,7 @@ module V4_07 = struct
         fun class_declaration ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_expr concrete in
@@ -7831,7 +7835,7 @@ module V4_07 = struct
         fun module_type ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -7843,7 +7847,7 @@ module V4_07 = struct
         fun module_type_desc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -7875,7 +7879,7 @@ module V4_07 = struct
         fun signature ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let concrete = self#list self#signature_item concrete in
@@ -7884,7 +7888,7 @@ module V4_07 = struct
         fun signature_item ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -7895,7 +7899,7 @@ module V4_07 = struct
         fun signature_item_desc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -7944,7 +7948,7 @@ module V4_07 = struct
         fun module_declaration ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -7957,7 +7961,7 @@ module V4_07 = struct
         fun module_type_declaration ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -7970,7 +7974,7 @@ module V4_07 = struct
         fun open_description ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -7983,7 +7987,7 @@ module V4_07 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -7995,7 +7999,7 @@ module V4_07 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -8007,7 +8011,7 @@ module V4_07 = struct
         fun include_description ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let concrete = self#include_infos_module_type concrete in
@@ -8016,7 +8020,7 @@ module V4_07 = struct
         fun include_declaration ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let concrete = self#include_infos_module_expr concrete in
@@ -8025,7 +8029,7 @@ module V4_07 = struct
         fun with_constraint ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -8049,7 +8053,7 @@ module V4_07 = struct
         fun module_expr ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -8061,7 +8065,7 @@ module V4_07 = struct
         fun module_expr_desc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -8094,7 +8098,7 @@ module V4_07 = struct
         fun structure ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let concrete = self#list self#structure_item concrete in
@@ -8103,7 +8107,7 @@ module V4_07 = struct
         fun structure_item ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -8114,7 +8118,7 @@ module V4_07 = struct
         fun structure_item_desc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -8171,7 +8175,7 @@ module V4_07 = struct
         fun value_binding ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -8184,7 +8188,7 @@ module V4_07 = struct
         fun module_binding ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -8197,7 +8201,7 @@ module V4_07 = struct
         fun toplevel_phrase ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -8212,7 +8216,7 @@ module V4_07 = struct
         fun directive_argument ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -8237,6 +8241,10 @@ end
 module V4_06 = struct
   open Versions.V4_06
 
+  let conversion_failed name =
+    let msg = Printf.sprintf "Ppx_ast: Could not convert %s to V4_06" name in
+    failwith msg
+
   class virtual map =
     object (self)
       method virtual bool : bool -> bool
@@ -8251,7 +8259,7 @@ module V4_06 = struct
         fun longident ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -8270,7 +8278,7 @@ module V4_06 = struct
         fun longident_loc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let concrete = self#loc self#longident concrete in
@@ -8279,7 +8287,7 @@ module V4_06 = struct
         fun rec_flag ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -8291,7 +8299,7 @@ module V4_06 = struct
         fun direction_flag ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -8303,7 +8311,7 @@ module V4_06 = struct
         fun private_flag ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -8315,7 +8323,7 @@ module V4_06 = struct
         fun mutable_flag ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -8327,7 +8335,7 @@ module V4_06 = struct
         fun virtual_flag ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -8339,7 +8347,7 @@ module V4_06 = struct
         fun override_flag ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -8351,7 +8359,7 @@ module V4_06 = struct
         fun closed_flag ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -8363,7 +8371,7 @@ module V4_06 = struct
         fun label ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let concrete = self#string concrete in
@@ -8372,7 +8380,7 @@ module V4_06 = struct
         fun arg_label ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -8388,7 +8396,7 @@ module V4_06 = struct
         fun variance ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -8402,7 +8410,7 @@ module V4_06 = struct
         fun constant ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -8425,7 +8433,7 @@ module V4_06 = struct
         fun attribute ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -8436,7 +8444,7 @@ module V4_06 = struct
         fun extension ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -8447,7 +8455,7 @@ module V4_06 = struct
         fun attributes ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let concrete = self#list self#attribute concrete in
@@ -8456,7 +8464,7 @@ module V4_06 = struct
         fun payload ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -8477,7 +8485,7 @@ module V4_06 = struct
         fun core_type ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -8489,7 +8497,7 @@ module V4_06 = struct
         fun core_type_desc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -8541,7 +8549,7 @@ module V4_06 = struct
         fun package_type ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -8552,7 +8560,7 @@ module V4_06 = struct
         fun row_field ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -8569,7 +8577,7 @@ module V4_06 = struct
         fun object_field ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -8585,7 +8593,7 @@ module V4_06 = struct
         fun pattern ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -8597,7 +8605,7 @@ module V4_06 = struct
         fun pattern_desc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -8666,7 +8674,7 @@ module V4_06 = struct
         fun expression ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -8678,7 +8686,7 @@ module V4_06 = struct
         fun expression_desc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -8827,7 +8835,7 @@ module V4_06 = struct
         fun case ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -8839,7 +8847,7 @@ module V4_06 = struct
         fun value_description ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -8853,7 +8861,7 @@ module V4_06 = struct
         fun type_declaration ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -8870,7 +8878,7 @@ module V4_06 = struct
         fun type_kind ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -8888,7 +8896,7 @@ module V4_06 = struct
         fun label_declaration ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -8902,7 +8910,7 @@ module V4_06 = struct
         fun constructor_declaration ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -8916,7 +8924,7 @@ module V4_06 = struct
         fun constructor_arguments ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -8930,7 +8938,7 @@ module V4_06 = struct
         fun type_extension ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -8944,7 +8952,7 @@ module V4_06 = struct
         fun extension_constructor ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -8957,7 +8965,7 @@ module V4_06 = struct
         fun extension_constructor_kind ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -8972,7 +8980,7 @@ module V4_06 = struct
         fun class_type ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -8984,7 +8992,7 @@ module V4_06 = struct
         fun class_type_desc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -9012,7 +9020,7 @@ module V4_06 = struct
         fun class_signature ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -9023,7 +9031,7 @@ module V4_06 = struct
         fun class_type_field ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -9035,7 +9043,7 @@ module V4_06 = struct
         fun class_type_field_desc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -9061,7 +9069,7 @@ module V4_06 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -9076,7 +9084,7 @@ module V4_06 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -9091,7 +9099,7 @@ module V4_06 = struct
         fun class_description ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type concrete in
@@ -9100,7 +9108,7 @@ module V4_06 = struct
         fun class_type_declaration ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type concrete in
@@ -9109,7 +9117,7 @@ module V4_06 = struct
         fun class_expr ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -9121,7 +9129,7 @@ module V4_06 = struct
         fun class_expr_desc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -9163,7 +9171,7 @@ module V4_06 = struct
         fun class_structure ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -9174,7 +9182,7 @@ module V4_06 = struct
         fun class_field ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -9186,7 +9194,7 @@ module V4_06 = struct
         fun class_field_desc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -9217,7 +9225,7 @@ module V4_06 = struct
         fun class_field_kind ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -9232,7 +9240,7 @@ module V4_06 = struct
         fun class_declaration ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_expr concrete in
@@ -9241,7 +9249,7 @@ module V4_06 = struct
         fun module_type ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -9253,7 +9261,7 @@ module V4_06 = struct
         fun module_type_desc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -9285,7 +9293,7 @@ module V4_06 = struct
         fun signature ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let concrete = self#list self#signature_item concrete in
@@ -9294,7 +9302,7 @@ module V4_06 = struct
         fun signature_item ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -9305,7 +9313,7 @@ module V4_06 = struct
         fun signature_item_desc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -9354,7 +9362,7 @@ module V4_06 = struct
         fun module_declaration ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -9367,7 +9375,7 @@ module V4_06 = struct
         fun module_type_declaration ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -9380,7 +9388,7 @@ module V4_06 = struct
         fun open_description ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -9393,7 +9401,7 @@ module V4_06 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -9405,7 +9413,7 @@ module V4_06 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -9417,7 +9425,7 @@ module V4_06 = struct
         fun include_description ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let concrete = self#include_infos_module_type concrete in
@@ -9426,7 +9434,7 @@ module V4_06 = struct
         fun include_declaration ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let concrete = self#include_infos_module_expr concrete in
@@ -9435,7 +9443,7 @@ module V4_06 = struct
         fun with_constraint ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -9459,7 +9467,7 @@ module V4_06 = struct
         fun module_expr ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -9471,7 +9479,7 @@ module V4_06 = struct
         fun module_expr_desc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -9504,7 +9512,7 @@ module V4_06 = struct
         fun structure ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let concrete = self#list self#structure_item concrete in
@@ -9513,7 +9521,7 @@ module V4_06 = struct
         fun structure_item ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -9524,7 +9532,7 @@ module V4_06 = struct
         fun structure_item_desc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -9581,7 +9589,7 @@ module V4_06 = struct
         fun value_binding ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -9594,7 +9602,7 @@ module V4_06 = struct
         fun module_binding ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -9607,7 +9615,7 @@ module V4_06 = struct
         fun toplevel_phrase ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -9622,7 +9630,7 @@ module V4_06 = struct
         fun directive_argument ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -9657,7 +9665,7 @@ module V4_06 = struct
         fun longident ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -9673,7 +9681,7 @@ module V4_06 = struct
         fun longident_loc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           self#loc self#longident concrete
@@ -9681,7 +9689,7 @@ module V4_06 = struct
         fun rec_flag ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -9693,7 +9701,7 @@ module V4_06 = struct
         fun direction_flag ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -9705,7 +9713,7 @@ module V4_06 = struct
         fun private_flag ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -9717,7 +9725,7 @@ module V4_06 = struct
         fun mutable_flag ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -9729,7 +9737,7 @@ module V4_06 = struct
         fun virtual_flag ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -9741,7 +9749,7 @@ module V4_06 = struct
         fun override_flag ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -9753,7 +9761,7 @@ module V4_06 = struct
         fun closed_flag ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -9765,7 +9773,7 @@ module V4_06 = struct
         fun label ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           self#string concrete
@@ -9773,7 +9781,7 @@ module V4_06 = struct
         fun arg_label ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -9787,7 +9795,7 @@ module V4_06 = struct
         fun variance ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -9801,7 +9809,7 @@ module V4_06 = struct
         fun constant ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -9820,7 +9828,7 @@ module V4_06 = struct
         fun attribute ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -9830,7 +9838,7 @@ module V4_06 = struct
         fun extension ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -9840,7 +9848,7 @@ module V4_06 = struct
         fun attributes ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           self#list self#attribute concrete
@@ -9848,7 +9856,7 @@ module V4_06 = struct
         fun payload ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -9865,7 +9873,7 @@ module V4_06 = struct
         fun core_type ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -9876,7 +9884,7 @@ module V4_06 = struct
         fun core_type_desc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -9917,7 +9925,7 @@ module V4_06 = struct
         fun package_type ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -9927,7 +9935,7 @@ module V4_06 = struct
         fun row_field ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -9942,7 +9950,7 @@ module V4_06 = struct
         fun object_field ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -9956,7 +9964,7 @@ module V4_06 = struct
         fun pattern ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -9967,7 +9975,7 @@ module V4_06 = struct
         fun pattern_desc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -10019,7 +10027,7 @@ module V4_06 = struct
         fun expression ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -10030,7 +10038,7 @@ module V4_06 = struct
         fun expression_desc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -10144,7 +10152,7 @@ module V4_06 = struct
         fun case ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -10155,7 +10163,7 @@ module V4_06 = struct
         fun value_description ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -10168,7 +10176,7 @@ module V4_06 = struct
         fun type_declaration ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -10184,7 +10192,7 @@ module V4_06 = struct
         fun type_kind ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -10200,7 +10208,7 @@ module V4_06 = struct
         fun label_declaration ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -10213,7 +10221,7 @@ module V4_06 = struct
         fun constructor_declaration ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -10226,7 +10234,7 @@ module V4_06 = struct
         fun constructor_arguments ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -10238,7 +10246,7 @@ module V4_06 = struct
         fun type_extension ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -10251,7 +10259,7 @@ module V4_06 = struct
         fun extension_constructor ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -10263,7 +10271,7 @@ module V4_06 = struct
         fun extension_constructor_kind ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -10276,7 +10284,7 @@ module V4_06 = struct
         fun class_type ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -10287,7 +10295,7 @@ module V4_06 = struct
         fun class_type_desc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -10310,7 +10318,7 @@ module V4_06 = struct
         fun class_signature ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -10320,7 +10328,7 @@ module V4_06 = struct
         fun class_type_field ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -10331,7 +10339,7 @@ module V4_06 = struct
         fun class_type_field_desc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -10351,7 +10359,7 @@ module V4_06 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -10365,7 +10373,7 @@ module V4_06 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -10379,7 +10387,7 @@ module V4_06 = struct
         fun class_description ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           self#class_infos_class_type concrete
@@ -10387,7 +10395,7 @@ module V4_06 = struct
         fun class_type_declaration ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           self#class_infos_class_type concrete
@@ -10395,7 +10403,7 @@ module V4_06 = struct
         fun class_expr ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -10406,7 +10414,7 @@ module V4_06 = struct
         fun class_expr_desc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -10440,7 +10448,7 @@ module V4_06 = struct
         fun class_structure ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -10450,7 +10458,7 @@ module V4_06 = struct
         fun class_field ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -10461,7 +10469,7 @@ module V4_06 = struct
         fun class_field_desc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -10485,7 +10493,7 @@ module V4_06 = struct
         fun class_field_kind ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -10498,7 +10506,7 @@ module V4_06 = struct
         fun class_declaration ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           self#class_infos_class_expr concrete
@@ -10506,7 +10514,7 @@ module V4_06 = struct
         fun module_type ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -10517,7 +10525,7 @@ module V4_06 = struct
         fun module_type_desc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -10542,7 +10550,7 @@ module V4_06 = struct
         fun signature ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           self#list self#signature_item concrete
@@ -10550,7 +10558,7 @@ module V4_06 = struct
         fun signature_item ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -10560,7 +10568,7 @@ module V4_06 = struct
         fun signature_item_desc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -10596,7 +10604,7 @@ module V4_06 = struct
         fun module_declaration ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -10608,7 +10616,7 @@ module V4_06 = struct
         fun module_type_declaration ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -10620,7 +10628,7 @@ module V4_06 = struct
         fun open_description ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -10632,7 +10640,7 @@ module V4_06 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -10643,7 +10651,7 @@ module V4_06 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -10654,7 +10662,7 @@ module V4_06 = struct
         fun include_description ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           self#include_infos_module_type concrete
@@ -10662,7 +10670,7 @@ module V4_06 = struct
         fun include_declaration ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           self#include_infos_module_expr concrete
@@ -10670,7 +10678,7 @@ module V4_06 = struct
         fun with_constraint ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -10690,7 +10698,7 @@ module V4_06 = struct
         fun module_expr ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -10701,7 +10709,7 @@ module V4_06 = struct
         fun module_expr_desc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -10727,7 +10735,7 @@ module V4_06 = struct
         fun structure ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           self#list self#structure_item concrete
@@ -10735,7 +10743,7 @@ module V4_06 = struct
         fun structure_item ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -10745,7 +10753,7 @@ module V4_06 = struct
         fun structure_item_desc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -10787,7 +10795,7 @@ module V4_06 = struct
         fun value_binding ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -10799,7 +10807,7 @@ module V4_06 = struct
         fun module_binding ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -10811,7 +10819,7 @@ module V4_06 = struct
         fun toplevel_phrase ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -10824,7 +10832,7 @@ module V4_06 = struct
         fun directive_argument ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -10855,7 +10863,7 @@ module V4_06 = struct
         fun longident acc ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -10874,7 +10882,7 @@ module V4_06 = struct
         fun longident_loc acc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let acc = self#loc self#longident concrete acc in
@@ -10883,7 +10891,7 @@ module V4_06 = struct
         fun rec_flag acc ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -10895,7 +10903,7 @@ module V4_06 = struct
         fun direction_flag acc ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -10907,7 +10915,7 @@ module V4_06 = struct
         fun private_flag acc ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -10919,7 +10927,7 @@ module V4_06 = struct
         fun mutable_flag acc ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -10931,7 +10939,7 @@ module V4_06 = struct
         fun virtual_flag acc ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -10943,7 +10951,7 @@ module V4_06 = struct
         fun override_flag acc ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -10955,7 +10963,7 @@ module V4_06 = struct
         fun closed_flag acc ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -10967,7 +10975,7 @@ module V4_06 = struct
         fun label acc ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let acc = self#string concrete acc in
@@ -10976,7 +10984,7 @@ module V4_06 = struct
         fun arg_label acc ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -10992,7 +11000,7 @@ module V4_06 = struct
         fun variance acc ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -11006,7 +11014,7 @@ module V4_06 = struct
         fun constant acc ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -11029,7 +11037,7 @@ module V4_06 = struct
         fun attribute acc ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -11040,7 +11048,7 @@ module V4_06 = struct
         fun extension acc ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -11051,7 +11059,7 @@ module V4_06 = struct
         fun attributes acc ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let acc = self#list self#attribute concrete acc in
@@ -11060,7 +11068,7 @@ module V4_06 = struct
         fun payload acc ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -11081,7 +11089,7 @@ module V4_06 = struct
         fun core_type acc ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -11093,7 +11101,7 @@ module V4_06 = struct
         fun core_type_desc acc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -11145,7 +11153,7 @@ module V4_06 = struct
         fun package_type acc ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -11156,7 +11164,7 @@ module V4_06 = struct
         fun row_field acc ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -11173,7 +11181,7 @@ module V4_06 = struct
         fun object_field acc ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -11189,7 +11197,7 @@ module V4_06 = struct
         fun pattern acc ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -11201,7 +11209,7 @@ module V4_06 = struct
         fun pattern_desc acc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -11270,7 +11278,7 @@ module V4_06 = struct
         fun expression acc ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -11282,7 +11290,7 @@ module V4_06 = struct
         fun expression_desc acc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -11431,7 +11439,7 @@ module V4_06 = struct
         fun case acc ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -11443,7 +11451,7 @@ module V4_06 = struct
         fun value_description acc ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -11457,7 +11465,7 @@ module V4_06 = struct
         fun type_declaration acc ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -11474,7 +11482,7 @@ module V4_06 = struct
         fun type_kind acc ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -11492,7 +11500,7 @@ module V4_06 = struct
         fun label_declaration acc ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -11506,7 +11514,7 @@ module V4_06 = struct
         fun constructor_declaration acc ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -11520,7 +11528,7 @@ module V4_06 = struct
         fun constructor_arguments acc ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -11534,7 +11542,7 @@ module V4_06 = struct
         fun type_extension acc ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -11548,7 +11556,7 @@ module V4_06 = struct
         fun extension_constructor acc ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -11561,7 +11569,7 @@ module V4_06 = struct
         fun extension_constructor_kind acc ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -11576,7 +11584,7 @@ module V4_06 = struct
         fun class_type acc ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -11588,7 +11596,7 @@ module V4_06 = struct
         fun class_type_desc acc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -11616,7 +11624,7 @@ module V4_06 = struct
         fun class_signature acc ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -11627,7 +11635,7 @@ module V4_06 = struct
         fun class_type_field acc ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -11639,7 +11647,7 @@ module V4_06 = struct
         fun class_type_field_desc acc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -11665,7 +11673,7 @@ module V4_06 = struct
         fun class_infos acc ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -11680,7 +11688,7 @@ module V4_06 = struct
         fun class_infos acc ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -11695,7 +11703,7 @@ module V4_06 = struct
         fun class_description acc ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let acc = self#class_infos_class_type concrete acc in
@@ -11704,7 +11712,7 @@ module V4_06 = struct
         fun class_type_declaration acc ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let acc = self#class_infos_class_type concrete acc in
@@ -11713,7 +11721,7 @@ module V4_06 = struct
         fun class_expr acc ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -11725,7 +11733,7 @@ module V4_06 = struct
         fun class_expr_desc acc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -11767,7 +11775,7 @@ module V4_06 = struct
         fun class_structure acc ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -11778,7 +11786,7 @@ module V4_06 = struct
         fun class_field acc ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -11790,7 +11798,7 @@ module V4_06 = struct
         fun class_field_desc acc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -11821,7 +11829,7 @@ module V4_06 = struct
         fun class_field_kind acc ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -11836,7 +11844,7 @@ module V4_06 = struct
         fun class_declaration acc ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let acc = self#class_infos_class_expr concrete acc in
@@ -11845,7 +11853,7 @@ module V4_06 = struct
         fun module_type acc ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -11857,7 +11865,7 @@ module V4_06 = struct
         fun module_type_desc acc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -11889,7 +11897,7 @@ module V4_06 = struct
         fun signature acc ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let acc = self#list self#signature_item concrete acc in
@@ -11898,7 +11906,7 @@ module V4_06 = struct
         fun signature_item acc ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -11909,7 +11917,7 @@ module V4_06 = struct
         fun signature_item_desc acc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -11958,7 +11966,7 @@ module V4_06 = struct
         fun module_declaration acc ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -11971,7 +11979,7 @@ module V4_06 = struct
         fun module_type_declaration acc ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -11984,7 +11992,7 @@ module V4_06 = struct
         fun open_description acc ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -11997,7 +12005,7 @@ module V4_06 = struct
         fun include_infos acc ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -12009,7 +12017,7 @@ module V4_06 = struct
         fun include_infos acc ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -12021,7 +12029,7 @@ module V4_06 = struct
         fun include_description acc ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let acc = self#include_infos_module_type concrete acc in
@@ -12030,7 +12038,7 @@ module V4_06 = struct
         fun include_declaration acc ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let acc = self#include_infos_module_expr concrete acc in
@@ -12039,7 +12047,7 @@ module V4_06 = struct
         fun with_constraint acc ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -12063,7 +12071,7 @@ module V4_06 = struct
         fun module_expr acc ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -12075,7 +12083,7 @@ module V4_06 = struct
         fun module_expr_desc acc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -12108,7 +12116,7 @@ module V4_06 = struct
         fun structure acc ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let acc = self#list self#structure_item concrete acc in
@@ -12117,7 +12125,7 @@ module V4_06 = struct
         fun structure_item acc ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -12128,7 +12136,7 @@ module V4_06 = struct
         fun structure_item_desc acc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -12185,7 +12193,7 @@ module V4_06 = struct
         fun value_binding acc ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -12198,7 +12206,7 @@ module V4_06 = struct
         fun module_binding acc ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -12211,7 +12219,7 @@ module V4_06 = struct
         fun toplevel_phrase acc ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -12226,7 +12234,7 @@ module V4_06 = struct
         fun directive_argument acc ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -12261,7 +12269,7 @@ module V4_06 = struct
         fun longident acc ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -12280,7 +12288,7 @@ module V4_06 = struct
         fun longident_loc acc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let (concrete, acc) = self#loc self#longident concrete acc in
@@ -12289,7 +12297,7 @@ module V4_06 = struct
         fun rec_flag acc ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -12301,7 +12309,7 @@ module V4_06 = struct
         fun direction_flag acc ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -12313,7 +12321,7 @@ module V4_06 = struct
         fun private_flag acc ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -12325,7 +12333,7 @@ module V4_06 = struct
         fun mutable_flag acc ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -12337,7 +12345,7 @@ module V4_06 = struct
         fun virtual_flag acc ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -12349,7 +12357,7 @@ module V4_06 = struct
         fun override_flag acc ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -12361,7 +12369,7 @@ module V4_06 = struct
         fun closed_flag acc ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -12373,7 +12381,7 @@ module V4_06 = struct
         fun label acc ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let (concrete, acc) = self#string concrete acc in
@@ -12382,7 +12390,7 @@ module V4_06 = struct
         fun arg_label acc ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -12398,7 +12406,7 @@ module V4_06 = struct
         fun variance acc ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -12412,7 +12420,7 @@ module V4_06 = struct
         fun constant acc ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -12435,7 +12443,7 @@ module V4_06 = struct
         fun attribute acc ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -12446,7 +12454,7 @@ module V4_06 = struct
         fun extension acc ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -12457,7 +12465,7 @@ module V4_06 = struct
         fun attributes acc ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let (concrete, acc) = self#list self#attribute concrete acc in
@@ -12466,7 +12474,7 @@ module V4_06 = struct
         fun payload acc ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -12487,7 +12495,7 @@ module V4_06 = struct
         fun core_type acc ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -12499,7 +12507,7 @@ module V4_06 = struct
         fun core_type_desc acc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -12551,7 +12559,7 @@ module V4_06 = struct
         fun package_type acc ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -12562,7 +12570,7 @@ module V4_06 = struct
         fun row_field acc ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -12579,7 +12587,7 @@ module V4_06 = struct
         fun object_field acc ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -12595,7 +12603,7 @@ module V4_06 = struct
         fun pattern acc ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -12607,7 +12615,7 @@ module V4_06 = struct
         fun pattern_desc acc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -12676,7 +12684,7 @@ module V4_06 = struct
         fun expression acc ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -12688,7 +12696,7 @@ module V4_06 = struct
         fun expression_desc acc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -12837,7 +12845,7 @@ module V4_06 = struct
         fun case acc ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -12849,7 +12857,7 @@ module V4_06 = struct
         fun value_description acc ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -12863,7 +12871,7 @@ module V4_06 = struct
         fun type_declaration acc ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -12880,7 +12888,7 @@ module V4_06 = struct
         fun type_kind acc ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -12898,7 +12906,7 @@ module V4_06 = struct
         fun label_declaration acc ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -12912,7 +12920,7 @@ module V4_06 = struct
         fun constructor_declaration acc ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -12926,7 +12934,7 @@ module V4_06 = struct
         fun constructor_arguments acc ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -12940,7 +12948,7 @@ module V4_06 = struct
         fun type_extension acc ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -12954,7 +12962,7 @@ module V4_06 = struct
         fun extension_constructor acc ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -12967,7 +12975,7 @@ module V4_06 = struct
         fun extension_constructor_kind acc ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -12982,7 +12990,7 @@ module V4_06 = struct
         fun class_type acc ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -12994,7 +13002,7 @@ module V4_06 = struct
         fun class_type_desc acc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -13022,7 +13030,7 @@ module V4_06 = struct
         fun class_signature acc ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -13033,7 +13041,7 @@ module V4_06 = struct
         fun class_type_field acc ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -13045,7 +13053,7 @@ module V4_06 = struct
         fun class_type_field_desc acc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -13071,7 +13079,7 @@ module V4_06 = struct
         fun class_infos acc ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -13086,7 +13094,7 @@ module V4_06 = struct
         fun class_infos acc ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -13101,7 +13109,7 @@ module V4_06 = struct
         fun class_description acc ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let (concrete, acc) = self#class_infos_class_type concrete acc in
@@ -13110,7 +13118,7 @@ module V4_06 = struct
         fun class_type_declaration acc ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let (concrete, acc) = self#class_infos_class_type concrete acc in
@@ -13119,7 +13127,7 @@ module V4_06 = struct
         fun class_expr acc ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -13131,7 +13139,7 @@ module V4_06 = struct
         fun class_expr_desc acc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -13173,7 +13181,7 @@ module V4_06 = struct
         fun class_structure acc ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -13184,7 +13192,7 @@ module V4_06 = struct
         fun class_field acc ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -13196,7 +13204,7 @@ module V4_06 = struct
         fun class_field_desc acc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -13227,7 +13235,7 @@ module V4_06 = struct
         fun class_field_kind acc ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -13242,7 +13250,7 @@ module V4_06 = struct
         fun class_declaration acc ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let (concrete, acc) = self#class_infos_class_expr concrete acc in
@@ -13251,7 +13259,7 @@ module V4_06 = struct
         fun module_type acc ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -13263,7 +13271,7 @@ module V4_06 = struct
         fun module_type_desc acc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -13295,7 +13303,7 @@ module V4_06 = struct
         fun signature acc ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let (concrete, acc) = self#list self#signature_item concrete acc in
@@ -13304,7 +13312,7 @@ module V4_06 = struct
         fun signature_item acc ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -13315,7 +13323,7 @@ module V4_06 = struct
         fun signature_item_desc acc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -13364,7 +13372,7 @@ module V4_06 = struct
         fun module_declaration acc ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -13377,7 +13385,7 @@ module V4_06 = struct
         fun module_type_declaration acc ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -13390,7 +13398,7 @@ module V4_06 = struct
         fun open_description acc ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -13403,7 +13411,7 @@ module V4_06 = struct
         fun include_infos acc ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -13415,7 +13423,7 @@ module V4_06 = struct
         fun include_infos acc ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -13427,7 +13435,7 @@ module V4_06 = struct
         fun include_description acc ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let (concrete, acc) = self#include_infos_module_type concrete acc in
@@ -13436,7 +13444,7 @@ module V4_06 = struct
         fun include_declaration acc ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let (concrete, acc) = self#include_infos_module_expr concrete acc in
@@ -13445,7 +13453,7 @@ module V4_06 = struct
         fun with_constraint acc ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -13469,7 +13477,7 @@ module V4_06 = struct
         fun module_expr acc ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -13481,7 +13489,7 @@ module V4_06 = struct
         fun module_expr_desc acc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -13514,7 +13522,7 @@ module V4_06 = struct
         fun structure acc ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let (concrete, acc) = self#list self#structure_item concrete acc in
@@ -13523,7 +13531,7 @@ module V4_06 = struct
         fun structure_item acc ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -13534,7 +13542,7 @@ module V4_06 = struct
         fun structure_item_desc acc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -13591,7 +13599,7 @@ module V4_06 = struct
         fun value_binding acc ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -13604,7 +13612,7 @@ module V4_06 = struct
         fun module_binding acc ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -13617,7 +13625,7 @@ module V4_06 = struct
         fun toplevel_phrase acc ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -13632,7 +13640,7 @@ module V4_06 = struct
         fun directive_argument acc ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -13667,7 +13675,7 @@ module V4_06 = struct
         fun _ctx longident ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -13686,7 +13694,7 @@ module V4_06 = struct
         fun _ctx longident_loc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let concrete = self#loc self#longident _ctx concrete in
@@ -13695,7 +13703,7 @@ module V4_06 = struct
         fun _ctx rec_flag ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -13707,7 +13715,7 @@ module V4_06 = struct
         fun _ctx direction_flag ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -13719,7 +13727,7 @@ module V4_06 = struct
         fun _ctx private_flag ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -13731,7 +13739,7 @@ module V4_06 = struct
         fun _ctx mutable_flag ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -13743,7 +13751,7 @@ module V4_06 = struct
         fun _ctx virtual_flag ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -13755,7 +13763,7 @@ module V4_06 = struct
         fun _ctx override_flag ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -13767,7 +13775,7 @@ module V4_06 = struct
         fun _ctx closed_flag ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -13779,7 +13787,7 @@ module V4_06 = struct
         fun _ctx label ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let concrete = self#string _ctx concrete in
@@ -13788,7 +13796,7 @@ module V4_06 = struct
         fun _ctx arg_label ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -13804,7 +13812,7 @@ module V4_06 = struct
         fun _ctx variance ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -13818,7 +13826,7 @@ module V4_06 = struct
         fun _ctx constant ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -13841,7 +13849,7 @@ module V4_06 = struct
         fun _ctx attribute ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -13852,7 +13860,7 @@ module V4_06 = struct
         fun _ctx extension ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -13863,7 +13871,7 @@ module V4_06 = struct
         fun _ctx attributes ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let concrete = self#list self#attribute _ctx concrete in
@@ -13872,7 +13880,7 @@ module V4_06 = struct
         fun _ctx payload ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -13893,7 +13901,7 @@ module V4_06 = struct
         fun _ctx core_type ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -13905,7 +13913,7 @@ module V4_06 = struct
         fun _ctx core_type_desc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -13957,7 +13965,7 @@ module V4_06 = struct
         fun _ctx package_type ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -13968,7 +13976,7 @@ module V4_06 = struct
         fun _ctx row_field ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -13985,7 +13993,7 @@ module V4_06 = struct
         fun _ctx object_field ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -14001,7 +14009,7 @@ module V4_06 = struct
         fun _ctx pattern ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -14013,7 +14021,7 @@ module V4_06 = struct
         fun _ctx pattern_desc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -14082,7 +14090,7 @@ module V4_06 = struct
         fun _ctx expression ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -14094,7 +14102,7 @@ module V4_06 = struct
         fun _ctx expression_desc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -14243,7 +14251,7 @@ module V4_06 = struct
         fun _ctx case ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -14255,7 +14263,7 @@ module V4_06 = struct
         fun _ctx value_description ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -14269,7 +14277,7 @@ module V4_06 = struct
         fun _ctx type_declaration ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -14286,7 +14294,7 @@ module V4_06 = struct
         fun _ctx type_kind ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -14304,7 +14312,7 @@ module V4_06 = struct
         fun _ctx label_declaration ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -14318,7 +14326,7 @@ module V4_06 = struct
         fun _ctx constructor_declaration ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -14332,7 +14340,7 @@ module V4_06 = struct
         fun _ctx constructor_arguments ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -14346,7 +14354,7 @@ module V4_06 = struct
         fun _ctx type_extension ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -14360,7 +14368,7 @@ module V4_06 = struct
         fun _ctx extension_constructor ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -14373,7 +14381,7 @@ module V4_06 = struct
         fun _ctx extension_constructor_kind ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -14388,7 +14396,7 @@ module V4_06 = struct
         fun _ctx class_type ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -14400,7 +14408,7 @@ module V4_06 = struct
         fun _ctx class_type_desc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -14428,7 +14436,7 @@ module V4_06 = struct
         fun _ctx class_signature ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -14439,7 +14447,7 @@ module V4_06 = struct
         fun _ctx class_type_field ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -14451,7 +14459,7 @@ module V4_06 = struct
         fun _ctx class_type_field_desc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -14477,7 +14485,7 @@ module V4_06 = struct
         fun _ctx class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -14492,7 +14500,7 @@ module V4_06 = struct
         fun _ctx class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -14507,7 +14515,7 @@ module V4_06 = struct
         fun _ctx class_description ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type _ctx concrete in
@@ -14516,7 +14524,7 @@ module V4_06 = struct
         fun _ctx class_type_declaration ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type _ctx concrete in
@@ -14525,7 +14533,7 @@ module V4_06 = struct
         fun _ctx class_expr ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -14537,7 +14545,7 @@ module V4_06 = struct
         fun _ctx class_expr_desc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -14579,7 +14587,7 @@ module V4_06 = struct
         fun _ctx class_structure ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -14590,7 +14598,7 @@ module V4_06 = struct
         fun _ctx class_field ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -14602,7 +14610,7 @@ module V4_06 = struct
         fun _ctx class_field_desc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -14633,7 +14641,7 @@ module V4_06 = struct
         fun _ctx class_field_kind ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -14648,7 +14656,7 @@ module V4_06 = struct
         fun _ctx class_declaration ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_expr _ctx concrete in
@@ -14657,7 +14665,7 @@ module V4_06 = struct
         fun _ctx module_type ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -14669,7 +14677,7 @@ module V4_06 = struct
         fun _ctx module_type_desc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -14701,7 +14709,7 @@ module V4_06 = struct
         fun _ctx signature ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let concrete = self#list self#signature_item _ctx concrete in
@@ -14710,7 +14718,7 @@ module V4_06 = struct
         fun _ctx signature_item ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -14721,7 +14729,7 @@ module V4_06 = struct
         fun _ctx signature_item_desc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -14770,7 +14778,7 @@ module V4_06 = struct
         fun _ctx module_declaration ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -14783,7 +14791,7 @@ module V4_06 = struct
         fun _ctx module_type_declaration ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -14796,7 +14804,7 @@ module V4_06 = struct
         fun _ctx open_description ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -14809,7 +14817,7 @@ module V4_06 = struct
         fun _ctx include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -14821,7 +14829,7 @@ module V4_06 = struct
         fun _ctx include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -14833,7 +14841,7 @@ module V4_06 = struct
         fun _ctx include_description ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let concrete = self#include_infos_module_type _ctx concrete in
@@ -14842,7 +14850,7 @@ module V4_06 = struct
         fun _ctx include_declaration ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let concrete = self#include_infos_module_expr _ctx concrete in
@@ -14851,7 +14859,7 @@ module V4_06 = struct
         fun _ctx with_constraint ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -14875,7 +14883,7 @@ module V4_06 = struct
         fun _ctx module_expr ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -14887,7 +14895,7 @@ module V4_06 = struct
         fun _ctx module_expr_desc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -14920,7 +14928,7 @@ module V4_06 = struct
         fun _ctx structure ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let concrete = self#list self#structure_item _ctx concrete in
@@ -14929,7 +14937,7 @@ module V4_06 = struct
         fun _ctx structure_item ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -14940,7 +14948,7 @@ module V4_06 = struct
         fun _ctx structure_item_desc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -14997,7 +15005,7 @@ module V4_06 = struct
         fun _ctx value_binding ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -15010,7 +15018,7 @@ module V4_06 = struct
         fun _ctx module_binding ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -15023,7 +15031,7 @@ module V4_06 = struct
         fun _ctx toplevel_phrase ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -15038,7 +15046,7 @@ module V4_06 = struct
         fun _ctx directive_argument ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with
@@ -15076,7 +15084,7 @@ module V4_06 = struct
         fun longident ->
           let concrete =
             match Longident.to_concrete longident with
-            | None -> failwith "longident"
+            | None -> conversion_failed "longident"
             | Some n -> n
           in
           match (concrete : Longident.concrete) with
@@ -15095,7 +15103,7 @@ module V4_06 = struct
         fun longident_loc ->
           let concrete =
             match Longident_loc.to_concrete longident_loc with
-            | None -> failwith "longident_loc"
+            | None -> conversion_failed "longident_loc"
             | Some n -> n
           in
           let concrete = self#loc self#longident concrete in
@@ -15104,7 +15112,7 @@ module V4_06 = struct
         fun rec_flag ->
           let concrete =
             match Rec_flag.to_concrete rec_flag with
-            | None -> failwith "rec_flag"
+            | None -> conversion_failed "rec_flag"
             | Some n -> n
           in
           match (concrete : Rec_flag.concrete) with
@@ -15116,7 +15124,7 @@ module V4_06 = struct
         fun direction_flag ->
           let concrete =
             match Direction_flag.to_concrete direction_flag with
-            | None -> failwith "direction_flag"
+            | None -> conversion_failed "direction_flag"
             | Some n -> n
           in
           match (concrete : Direction_flag.concrete) with
@@ -15128,7 +15136,7 @@ module V4_06 = struct
         fun private_flag ->
           let concrete =
             match Private_flag.to_concrete private_flag with
-            | None -> failwith "private_flag"
+            | None -> conversion_failed "private_flag"
             | Some n -> n
           in
           match (concrete : Private_flag.concrete) with
@@ -15140,7 +15148,7 @@ module V4_06 = struct
         fun mutable_flag ->
           let concrete =
             match Mutable_flag.to_concrete mutable_flag with
-            | None -> failwith "mutable_flag"
+            | None -> conversion_failed "mutable_flag"
             | Some n -> n
           in
           match (concrete : Mutable_flag.concrete) with
@@ -15152,7 +15160,7 @@ module V4_06 = struct
         fun virtual_flag ->
           let concrete =
             match Virtual_flag.to_concrete virtual_flag with
-            | None -> failwith "virtual_flag"
+            | None -> conversion_failed "virtual_flag"
             | Some n -> n
           in
           match (concrete : Virtual_flag.concrete) with
@@ -15164,7 +15172,7 @@ module V4_06 = struct
         fun override_flag ->
           let concrete =
             match Override_flag.to_concrete override_flag with
-            | None -> failwith "override_flag"
+            | None -> conversion_failed "override_flag"
             | Some n -> n
           in
           match (concrete : Override_flag.concrete) with
@@ -15176,7 +15184,7 @@ module V4_06 = struct
         fun closed_flag ->
           let concrete =
             match Closed_flag.to_concrete closed_flag with
-            | None -> failwith "closed_flag"
+            | None -> conversion_failed "closed_flag"
             | Some n -> n
           in
           match (concrete : Closed_flag.concrete) with
@@ -15188,7 +15196,7 @@ module V4_06 = struct
         fun label ->
           let concrete =
             match Label.to_concrete label with
-            | None -> failwith "label"
+            | None -> conversion_failed "label"
             | Some n -> n
           in
           let concrete = self#string concrete in
@@ -15197,7 +15205,7 @@ module V4_06 = struct
         fun arg_label ->
           let concrete =
             match Arg_label.to_concrete arg_label with
-            | None -> failwith "arg_label"
+            | None -> conversion_failed "arg_label"
             | Some n -> n
           in
           match (concrete : Arg_label.concrete) with
@@ -15213,7 +15221,7 @@ module V4_06 = struct
         fun variance ->
           let concrete =
             match Variance.to_concrete variance with
-            | None -> failwith "variance"
+            | None -> conversion_failed "variance"
             | Some n -> n
           in
           match (concrete : Variance.concrete) with
@@ -15227,7 +15235,7 @@ module V4_06 = struct
         fun constant ->
           let concrete =
             match Constant.to_concrete constant with
-            | None -> failwith "constant"
+            | None -> conversion_failed "constant"
             | Some n -> n
           in
           match (concrete : Constant.concrete) with
@@ -15250,7 +15258,7 @@ module V4_06 = struct
         fun attribute ->
           let concrete =
             match Attribute.to_concrete attribute with
-            | None -> failwith "attribute"
+            | None -> conversion_failed "attribute"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -15261,7 +15269,7 @@ module V4_06 = struct
         fun extension ->
           let concrete =
             match Extension.to_concrete extension with
-            | None -> failwith "extension"
+            | None -> conversion_failed "extension"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -15272,7 +15280,7 @@ module V4_06 = struct
         fun attributes ->
           let concrete =
             match Attributes.to_concrete attributes with
-            | None -> failwith "attributes"
+            | None -> conversion_failed "attributes"
             | Some n -> n
           in
           let concrete = self#list self#attribute concrete in
@@ -15281,7 +15289,7 @@ module V4_06 = struct
         fun payload ->
           let concrete =
             match Payload.to_concrete payload with
-            | None -> failwith "payload"
+            | None -> conversion_failed "payload"
             | Some n -> n
           in
           match (concrete : Payload.concrete) with
@@ -15302,7 +15310,7 @@ module V4_06 = struct
         fun core_type ->
           let concrete =
             match Core_type.to_concrete core_type with
-            | None -> failwith "core_type"
+            | None -> conversion_failed "core_type"
             | Some n -> n
           in
           let { ptyp_desc; ptyp_loc; ptyp_attributes } : Core_type.concrete = concrete in
@@ -15314,7 +15322,7 @@ module V4_06 = struct
         fun core_type_desc ->
           let concrete =
             match Core_type_desc.to_concrete core_type_desc with
-            | None -> failwith "core_type_desc"
+            | None -> conversion_failed "core_type_desc"
             | Some n -> n
           in
           match (concrete : Core_type_desc.concrete) with
@@ -15366,7 +15374,7 @@ module V4_06 = struct
         fun package_type ->
           let concrete =
             match Package_type.to_concrete package_type with
-            | None -> failwith "package_type"
+            | None -> conversion_failed "package_type"
             | Some n -> n
           in
           let (x0, x1) = concrete in
@@ -15377,7 +15385,7 @@ module V4_06 = struct
         fun row_field ->
           let concrete =
             match Row_field.to_concrete row_field with
-            | None -> failwith "row_field"
+            | None -> conversion_failed "row_field"
             | Some n -> n
           in
           match (concrete : Row_field.concrete) with
@@ -15394,7 +15402,7 @@ module V4_06 = struct
         fun object_field ->
           let concrete =
             match Object_field.to_concrete object_field with
-            | None -> failwith "object_field"
+            | None -> conversion_failed "object_field"
             | Some n -> n
           in
           match (concrete : Object_field.concrete) with
@@ -15410,7 +15418,7 @@ module V4_06 = struct
         fun pattern ->
           let concrete =
             match Pattern.to_concrete pattern with
-            | None -> failwith "pattern"
+            | None -> conversion_failed "pattern"
             | Some n -> n
           in
           let { ppat_desc; ppat_loc; ppat_attributes } : Pattern.concrete = concrete in
@@ -15422,7 +15430,7 @@ module V4_06 = struct
         fun pattern_desc ->
           let concrete =
             match Pattern_desc.to_concrete pattern_desc with
-            | None -> failwith "pattern_desc"
+            | None -> conversion_failed "pattern_desc"
             | Some n -> n
           in
           match (concrete : Pattern_desc.concrete) with
@@ -15491,7 +15499,7 @@ module V4_06 = struct
         fun expression ->
           let concrete =
             match Expression.to_concrete expression with
-            | None -> failwith "expression"
+            | None -> conversion_failed "expression"
             | Some n -> n
           in
           let { pexp_desc; pexp_loc; pexp_attributes } : Expression.concrete = concrete in
@@ -15503,7 +15511,7 @@ module V4_06 = struct
         fun expression_desc ->
           let concrete =
             match Expression_desc.to_concrete expression_desc with
-            | None -> failwith "expression_desc"
+            | None -> conversion_failed "expression_desc"
             | Some n -> n
           in
           match (concrete : Expression_desc.concrete) with
@@ -15652,7 +15660,7 @@ module V4_06 = struct
         fun case ->
           let concrete =
             match Case.to_concrete case with
-            | None -> failwith "case"
+            | None -> conversion_failed "case"
             | Some n -> n
           in
           let { pc_lhs; pc_guard; pc_rhs } : Case.concrete = concrete in
@@ -15664,7 +15672,7 @@ module V4_06 = struct
         fun value_description ->
           let concrete =
             match Value_description.to_concrete value_description with
-            | None -> failwith "value_description"
+            | None -> conversion_failed "value_description"
             | Some n -> n
           in
           let { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Value_description.concrete = concrete in
@@ -15678,7 +15686,7 @@ module V4_06 = struct
         fun type_declaration ->
           let concrete =
             match Type_declaration.to_concrete type_declaration with
-            | None -> failwith "type_declaration"
+            | None -> conversion_failed "type_declaration"
             | Some n -> n
           in
           let { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Type_declaration.concrete = concrete in
@@ -15695,7 +15703,7 @@ module V4_06 = struct
         fun type_kind ->
           let concrete =
             match Type_kind.to_concrete type_kind with
-            | None -> failwith "type_kind"
+            | None -> conversion_failed "type_kind"
             | Some n -> n
           in
           match (concrete : Type_kind.concrete) with
@@ -15713,7 +15721,7 @@ module V4_06 = struct
         fun label_declaration ->
           let concrete =
             match Label_declaration.to_concrete label_declaration with
-            | None -> failwith "label_declaration"
+            | None -> conversion_failed "label_declaration"
             | Some n -> n
           in
           let { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Label_declaration.concrete = concrete in
@@ -15727,7 +15735,7 @@ module V4_06 = struct
         fun constructor_declaration ->
           let concrete =
             match Constructor_declaration.to_concrete constructor_declaration with
-            | None -> failwith "constructor_declaration"
+            | None -> conversion_failed "constructor_declaration"
             | Some n -> n
           in
           let { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Constructor_declaration.concrete = concrete in
@@ -15741,7 +15749,7 @@ module V4_06 = struct
         fun constructor_arguments ->
           let concrete =
             match Constructor_arguments.to_concrete constructor_arguments with
-            | None -> failwith "constructor_arguments"
+            | None -> conversion_failed "constructor_arguments"
             | Some n -> n
           in
           match (concrete : Constructor_arguments.concrete) with
@@ -15755,7 +15763,7 @@ module V4_06 = struct
         fun type_extension ->
           let concrete =
             match Type_extension.to_concrete type_extension with
-            | None -> failwith "type_extension"
+            | None -> conversion_failed "type_extension"
             | Some n -> n
           in
           let { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Type_extension.concrete = concrete in
@@ -15769,7 +15777,7 @@ module V4_06 = struct
         fun extension_constructor ->
           let concrete =
             match Extension_constructor.to_concrete extension_constructor with
-            | None -> failwith "extension_constructor"
+            | None -> conversion_failed "extension_constructor"
             | Some n -> n
           in
           let { pext_name; pext_kind; pext_loc; pext_attributes } : Extension_constructor.concrete = concrete in
@@ -15782,7 +15790,7 @@ module V4_06 = struct
         fun extension_constructor_kind ->
           let concrete =
             match Extension_constructor_kind.to_concrete extension_constructor_kind with
-            | None -> failwith "extension_constructor_kind"
+            | None -> conversion_failed "extension_constructor_kind"
             | Some n -> n
           in
           match (concrete : Extension_constructor_kind.concrete) with
@@ -15797,7 +15805,7 @@ module V4_06 = struct
         fun class_type ->
           let concrete =
             match Class_type.to_concrete class_type with
-            | None -> failwith "class_type"
+            | None -> conversion_failed "class_type"
             | Some n -> n
           in
           let { pcty_desc; pcty_loc; pcty_attributes } : Class_type.concrete = concrete in
@@ -15809,7 +15817,7 @@ module V4_06 = struct
         fun class_type_desc ->
           let concrete =
             match Class_type_desc.to_concrete class_type_desc with
-            | None -> failwith "class_type_desc"
+            | None -> conversion_failed "class_type_desc"
             | Some n -> n
           in
           match (concrete : Class_type_desc.concrete) with
@@ -15837,7 +15845,7 @@ module V4_06 = struct
         fun class_signature ->
           let concrete =
             match Class_signature.to_concrete class_signature with
-            | None -> failwith "class_signature"
+            | None -> conversion_failed "class_signature"
             | Some n -> n
           in
           let { pcsig_self; pcsig_fields } : Class_signature.concrete = concrete in
@@ -15848,7 +15856,7 @@ module V4_06 = struct
         fun class_type_field ->
           let concrete =
             match Class_type_field.to_concrete class_type_field with
-            | None -> failwith "class_type_field"
+            | None -> conversion_failed "class_type_field"
             | Some n -> n
           in
           let { pctf_desc; pctf_loc; pctf_attributes } : Class_type_field.concrete = concrete in
@@ -15860,7 +15868,7 @@ module V4_06 = struct
         fun class_type_field_desc ->
           let concrete =
             match Class_type_field_desc.to_concrete class_type_field_desc with
-            | None -> failwith "class_type_field_desc"
+            | None -> conversion_failed "class_type_field_desc"
             | Some n -> n
           in
           match (concrete : Class_type_field_desc.concrete) with
@@ -15886,7 +15894,7 @@ module V4_06 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_expr class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
@@ -15901,7 +15909,7 @@ module V4_06 = struct
         fun class_infos ->
           let concrete =
             match Class_infos.to_concrete_class_type class_infos with
-            | None -> failwith "class_infos"
+            | None -> conversion_failed "class_infos"
             | Some n -> n
           in
           let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
@@ -15916,7 +15924,7 @@ module V4_06 = struct
         fun class_description ->
           let concrete =
             match Class_description.to_concrete class_description with
-            | None -> failwith "class_description"
+            | None -> conversion_failed "class_description"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type concrete in
@@ -15925,7 +15933,7 @@ module V4_06 = struct
         fun class_type_declaration ->
           let concrete =
             match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> failwith "class_type_declaration"
+            | None -> conversion_failed "class_type_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_type concrete in
@@ -15934,7 +15942,7 @@ module V4_06 = struct
         fun class_expr ->
           let concrete =
             match Class_expr.to_concrete class_expr with
-            | None -> failwith "class_expr"
+            | None -> conversion_failed "class_expr"
             | Some n -> n
           in
           let { pcl_desc; pcl_loc; pcl_attributes } : Class_expr.concrete = concrete in
@@ -15946,7 +15954,7 @@ module V4_06 = struct
         fun class_expr_desc ->
           let concrete =
             match Class_expr_desc.to_concrete class_expr_desc with
-            | None -> failwith "class_expr_desc"
+            | None -> conversion_failed "class_expr_desc"
             | Some n -> n
           in
           match (concrete : Class_expr_desc.concrete) with
@@ -15988,7 +15996,7 @@ module V4_06 = struct
         fun class_structure ->
           let concrete =
             match Class_structure.to_concrete class_structure with
-            | None -> failwith "class_structure"
+            | None -> conversion_failed "class_structure"
             | Some n -> n
           in
           let { pcstr_self; pcstr_fields } : Class_structure.concrete = concrete in
@@ -15999,7 +16007,7 @@ module V4_06 = struct
         fun class_field ->
           let concrete =
             match Class_field.to_concrete class_field with
-            | None -> failwith "class_field"
+            | None -> conversion_failed "class_field"
             | Some n -> n
           in
           let { pcf_desc; pcf_loc; pcf_attributes } : Class_field.concrete = concrete in
@@ -16011,7 +16019,7 @@ module V4_06 = struct
         fun class_field_desc ->
           let concrete =
             match Class_field_desc.to_concrete class_field_desc with
-            | None -> failwith "class_field_desc"
+            | None -> conversion_failed "class_field_desc"
             | Some n -> n
           in
           match (concrete : Class_field_desc.concrete) with
@@ -16042,7 +16050,7 @@ module V4_06 = struct
         fun class_field_kind ->
           let concrete =
             match Class_field_kind.to_concrete class_field_kind with
-            | None -> failwith "class_field_kind"
+            | None -> conversion_failed "class_field_kind"
             | Some n -> n
           in
           match (concrete : Class_field_kind.concrete) with
@@ -16057,7 +16065,7 @@ module V4_06 = struct
         fun class_declaration ->
           let concrete =
             match Class_declaration.to_concrete class_declaration with
-            | None -> failwith "class_declaration"
+            | None -> conversion_failed "class_declaration"
             | Some n -> n
           in
           let concrete = self#class_infos_class_expr concrete in
@@ -16066,7 +16074,7 @@ module V4_06 = struct
         fun module_type ->
           let concrete =
             match Module_type.to_concrete module_type with
-            | None -> failwith "module_type"
+            | None -> conversion_failed "module_type"
             | Some n -> n
           in
           let { pmty_desc; pmty_loc; pmty_attributes } : Module_type.concrete = concrete in
@@ -16078,7 +16086,7 @@ module V4_06 = struct
         fun module_type_desc ->
           let concrete =
             match Module_type_desc.to_concrete module_type_desc with
-            | None -> failwith "module_type_desc"
+            | None -> conversion_failed "module_type_desc"
             | Some n -> n
           in
           match (concrete : Module_type_desc.concrete) with
@@ -16110,7 +16118,7 @@ module V4_06 = struct
         fun signature ->
           let concrete =
             match Signature.to_concrete signature with
-            | None -> failwith "signature"
+            | None -> conversion_failed "signature"
             | Some n -> n
           in
           let concrete = self#list self#signature_item concrete in
@@ -16119,7 +16127,7 @@ module V4_06 = struct
         fun signature_item ->
           let concrete =
             match Signature_item.to_concrete signature_item with
-            | None -> failwith "signature_item"
+            | None -> conversion_failed "signature_item"
             | Some n -> n
           in
           let { psig_desc; psig_loc } : Signature_item.concrete = concrete in
@@ -16130,7 +16138,7 @@ module V4_06 = struct
         fun signature_item_desc ->
           let concrete =
             match Signature_item_desc.to_concrete signature_item_desc with
-            | None -> failwith "signature_item_desc"
+            | None -> conversion_failed "signature_item_desc"
             | Some n -> n
           in
           match (concrete : Signature_item_desc.concrete) with
@@ -16179,7 +16187,7 @@ module V4_06 = struct
         fun module_declaration ->
           let concrete =
             match Module_declaration.to_concrete module_declaration with
-            | None -> failwith "module_declaration"
+            | None -> conversion_failed "module_declaration"
             | Some n -> n
           in
           let { pmd_name; pmd_type; pmd_attributes; pmd_loc } : Module_declaration.concrete = concrete in
@@ -16192,7 +16200,7 @@ module V4_06 = struct
         fun module_type_declaration ->
           let concrete =
             match Module_type_declaration.to_concrete module_type_declaration with
-            | None -> failwith "module_type_declaration"
+            | None -> conversion_failed "module_type_declaration"
             | Some n -> n
           in
           let { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Module_type_declaration.concrete = concrete in
@@ -16205,7 +16213,7 @@ module V4_06 = struct
         fun open_description ->
           let concrete =
             match Open_description.to_concrete open_description with
-            | None -> failwith "open_description"
+            | None -> conversion_failed "open_description"
             | Some n -> n
           in
           let { popen_lid; popen_override; popen_loc; popen_attributes } : Open_description.concrete = concrete in
@@ -16218,7 +16226,7 @@ module V4_06 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_expr include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
@@ -16230,7 +16238,7 @@ module V4_06 = struct
         fun include_infos ->
           let concrete =
             match Include_infos.to_concrete_module_type include_infos with
-            | None -> failwith "include_infos"
+            | None -> conversion_failed "include_infos"
             | Some n -> n
           in
           let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
@@ -16242,7 +16250,7 @@ module V4_06 = struct
         fun include_description ->
           let concrete =
             match Include_description.to_concrete include_description with
-            | None -> failwith "include_description"
+            | None -> conversion_failed "include_description"
             | Some n -> n
           in
           let concrete = self#include_infos_module_type concrete in
@@ -16251,7 +16259,7 @@ module V4_06 = struct
         fun include_declaration ->
           let concrete =
             match Include_declaration.to_concrete include_declaration with
-            | None -> failwith "include_declaration"
+            | None -> conversion_failed "include_declaration"
             | Some n -> n
           in
           let concrete = self#include_infos_module_expr concrete in
@@ -16260,7 +16268,7 @@ module V4_06 = struct
         fun with_constraint ->
           let concrete =
             match With_constraint.to_concrete with_constraint with
-            | None -> failwith "with_constraint"
+            | None -> conversion_failed "with_constraint"
             | Some n -> n
           in
           match (concrete : With_constraint.concrete) with
@@ -16284,7 +16292,7 @@ module V4_06 = struct
         fun module_expr ->
           let concrete =
             match Module_expr.to_concrete module_expr with
-            | None -> failwith "module_expr"
+            | None -> conversion_failed "module_expr"
             | Some n -> n
           in
           let { pmod_desc; pmod_loc; pmod_attributes } : Module_expr.concrete = concrete in
@@ -16296,7 +16304,7 @@ module V4_06 = struct
         fun module_expr_desc ->
           let concrete =
             match Module_expr_desc.to_concrete module_expr_desc with
-            | None -> failwith "module_expr_desc"
+            | None -> conversion_failed "module_expr_desc"
             | Some n -> n
           in
           match (concrete : Module_expr_desc.concrete) with
@@ -16329,7 +16337,7 @@ module V4_06 = struct
         fun structure ->
           let concrete =
             match Structure.to_concrete structure with
-            | None -> failwith "structure"
+            | None -> conversion_failed "structure"
             | Some n -> n
           in
           let concrete = self#list self#structure_item concrete in
@@ -16338,7 +16346,7 @@ module V4_06 = struct
         fun structure_item ->
           let concrete =
             match Structure_item.to_concrete structure_item with
-            | None -> failwith "structure_item"
+            | None -> conversion_failed "structure_item"
             | Some n -> n
           in
           let { pstr_desc; pstr_loc } : Structure_item.concrete = concrete in
@@ -16349,7 +16357,7 @@ module V4_06 = struct
         fun structure_item_desc ->
           let concrete =
             match Structure_item_desc.to_concrete structure_item_desc with
-            | None -> failwith "structure_item_desc"
+            | None -> conversion_failed "structure_item_desc"
             | Some n -> n
           in
           match (concrete : Structure_item_desc.concrete) with
@@ -16406,7 +16414,7 @@ module V4_06 = struct
         fun value_binding ->
           let concrete =
             match Value_binding.to_concrete value_binding with
-            | None -> failwith "value_binding"
+            | None -> conversion_failed "value_binding"
             | Some n -> n
           in
           let { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Value_binding.concrete = concrete in
@@ -16419,7 +16427,7 @@ module V4_06 = struct
         fun module_binding ->
           let concrete =
             match Module_binding.to_concrete module_binding with
-            | None -> failwith "module_binding"
+            | None -> conversion_failed "module_binding"
             | Some n -> n
           in
           let { pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Module_binding.concrete = concrete in
@@ -16432,7 +16440,7 @@ module V4_06 = struct
         fun toplevel_phrase ->
           let concrete =
             match Toplevel_phrase.to_concrete toplevel_phrase with
-            | None -> failwith "toplevel_phrase"
+            | None -> conversion_failed "toplevel_phrase"
             | Some n -> n
           in
           match (concrete : Toplevel_phrase.concrete) with
@@ -16447,7 +16455,7 @@ module V4_06 = struct
         fun directive_argument ->
           let concrete =
             match Directive_argument.to_concrete directive_argument with
-            | None -> failwith "directive_argument"
+            | None -> conversion_failed "directive_argument"
             | Some n -> n
           in
           match (concrete : Directive_argument.concrete) with

--- a/ast/virtual_traverse.ml
+++ b/ast/virtual_traverse.ml
@@ -2,9 +2,7 @@
 module V4_07 = struct
   open Versions.V4_07
 
-  let conversion_failed name =
-    let msg = Printf.sprintf "Ppx_ast: Could not convert %s to V4_07" name in
-    failwith msg
+  let conversion_failed name = Raise.conversion_failed ~version:"V4_07" name
 
   class virtual map =
     object (self)
@@ -8241,9 +8239,7 @@ end
 module V4_06 = struct
   open Versions.V4_06
 
-  let conversion_failed name =
-    let msg = Printf.sprintf "Ppx_ast: Could not convert %s to V4_06" name in
-    failwith msg
+  let conversion_failed name = Raise.conversion_failed ~version:"V4_06" name
 
   class virtual map =
     object (self)


### PR DESCRIPTION
This is also something that will be shared between gen_traverse and gen_viewer.

I'm not super happy with this but to be fair I wasn't happy about the previous state either and this is probably better.

At some point we'll have to find a better way to deal with these errors than exceptions, especially in `Ppx_ast.viewer` as it is going to be used in ppx-es code and we'd rather avoid throwing exceptions in there!