### PR TITLE
Improve @view attributes behaviour

### DIFF
--- a/ppx_view/lib/error.ml
+++ b/ppx_view/lib/error.ml
@@ -13,7 +13,7 @@ let invalid_payload ~loc =
 
 let invalid_attribute_payload ~loc =
   errorf ~loc
-    "Invalid @view attribute payload, should be a single record expression"
+    "Invalid @view attribute payload, should be a record pattern"
 
 let unsupported_pattern ~loc pattern =
   errorf ~loc "ppx_view doesn't support pattern matching over %s" pattern

--- a/ppx_view/lib/expand.ml
+++ b/ppx_view/lib/expand.ml
@@ -90,11 +90,12 @@ let same_variables ~err_loc vl vl' =
         name = name'
       | _ -> false)
 
-let apply_attr_field_fun field expr =
+let apply_attr_field_fun ~loc field expr =
   let {View_attr.label; label_loc; var_loc; _} = field in
-  let f = Located.lident ~loc:label_loc (label ^ "'field") in
+  let f = Located.lident ~loc:label_loc (label ^ "'match") in
   let capture_arg = Builder.Exp.view_lib_capture ~loc:var_loc in
-  Builder.Exp.apply_lident ~loc:label_loc f [capture_arg; expr]
+  let field_match = Builder.Exp.apply_lident ~loc:label_loc f [capture_arg] in
+  Builder.Exp.view_lib_sequence ~loc [field_match; expr]
 
 let add_attr_field_var field vars =
   let {View_attr.var; var_loc; _} = field in
@@ -114,7 +115,7 @@ let rec translate_pattern ~err_loc pattern =
       List.fold_right fields
         ~init:(expr, vars)
         ~f:(fun field (acc_expr, acc_vars) ->
-          let acc_expr = apply_attr_field_fun field acc_expr in
+          let acc_expr = apply_attr_field_fun ~loc:ppat_loc field acc_expr in
           let acc_vars = add_attr_field_var field acc_vars in
           (acc_expr, acc_vars))
 

--- a/ppx_view/lib/view_attr.ml
+++ b/ppx_view/lib/view_attr.ml
@@ -1,58 +1,21 @@
 open Stdppx
 open Ppx_ast.V4_07
 
-type field =
-  { label : string
-  ; label_loc : Astlib.Location.t
-  ; var : string
-  ; var_loc : Astlib.Location.t
-  }
+type field = Longident_loc.t * Pattern.t
 
-let to_field ~loc (label, value) =
-  let label_loc, ident = Deconstructor.longident_loc ~loc label in
-  let pexp_loc, pexp_desc = Deconstructor.expression ~loc value in
-  match ident, pexp_desc with
-  | Lident label, Pexp_ident var_ident ->
-    let var_loc, ident =
-      Deconstructor.longident_loc ~loc:pexp_loc var_ident
-    in
-    (match ident with
-     | Lident var -> {label; label_loc; var; var_loc}
-     | _ -> Error.invalid_attribute_payload ~loc:var_loc)
-  | (Ldot _ | Lapply _), _ -> Error.invalid_attribute_payload ~loc:label_loc
-  | _, _ -> Error.invalid_attribute_payload ~loc:pexp_loc
-
-let fields_from_expr ~loc expr =
-  let pexp_loc, pexp_desc = Deconstructor.expression ~loc expr in
-  match pexp_desc with
-  | Pexp_record (fields, None) ->
-    let fields = List.map ~f:(to_field ~loc:pexp_loc) fields in
-    Some fields
-  | _ -> Error.invalid_attribute_payload ~loc:pexp_loc
-
-let fields_from_stri ~loc stri =
-  match Structure_item.to_concrete stri with
-  | None -> Error.conversion_failed ~loc "structure_item"
-  | Some {pstr_loc; pstr_desc} ->
-    match Structure_item_desc.to_concrete pstr_desc with
-    | None -> Error.conversion_failed ~loc "structure_item_desc"
-    | Some (Pstr_eval (expr, _attributes)) ->
-      fields_from_expr ~loc:pstr_loc expr
-    | _ -> Error.invalid_attribute_payload ~loc:pstr_loc
+let fields_from_pattern ~loc pattern =
+  let ppat_loc, ppat_desc = Deconstructor.pattern ~loc pattern in
+  match ppat_desc with
+  | Ppat_record (fields, _closed) -> (ppat_loc, fields)
+  | _ -> Error.invalid_attribute_payload ~loc:ppat_loc
 
 let fields_from_payload ~loc payload =
   match Payload.to_concrete payload with
   | None -> Error.conversion_failed ~loc "payload"
-  | Some (PSig _ | PTyp _ | PPat _) -> None
-  (* Shouldn't the paylaod be a pattern? so that one could write
-     [[@view? {pexp_attributes = []; _}]] for instance? Even
-     if we don't allow further deconstruction, I still feel like
-     a pattern would be better suited. *)
-  | Some (PStr structure) ->
-    match Structure.to_concrete structure with
-    | None -> Error.conversion_failed ~loc "structure"
-    | Some [stri] -> fields_from_stri ~loc stri
-    | Some _ -> Error.invalid_attribute_payload ~loc
+  | Some (PSig _ | PTyp _ | PStr _ | PPat (_, Some _)) ->
+    Error.invalid_attribute_payload ~loc
+  | Some (PPat (pattern, None)) ->
+    fields_from_pattern ~loc pattern
 
 let fields_from_attribute ~loc attribute =
   match Attribute.to_concrete attribute with
@@ -61,7 +24,7 @@ let fields_from_attribute ~loc attribute =
     let loc = Astlib.Loc.loc name in
     let name = Astlib.Loc.txt name in
     match name with
-    | "view" -> fields_from_payload ~loc payload
+    | "view" -> Some (fields_from_payload ~loc payload)
     | _ -> None
 
 let extract_fields ~err_loc:loc attributes =

--- a/ppx_view/lib/view_attr.mli
+++ b/ppx_view/lib/view_attr.mli
@@ -1,16 +1,14 @@
-(** Helpers to interpret [[@view ...]] attributes *)
+(** Helpers to interpret [[@view? ...]] attributes *)
 
 open Ppx_ast.V4_07
 
 (** The type for information about an extra record field. *)
-type field =
-  { label : string
-  ; label_loc : Astlib.Location.t
-  ; var : string
-  ; var_loc : Astlib.Location.t
-  }
+type field = Longident_loc.t * Pattern.t
 
-(** Extracts the extra field information from the [[@view ...]] attributes
+(** Extracts the extra field information from the [[@view? ...]] attributes
     amongst the given pattern attributes. Returns [None] if there is no
     such attribute. The given location is only used to report errors. *)
-val extract_fields : err_loc: Astlib.Location.t -> Attributes.t -> field list option
+val extract_fields :
+  err_loc: Astlib.Location.t ->
+  Attributes.t ->
+  (Astlib.Location.t * field list) option

--- a/ppx_view/test/test.ml
+++ b/ppx_view/test/test.ml
@@ -272,3 +272,53 @@ let%expect_test "match with array" =
    | [|x; y|] -> print_int (x + y)
    | _ -> assert false);
   [%expect {|3|}]
+
+module Shortcut = struct
+  type a =
+    | An_int of int
+    | A_float of float
+
+  type t =
+    { a : a
+    ; b : int
+    ; c : int
+    }
+
+  let an_int view value =
+    match value.a with
+    | An_int i -> view i
+    | _ -> Viewlib.View.error
+
+  let a_float view value =
+    match value.a with
+    | A_float f -> view f
+    | _ -> Viewlib.View.error
+
+  let a'match view value = view value.a
+
+  let b'match view value = view value.b
+
+  let c'match view value = view value.c
+
+  let a'field field_view view value =
+    let open Viewlib.View in
+    (field_view value.a) >>+ view value
+
+  let b'field field_view view value =
+    let open Viewlib.View in
+    (field_view value.b) >>+ view value
+
+  let c'field field_view view value =
+    let open Viewlib.View in
+    (field_view value.c) >>+ view value
+end
+
+let %expect_test "shortcut fields" =
+  let open Shortcut in
+  (match%view {a = An_int 1; b = 2; c = 3} with
+   | An_int a [@view {b; c}] ->
+     print_int a;
+     print_int b;
+     print_int c
+   | _ -> assert false);
+  [%expect {|123|}]

--- a/ppx_view/test/test.ml
+++ b/ppx_view/test/test.ml
@@ -301,12 +301,22 @@ module Shortcut = struct
   let c'match view value = view value.c
 end
 
-let %expect_test "shortcut fields" =
+let%expect_test "shortcut fields" =
   let open Shortcut in
   (match%view {a = An_int 1; b = 2; c = 3} with
-   | An_int a [@view {b; c}] ->
+   | An_int a [@view? {b; c}] ->
      print_int a;
      print_int b;
      print_int c
+   | _ -> assert false);
+  [%expect {|123|}]
+
+let%expect_test "shortcut fields pattern" =
+  let open Shortcut in
+  (match%view {a = An_int 1; b = 2; c = 3} with
+   | An_int a [@view? {b = (2 as x); c = (_ as y)}] ->
+     print_int a;
+     print_int x;
+     print_int y
    | _ -> assert false);
   [%expect {|123|}]

--- a/ppx_view/test/test.ml
+++ b/ppx_view/test/test.ml
@@ -299,18 +299,6 @@ module Shortcut = struct
   let b'match view value = view value.b
 
   let c'match view value = view value.c
-
-  let a'field field_view view value =
-    let open Viewlib.View in
-    (field_view value.a) >>+ view value
-
-  let b'field field_view view value =
-    let open Viewlib.View in
-    (field_view value.b) >>+ view value
-
-  let c'field field_view view value =
-    let open Viewlib.View in
-    (field_view value.c) >>+ view value
 end
 
 let %expect_test "shortcut fields" =


### PR DESCRIPTION
This PR changes two things.

### Use `'match` instead of `'field` function

It turns `[@view ...]` attributes into sequenced calls to `'match` functions instead of relying on 
separate `'field` functions, e.g. it turns ` Some_const a [@view {b; c}]` into
```ocaml
sequence (b'match __) (sequence (c'match __) (some_const __))
```
instead of:
```ocaml
b'field __ (c'field __ (some_const __))
```
Both are equivalent but the first one doesn't require any extra boiler plate to work!

### Make `@view`'s paylod a pattern

This allows to deconstruct those other fields instead of only binding them. I.e. you can now write:
```ocaml
match%view x with
| Some_const a [@view {b = None; c = []}] -> ...
```