### PR TITLE
Properly handle keywords in cinaps helper Ml.id

### DIFF
--- a/ast/cinaps/gen_builder.ml
+++ b/ast/cinaps/gen_builder.ml
@@ -1,20 +1,5 @@
 open Stdppx
 
-let map_keyword = function
-  | "open"
-  | "private"
-  | "downto"
-  | "to"
-  | "mutable"
-  | "rec"
-  | "nonrec"
-  | "virtual"
-  | "type"
-  | "mod"
-  | "begin"
-  | "end" as s -> s ^ "_"
-  | s -> s
-
 module Arrow = struct
   module Arg = struct
     type t =
@@ -24,7 +9,7 @@ module Arrow = struct
 
     let anon typ = { label = None; typ }
 
-    let named name typ = { label = Some (map_keyword name); typ }
+    let named name typ = { label = Some (Ml.id name); typ }
 
     let loc = { label = Some "loc"; typ = Astlib.Grammar.Location }
   end
@@ -268,7 +253,7 @@ module Builder = struct
           if pat = "attributes" then
             (Some name, empty_attributes)
           else
-            (Some name, Expr.Ident (map_keyword pat))
+            (Some name, Expr.Ident (Ml.id pat))
         ) in
         let constructor = Printf.sprintf "%s.create"
                             (String.capitalize_ascii name) in

--- a/ast/cinaps/gen_traverse.ml
+++ b/ast/cinaps/gen_traverse.ml
@@ -80,7 +80,7 @@ let node_type ~type_ ~args node_name =
   let args = List.map args ~f:string_of_ty in
   Ml.poly_inst node_type ~args
 
-let fun_arg type_name = Printf.sprintf "f%s" (Ml.id type_name)
+let fun_arg type_name = Ml.id (Printf.sprintf "f%s" type_name)
 
 let tuple_var i = Printf.sprintf "x%d" i
 
@@ -437,7 +437,7 @@ let declare_node_methods ~env_table ~signature (node_name, kind) =
       let name = Name.make [node_name] args in
       let signature = signature (node_type ~type_:T ~args node_name) in
       Ml.declare_method ~signature ~name ())
-      
+
 let define_node_methods ~env_table ~traversal (node_name, kind) =
   match (kind : Astlib.Grammar.kind) with
   | Mono decl ->

--- a/ast/cinaps/ml.ml
+++ b/ast/cinaps/ml.ml
@@ -1,5 +1,20 @@
 open StdLabels
 
+let map_keyword = function
+  | "open"
+  | "private"
+  | "downto"
+  | "to"
+  | "mutable"
+  | "rec"
+  | "nonrec"
+  | "virtual"
+  | "type"
+  | "mod"
+  | "begin"
+  | "end" as s -> s ^ "_"
+  | s -> s
+
 let is_id_char = function
   | 'A' .. 'Z' -> true
   | 'a' .. 'z' -> true
@@ -14,7 +29,7 @@ let to_id_char char =
 
 let raw_id string = String.map string ~f:to_id_char
 
-let id string = String.lowercase_ascii (raw_id string)
+let id string = map_keyword (String.lowercase_ascii (raw_id string))
 let tvar string = "'" ^ id string
 let module_name string = String.capitalize_ascii (raw_id string)
 let tag string = String.capitalize_ascii (raw_id string)

--- a/ast/cinaps/ml.ml
+++ b/ast/cinaps/ml.ml
@@ -1,19 +1,19 @@
-open StdLabels
+open Stdppx
 
-let map_keyword = function
-  | "open"
-  | "private"
-  | "downto"
-  | "to"
-  | "mutable"
-  | "rec"
-  | "nonrec"
-  | "virtual"
-  | "type"
-  | "mod"
-  | "begin"
-  | "end" as s -> s ^ "_"
-  | s -> s
+let keywords =
+  [ "and"; "as"; "assert"; "asr"; "begin"; "class"; "constraint"; "do"; "done"
+  ; "downto"; "else"; "end"; "exception"; "external"; "false"; "for"; "fun"
+  ; "function"; "functor"; "if"; "in"; "include"; "inherit"; "initializer"
+  ; "land"; "lazy"; "let"; "lor"; "lsl"; "lsr"; "lxor"; "match"; "method"
+  ; "mod"; "module"; "mutable"; "new"; "nonrec"; "object"; "of"; "open"; "or"
+  ; "private"; "rec"; "sig"; "struct"; "then"; "to"; "true"; "try"; "type"
+  ; "val"; "virtual"; "when"; "while"; "with" ]
+
+let map_keyword s =
+  if List.mem_sorted ~compare:String.compare s keywords then
+    s ^ "_"
+  else
+    s
 
 let is_id_char = function
   | 'A' .. 'Z' -> true

--- a/stdppx/list.ml
+++ b/stdppx/list.ml
@@ -168,3 +168,12 @@ let find_a_dup ~compare l =
     | hd::(hd'::_ as tl) -> if compare hd hd' = Eq then Some hd else loop tl
   in
   loop sorted
+
+let rec mem_sorted ~compare elm l =
+  match l with
+  | [] -> false
+  | hd::tl ->
+    (match (compare hd elm : Ordering.t) with
+     | Lt -> mem_sorted ~compare elm tl
+     | Eq -> true
+     | Gt -> false)

--- a/stdppx/list.mli
+++ b/stdppx/list.mli
@@ -45,6 +45,8 @@ val   sort_uniq : 'a t -> compare:('a -> 'a -> Ordering.t) -> 'a t
 
 val find_a_dup : compare:('a -> 'a -> Ordering.t) -> 'a t -> 'a option
 
+val mem_sorted : compare:('a -> 'a -> Ordering.t) -> 'a -> 'a t -> bool
+
 val compare : 'a t -> 'a t -> compare:('a -> 'a -> Ordering.t) -> Ordering.t
 
 val assoc : ('a * 'b) t -> 'a -> 'b option


### PR DESCRIPTION
I basically moved the code from `Gen_builder` to `Ml` as I needed it to generate Ast_viewer but I think it's a good thing to have in `Ml.id` anyway.