### PR TITLE
Add unversioned helpers to Ppx_ast.Builder

### DIFF
--- a/ast/builder.ml
+++ b/ast/builder.ml
@@ -1,3 +1,5 @@
+open Stdppx
+
 (*$ Ppx_ast_cinaps.print_builder_ml () *)
 module V4_07 = struct
   open Versions.V4_07
@@ -599,3 +601,91 @@ Value_binding.create ~pvb_pat:pat ~pvb_expr:expr ~pvb_attributes:(Attributes.of_
 Module_binding.create ~pmb_name:name ~pmb_expr:expr ~pmb_attributes:(Attributes.of_concrete []) ~pmb_loc:loc
 end
 (*$*)
+
+module Common = struct
+  open V4_07
+  open Versions.V4_07
+
+  module Located = struct
+    let longident ~loc longident =
+      Longident_loc.create (Astlib.Loc.create ~loc ~txt:longident ())
+
+    let lident ~loc x = longident ~loc (Longident.lident x)
+  end
+
+  let echar ~loc x = pexp_constant ~loc (Constant.pconst_char x)
+
+  let estring ~loc x = pexp_constant ~loc (Constant.pconst_string x None)
+
+  let eint ~loc x =
+    pexp_constant ~loc (Constant.pconst_integer (Int.to_string x) None)
+
+  let eint32 ~loc x =
+    pexp_constant ~loc (Constant.pconst_integer (Int32.to_string x) (Some 'l'))
+
+  let eint64 ~loc x =
+    pexp_constant ~loc (Constant.pconst_integer (Int64.to_string x) (Some 'L'))
+
+  let enativeint ~loc x =
+    pexp_constant ~loc (Constant.pconst_integer (Nativeint.to_string x) (Some 'n'))
+
+  let efloat ~loc x =
+    pexp_constant ~loc (Constant.pconst_float (Float.to_string x) None)
+
+  let eunit ~loc =
+    pexp_construct ~loc (Located.lident ~loc "()") None
+
+  let ebool ~loc x = pexp_construct ~loc (Located.lident ~loc (Bool.to_string x)) None
+
+  let enil ~loc = pexp_construct ~loc (Located.lident ~loc "[]") None
+
+  let elist ~loc exprs =
+    let nil = enil ~loc in
+    let cons expr list_expr =
+      pexp_construct ~loc
+        (Located.lident ~loc "::")
+        (Some (pexp_tuple ~loc [expr; list_expr]))
+    in
+    List.fold_right exprs ~f:cons ~init:nil
+
+  let eapply ~loc fun_expr args =
+    pexp_apply ~loc
+      fun_expr
+      (List.map args ~f:(fun expr -> (Arg_label.nolabel, expr)))
+
+  let pchar ~loc x = ppat_constant ~loc (Constant.pconst_char x)
+
+  let pstring ~loc x = ppat_constant ~loc (Constant.pconst_string x None)
+
+  let pint ~loc x =
+    ppat_constant ~loc (Constant.pconst_integer (Int.to_string x) None)
+
+  let pint32 ~loc x =
+    ppat_constant ~loc (Constant.pconst_integer (Int32.to_string x) (Some 'l'))
+
+  let pint64 ~loc x =
+    ppat_constant ~loc (Constant.pconst_integer (Int64.to_string x) (Some 'L'))
+
+  let pnativeint ~loc x =
+    ppat_constant ~loc (Constant.pconst_integer (Nativeint.to_string x) (Some 'n'))
+
+  let pfloat ~loc x =
+    ppat_constant ~loc (Constant.pconst_float (Float.to_string x) None)
+
+  let punit ~loc = ppat_construct ~loc (Located.lident ~loc "()") None
+
+  let pbool ~loc x = ppat_construct ~loc (Located.lident ~loc (Bool.to_string x)) None
+
+  let pnil ~loc = ppat_construct ~loc (Located.lident ~loc "[]") None
+
+  let pvar ~loc x = ppat_var ~loc (Astlib.Loc.create ~loc ~txt:x ())
+
+  let plist ~loc exprs =
+    let nil = pnil ~loc in
+    let cons pat list_pat =
+      ppat_construct ~loc
+        (Located.lident ~loc "::")
+        (Some (ppat_tuple ~loc [pat; list_pat]))
+    in
+    List.fold_right exprs ~f:cons ~init:nil
+end

--- a/ast/builder.mli
+++ b/ast/builder.mli
@@ -1387,3 +1387,40 @@ module V4_06 : sig
     -> Module_binding.t
 end
 (*$*)
+
+module Common : sig
+  module Located : sig
+    val longident : loc: Astlib.Location.t -> Versions.longident -> Versions.longident_loc
+    val lident : loc: Astlib.Location.t -> string -> Versions.longident_loc
+  end
+
+  val echar : loc: Astlib.Location.t -> char -> Versions.expression
+  val estring : loc: Astlib.Location.t -> string -> Versions.expression
+  val eint : loc: Astlib.Location.t -> int -> Versions.expression
+  val eint32 : loc: Astlib.Location.t -> int32 -> Versions.expression
+  val eint64 : loc: Astlib.Location.t -> int64 -> Versions.expression
+  val enativeint : loc: Astlib.Location.t -> nativeint -> Versions.expression
+  val efloat : loc: Astlib.Location.t -> float -> Versions.expression
+  val eunit : loc: Astlib.Location.t -> Versions.expression
+  val ebool : loc: Astlib.Location.t -> bool -> Versions.expression
+  val enil : loc: Astlib.Location.t -> Versions.expression
+  val elist : loc: Astlib.Location.t -> Versions.expression list -> Versions.expression
+  val eapply :
+    loc : Astlib.Location.t ->
+    Versions.expression ->
+    Versions.expression list ->
+    Versions.expression
+
+  val pchar : loc: Astlib.Location.t -> char -> Versions.pattern
+  val pstring : loc: Astlib.Location.t -> string -> Versions.pattern
+  val pint : loc: Astlib.Location.t -> int -> Versions.pattern
+  val pint32 : loc: Astlib.Location.t -> int32 -> Versions.pattern
+  val pint64 : loc: Astlib.Location.t -> int64 -> Versions.pattern
+  val pnativeint : loc: Astlib.Location.t -> nativeint -> Versions.pattern
+  val pfloat : loc: Astlib.Location.t -> float -> Versions.pattern
+  val pvar : loc: Astlib.Location.t -> string -> Versions.pattern
+  val punit : loc: Astlib.Location.t -> Versions.pattern
+  val pbool : loc: Astlib.Location.t -> bool -> Versions.pattern
+  val pnil : loc: Astlib.Location.t -> Versions.pattern
+  val plist : loc: Astlib.Location.t -> Versions.pattern list -> Versions.pattern
+end

--- a/ppx_view/lib/builder.ml
+++ b/ppx_view/lib/builder.ml
@@ -1,5 +1,6 @@
 open Stdppx
 open Ppx_ast.V4_07
+open Ppx_ast.Builder
 
 module Module : sig
   val view : string
@@ -8,28 +9,8 @@ end = struct
   let view = runtime "View"
 end
 
-let expression ~loc pexp_desc =
-  Expression.create
-    ~pexp_desc
-    ~pexp_attributes:(Attributes.create [])
-    ~pexp_loc:loc
-
-let pattern ~loc ppat_desc =
-  Pattern.create
-    ~ppat_desc
-    ~ppat_loc:loc
-    ~ppat_attributes:(Attributes.create [])
-
-let longident_loc ~loc longident =
-  Astlib.Loc.create ~loc ~txt:longident ()
-  |> Longident_loc.create
-
-let lident_loc ~loc str =
-  let lident = Longident.lident str in
-  longident_loc ~loc lident
-
 let view_lib_ident ~loc name =
-  longident_loc ~loc Longident.(ldot (lident Module.view) name)
+  Located.longident ~loc Longident.(ldot (lident Module.view) name)
 
 let view_lib_sequence ~loc = view_lib_ident ~loc "sequence"
 
@@ -40,38 +21,23 @@ let view_lib_choice ~loc = view_lib_ident ~loc "choice"
 let view_lib_larray_cons ~loc = view_lib_ident ~loc "larray_cons"
 
 module Exp = struct
-  let apply ~loc fun_expr args =
-    let no_label_args = List.map args ~f:(fun expr -> (Arg_label.nolabel, expr)) in
-    expression ~loc (Expression_desc.pexp_apply fun_expr no_label_args)
-
   let apply_lident ~loc lident args =
-    let f = expression ~loc (Expression_desc.pexp_ident lident) in
-    apply ~loc f args
+    let f = V4_07.pexp_ident ~loc lident in
+    eapply ~loc f args
 
-  let list_lit ~loc exprs =
-    let open Expression_desc in
-    let cons_ident = lident_loc ~loc "::" in
-    let nil = expression ~loc (pexp_construct (lident_loc ~loc "[]") None) in
-    let cons expr list =
-      let cons_args = expression ~loc (pexp_tuple [expr; list]) in
-      expression ~loc (pexp_construct cons_ident (Some cons_args))
-    in
-    List.fold_right exprs ~init:nil ~f:cons
-
-  let unit ~loc =
-    expression ~loc (Expression_desc.pexp_construct (lident_loc ~loc "()") None)
-
-  let lident ~loc name =
-    expression ~loc (Expression_desc.pexp_ident (lident_loc ~loc name))
+  let lident ~loc name = V4_07.pexp_ident (Located.lident ~loc name)
 
   let view_lib_ident ~loc name =
-    expression ~loc (Expression_desc.pexp_ident (view_lib_ident ~loc name))
+    V4_07.pexp_ident ~loc (view_lib_ident ~loc name)
 
-  let view_lib_capture ~loc = view_lib_ident ~loc "__"
+  let view_lib_capture ~loc =
+    view_lib_ident ~loc "__"
 
-  let view_lib_drop ~loc = view_lib_ident ~loc "drop"
+  let view_lib_drop ~loc =
+    view_lib_ident ~loc "drop"
 
-  let view_lib_larray_nil ~loc = view_lib_ident ~loc "larray_nil"
+  let view_lib_larray_nil ~loc =
+    view_lib_ident ~loc "larray_nil"
 
   let view_lib_sequence ~loc exprs =
     let rec aux = function
@@ -89,13 +55,9 @@ module Pat = struct
       match args with
       | [] -> None
       | [one] -> Some one
-      | _ -> Some (pattern ~loc (Pattern_desc.ppat_tuple args))
+      | _ -> Some (V4_07.ppat_tuple ~loc args)
     in
-    pattern ~loc (Pattern_desc.ppat_construct ident args)
-
-  let var ~loc name =
-    let var = Astlib.Loc.create ~loc ~txt:name () in
-    pattern ~loc (Pattern_desc.ppat_var var)
+    V4_07.ppat_construct ident args
 
   let view_lib_var_nil ~loc =
     construct ~loc (view_lib_ident ~loc "Var_nil") []

--- a/ppx_view/lib/builder.ml
+++ b/ppx_view/lib/builder.ml
@@ -1,6 +1,4 @@
-open Stdppx
-open Ppx_ast.V4_07
-open Ppx_ast.Builder
+open Import
 
 module Module : sig
   val view : string
@@ -22,13 +20,13 @@ let view_lib_larray_cons ~loc = view_lib_ident ~loc "larray_cons"
 
 module Exp = struct
   let apply_lident ~loc lident args =
-    let f = V4_07.pexp_ident ~loc lident in
+    let f = pexp_ident ~loc lident in
     eapply ~loc f args
 
-  let lident ~loc name = V4_07.pexp_ident (Located.lident ~loc name)
+  let lident ~loc name = pexp_ident ~loc (Located.lident ~loc name)
 
   let view_lib_ident ~loc name =
-    V4_07.pexp_ident ~loc (view_lib_ident ~loc name)
+    pexp_ident ~loc (view_lib_ident ~loc name)
 
   let view_lib_capture ~loc =
     view_lib_ident ~loc "__"
@@ -55,9 +53,9 @@ module Pat = struct
       match args with
       | [] -> None
       | [one] -> Some one
-      | _ -> Some (V4_07.ppat_tuple ~loc args)
+      | _ -> Some (ppat_tuple ~loc args)
     in
-    V4_07.ppat_construct ident args
+    ppat_construct ~loc ident args
 
   let view_lib_var_nil ~loc =
     construct ~loc (view_lib_ident ~loc "Var_nil") []

--- a/ppx_view/lib/builder.mli
+++ b/ppx_view/lib/builder.mli
@@ -2,17 +2,6 @@
 
 open Ppx_ast.V4_07
 
-(** Builds an expression w/o attributes. *)
-val expression : loc: Astlib.Location.t -> Expression_desc.t -> Expression.t
-
-(** Builds a pattern w/o attributes. *)
-val pattern : loc: Astlib.Location.t -> Pattern_desc.t -> Pattern.t
-
-val longident_loc: loc: Astlib.Location.t -> Longident.t -> Longident_loc.t
-
-(** [lident_loc ~loc s] builds a [Lident s] with loc [loc]. *)
-val lident_loc : loc: Astlib.Location.t -> string -> Longident_loc.t
-
 (** Builds an identifier prefixed by the ppx_view runtime library module
     path. *)
 val view_lib_ident : loc: Astlib.Location.t -> string -> Longident_loc.t
@@ -30,25 +19,11 @@ module Exp : sig
   (** Helpers for building expressions *)
 
   (** Builds a function application with unlabelled arguments. *)
-  val apply :
-    loc: Astlib.Location.t ->
-    Expression.t ->
-    Expression.t list ->
-    Expression.t
-
-  (** Same as [apply] but takes a function identifier instead of an arbitrary
-      expression. *)
   val apply_lident :
     loc: Astlib.Location.t ->
     Longident_loc.t ->
     Expression.t list ->
     Expression.t
-
-  (** Builds a list literal expression. *)
-  val list_lit : loc: Astlib.Location.t -> Expression.t list -> Expression.t
-
-  (** Builds [()] *)
-  val unit : loc: Astlib.Location.t -> Expression.t
 
   (** Same as [lident_loc] but wraps it into an expression. *)
   val lident : loc: Astlib.Location.t -> string -> Expression.t
@@ -73,9 +48,6 @@ end
 
 module Pat : sig
   (** Helpers for building patterns *)
-
-  (** Builds a variable pattern from the variable name. *)
-  val var : loc: Astlib.Location.t -> string -> Pattern.t
 
   (** Builds a pattern for runtime lib's [Var_nil] *)
   val view_lib_var_nil : loc: Astlib.Location.t -> Pattern.t

--- a/ppx_view/lib/expand.ml
+++ b/ppx_view/lib/expand.ml
@@ -1,17 +1,11 @@
-open Stdppx
-open Ppx_ast.V4_07
-
-module Ast_builder = struct
-  include Ppx_ast.Builder
-  include Ppx_ast.Builder.V4_07
-end
+open Import
 
 (** Generates functions akin to `View.tuple{2,3,4}` for arbitrary order *)
 let inline_tuple_function ~loc n =
   let view idx = Printf.sprintf "view%d" idx in
   let value idx = Printf.sprintf "value%d" idx in
   let component idx =
-    let view_idx = Ast_builder.Located.lident ~loc (view idx) in
+    let view_idx = Located.lident ~loc (view idx) in
     let value_idx = Builder.Exp.lident ~loc (value idx) in
     Builder.Exp.apply_lident ~loc (view_idx) [value_idx]
   in
@@ -26,20 +20,20 @@ let inline_tuple_function ~loc n =
     if idx <= 0 then
       acc
     else
-      values (Ast_builder.pvar ~loc (value idx)::acc) (idx - 1)
+      values (pvar ~loc (value idx)::acc) (idx - 1)
   in
-  let values_tuple = Ast_builder.ppat_tuple ~loc (values [] n) in
+  let values_tuple = ppat_tuple ~loc (values [] n) in
   let res =
-    Ast_builder.pexp_fun ~loc Arg_label.nolabel None values_tuple (body 1)
+    pexp_fun ~loc Arg_label.nolabel None values_tuple (body 1)
   in
   let rec fun_ idx =
     if idx > n then
       res
     else
-      Ast_builder.pexp_fun ~loc
+      pexp_fun ~loc
         Arg_label.nolabel
         None
-        (Ast_builder.pvar ~loc (view idx))
+        (pvar ~loc (view idx))
         (fun_ (idx + 1))
   in
   fun_ 1
@@ -60,16 +54,16 @@ let translate_ctor_ident ~loc (ident : Longident.concrete) =
   | Lident s ->
     (match predefined_ident ~loc s with
      | Some ident -> ident
-     | None -> Ast_builder.Located.lident ~loc (String.uncapitalize_ascii s))
+     | None -> Located.lident ~loc (String.uncapitalize_ascii s))
   | Ldot (li, s) ->
-    Ast_builder.Located.longident ~loc (Longident.ldot li (String.uncapitalize_ascii s))
+    Located.longident ~loc (Longident.ldot li (String.uncapitalize_ascii s))
   | (Lapply _) as li ->
-    Ast_builder.Located.longident ~loc (Longident.of_concrete li)
+    Located.longident ~loc (Longident.of_concrete li)
 
 let translate_constant ~loc constant =
   let make name =
     let f = Builder.view_lib_ident ~loc name in
-    Builder.Exp.apply_lident ~loc f [Ast_builder.pexp_constant ~loc constant]
+    Builder.Exp.apply_lident ~loc f [pexp_constant ~loc constant]
   in
   match Constant.to_concrete constant with
   | None -> Error.conversion_failed ~loc "constant"
@@ -98,13 +92,13 @@ let same_variables ~err_loc vl vl' =
 
 let apply_attr_field_fun field expr =
   let {View_attr.label; label_loc; var_loc; _} = field in
-  let f = Ast_builder.Located.lident ~loc:label_loc (label ^ "'field") in
+  let f = Located.lident ~loc:label_loc (label ^ "'field") in
   let capture_arg = Builder.Exp.view_lib_capture ~loc:var_loc in
   Builder.Exp.apply_lident ~loc:label_loc f [capture_arg; expr]
 
 let add_attr_field_var field vars =
   let {View_attr.var; var_loc; _} = field in
-  let var_pat = Ast_builder.pvar ~loc:var_loc var in
+  let var_pat = pvar ~loc:var_loc var in
   var_pat::vars
 
 let rec translate_pattern ~err_loc pattern =
@@ -131,12 +125,12 @@ and translate_pattern_desc ~loc desc =
   | Some Ppat_any ->
     ( Builder.Exp.view_lib_drop ~loc
     , [] )
-  | Some (Ppat_var _) ->
+  | Some (Ppat_var v) ->
     ( Builder.Exp.view_lib_capture ~loc
-    , [Builder.pattern ~loc desc] )
+    , [ppat_var ~loc v] )
   | Some (Ppat_alias (patt, alias)) ->
     let expr, vars = translate_pattern ~err_loc:loc patt in
-    let alias_var = Builder.pattern ~loc (Pattern_desc.ppat_var alias) in
+    let alias_var = ppat_var ~loc alias in
     ( Builder.Exp.view_lib_sequence ~loc
         [Builder.Exp.view_lib_capture ~loc; expr]
     , alias_var :: vars )
@@ -153,7 +147,7 @@ and translate_pattern_desc ~loc desc =
   | Some (Ppat_construct (ctor_ident, None)) ->
     let ctor_loc, ctor_ident = Deconstructor.longident_loc ~loc ctor_ident in
     let f = translate_ctor_ident ~loc:ctor_loc ctor_ident in
-    ( Builder.expression ~loc (Expression_desc.pexp_ident f)
+    ( pexp_ident ~loc f
     , [] )
   | Some (Ppat_construct (ctor_ident, Some patt)) ->
     let ctor_loc, ctor_ident = Deconstructor.longident_loc ~loc ctor_ident in
@@ -192,12 +186,11 @@ and translate_pattern_desc ~loc desc =
     translate_array ~loc patts
   | Some (Ppat_constraint (patt, ctyp)) ->
     let expr, vars = translate_pattern ~err_loc:loc patt in
-    ( Builder.expression ~loc (Expression_desc.pexp_constraint expr ctyp)
+    ( pexp_constraint ~loc expr ctyp
     , vars )
   | Some (Ppat_open (lid, patt)) ->
     let expr, vars = translate_pattern ~err_loc:loc patt in
-    ( Builder.expression ~loc
-        (Expression_desc.pexp_open Override_flag.override lid expr)
+    ( pexp_open ~loc Override_flag.override lid expr
     , vars )
   | Some (Ppat_variant _) ->
     Error.unsupported_pattern ~loc "polymorphic variants"
@@ -228,7 +221,7 @@ and translate_tuple ~loc patts =
   | len ->
     assert (len > 4);
     let f = inline_tuple_function ~loc len in
-    ( Builder.Exp.apply ~loc f exprs
+    ( eapply ~loc f exprs
     , vars )
 
 and translate_record_field ~loc (label, patt) =
@@ -236,7 +229,7 @@ and translate_record_field ~loc (label, patt) =
   match label with
   | Lident label ->
     let expr, vars = translate_pattern ~err_loc:label_loc patt in
-    let f = Builder.lident_loc ~loc:label_loc (label ^ "'match") in
+    let f = Located.lident ~loc:label_loc (label ^ "'match") in
     ( Builder.Exp.apply_lident ~loc:label_loc f [expr]
     , vars )
   | _ ->
@@ -266,18 +259,16 @@ let translate_case_body ~loc ~vars ~pc_guard ~pc_rhs =
       Case.create ~pc_lhs:vars_cons_pattern ~pc_guard ~pc_rhs
     in
     let guard_failed_case =
-      let pc_lhs = Builder.pattern ~loc Pattern_desc.ppat_any in
+      let pc_lhs = ppat_any ~loc in
       let pc_rhs =
         let f = Builder.view_lib_ident ~loc "guard_failed" in
-        Builder.Exp.(apply_lident ~loc f [unit ~loc])
+        Builder.Exp.(apply_lident ~loc f [eunit ~loc])
       in
       Case.create ~pc_lhs ~pc_guard:None ~pc_rhs
     in
-    Builder.expression ~loc
-      (Expression_desc.pexp_function [guarded_case; guard_failed_case])
+    pexp_function ~loc [guarded_case; guard_failed_case]
   | None ->
-    Builder.expression ~loc
-      (Expression_desc.pexp_fun Arg_label.nolabel None vars_cons_pattern pc_rhs)
+    pexp_fun ~loc Arg_label.nolabel None vars_cons_pattern pc_rhs
 
 let translate_case ~loc ~err_loc match_case =
   match Case.to_concrete match_case with
@@ -294,21 +285,12 @@ let pos_argument loc =
   let lnum = Astlib.Position.lnum start in
   let cnum = Astlib.Position.cnum start in
   let fname = Astlib.Position.fname start in
-  let string x =
-    Builder.expression ~loc
-      (Expression_desc.pexp_constant (Constant.pconst_string x None))
-  in
-  let int x =
-    Builder.expression ~loc
-      (Expression_desc.pexp_constant (Constant.pconst_integer (string_of_int x) None))
-  in
-  Builder.expression ~loc
-    (Expression_desc.pexp_tuple [string fname; int lnum; int (cnum - bol)])
+  pexp_tuple ~loc [estring ~loc fname; eint ~loc lnum; eint ~loc (cnum - bol)]
 
 let translate_match ~loc ~err_loc ?match_expr match_cases =
   let pos = pos_argument loc in
   let cases = List.map match_cases ~f:(translate_case ~err_loc ~loc) in
-  let cases_arg = Builder.Exp.list_lit ~loc cases in
+  let cases_arg = elist ~loc cases in
   let args =
     match match_expr with
     | Some expr -> [pos; cases_arg; expr]

--- a/ppx_view/lib/import.ml
+++ b/ppx_view/lib/import.ml
@@ -1,0 +1,4 @@
+include Stdppx
+include Ppx_ast.V4_07
+include Ppx_ast.Builder.V4_07
+include Ppx_ast.Builder.Common


### PR DESCRIPTION
I started by adding the obvious ones, in particular the ones that I needed in `ppx_view` so that we can get rid of that code and put it somewhere it's easy to share.