### PR TITLE
Basic tests for metaquot expressions and patterns.

### DIFF
--- a/metaquot/test/dune
+++ b/metaquot/test/dune
@@ -1,5 +1,8 @@
 (library
  (name ppx_metaquot_test)
- (public_name ppx.metaquot_test)
  (libraries ppx)
- (preprocess (pps ppx.metaquot ppx.runner)))
+ (preprocess (pps ppx.metaquot)))
+
+(alias
+ (name runtest)
+ (deps (alias check)))

--- a/metaquot/test/dune
+++ b/metaquot/test/dune
@@ -1,0 +1,5 @@
+(library
+ (name ppx_metaquot_test)
+ (public_name ppx.metaquot_test)
+ (libraries ppx)
+ (preprocess (pps ppx.metaquot ppx.runner)))

--- a/metaquot/test/test_ppx_metaquot.ml
+++ b/metaquot/test/test_ppx_metaquot.ml
@@ -1,0 +1,21 @@
+open! Ppx
+
+let loc = Location.none
+
+(* AST expressions *)
+let expr  = [%expr 1, 2, 3]
+let pat   = [%pat? _, 2, 3]
+let type_ = [%type: int * int * _]
+let stri  = [%stri let x = 1]
+let str   = [%str let x = 1 let y = 2]
+let sigi  = [%sigi: module M : S]
+let sig_  = [%sig: module M : S type t = unit]
+
+(* AST patterns *)
+let f_expr = function [%expr 1, 2, 3]                    -> true | _ -> false
+let f_pat  = function [%pat? _, 2, 3]                    -> true | _ -> false
+let f_type = function [%type: int * int * _]             -> true | _ -> false
+let f_stri = function [%stri let x = 1]                  -> true | _ -> false
+let f_str  = function [%str let x = 1 let y = 2]         -> true | _ -> false
+let f_sigi = function [%sigi: module M : S]              -> true | _ -> false
+let f_sig  = function [%sig: module M : S type t = unit] -> true | _ -> false

--- a/metaquot/test/test_ppx_metaquot.mli
+++ b/metaquot/test/test_ppx_metaquot.mli
@@ -1,0 +1,17 @@
+open! Ppx
+
+val expr  : Ppx.expression
+val pat   : Ppx.pattern
+val type_ : Ppx.core_type
+val stri  : Ppx.structure_item
+val str   : Ppx.structure
+val sigi  : Ppx.signature_item
+val sig_  : Ppx.signature
+
+val f_expr : Ppx.expression     -> bool
+val f_pat  : Ppx.pattern        -> bool
+val f_type : Ppx.core_type      -> bool
+val f_stri : Ppx.structure_item -> bool
+val f_str  : Ppx.structure      -> bool
+val f_sigi : Ppx.signature_item -> bool
+val f_sig  : Ppx.signature      -> bool


### PR DESCRIPTION
Adding basic tests for ppx_metaquot, showing the expression and pattern forms and annotating their types in the .mli.

We don't bother to test escapes for now. I don't think it's necessary. The main thing I wanted to show here is that (a) we're generating compiler ASTs rather than `Ppx_ast` ASTs, and (b) opening Ppx is required, I think because we're relying on constructor definitions that are not otherwise in scope.

I hope to be able to fix ppx_metaquot in subsequent pull requests so that no `open` is required, and so that we generate `Ppx_ast` types.