### PR TITLE
Move the list of keywords to Astlib

### DIFF
--- a/ast/cinaps/ml.ml
+++ b/ast/cinaps/ml.ml
@@ -1,19 +1,10 @@
 open Stdppx
 
-let keywords =
-  [ "and"; "as"; "assert"; "asr"; "begin"; "class"; "constraint"; "do"; "done"
-  ; "downto"; "else"; "end"; "exception"; "external"; "false"; "for"; "fun"
-  ; "function"; "functor"; "if"; "in"; "include"; "inherit"; "initializer"
-  ; "land"; "lazy"; "let"; "lor"; "lsl"; "lsr"; "lxor"; "match"; "method"
-  ; "mod"; "module"; "mutable"; "new"; "nonrec"; "object"; "of"; "open"; "or"
-  ; "private"; "rec"; "sig"; "struct"; "then"; "to"; "true"; "try"; "type"
-  ; "val"; "virtual"; "when"; "while"; "with" ]
+let is_keyword s =
+  List.mem_sorted ~compare:String.compare s Astlib.Syntax.keywords
 
 let map_keyword s =
-  if List.mem_sorted ~compare:String.compare s keywords then
-    s ^ "_"
-  else
-    s
+  if is_keyword s then s ^ "_" else s
 
 let is_id_char = function
   | 'A' .. 'Z' -> true

--- a/astlib/astlib.ml
+++ b/astlib/astlib.ml
@@ -4,6 +4,7 @@ module History = History
 module Loc = Loc
 module Location = Location
 module Position = Position
+module Syntax = Syntax
 
 let current_version = Versions.current_version
 let history = Versions.history

--- a/astlib/astlib_intf.ml
+++ b/astlib/astlib_intf.ml
@@ -30,6 +30,7 @@ module type Astlib = sig
   module Loc = Loc
   module Location = Location
   module Position = Position
+  module Syntax = Syntax
 
   val current_version : string
   val history : History.t

--- a/astlib/syntax.ml
+++ b/astlib/syntax.ml
@@ -1,0 +1,10 @@
+(* When upstreaming this, we need to make sure it's built from the lexer's
+   keyword_table rather than duplicated. *)
+let keywords =
+  [ "and"; "as"; "assert"; "asr"; "begin"; "class"; "constraint"; "do"; "done"
+  ; "downto"; "else"; "end"; "exception"; "external"; "false"; "for"; "fun"
+  ; "function"; "functor"; "if"; "in"; "include"; "inherit"; "initializer"
+  ; "land"; "lazy"; "let"; "lor"; "lsl"; "lsr"; "lxor"; "match"; "method"
+  ; "mod"; "module"; "mutable"; "new"; "nonrec"; "object"; "of"; "open"; "or"
+  ; "private"; "rec"; "sig"; "struct"; "then"; "to"; "true"; "try"; "type"
+  ; "val"; "virtual"; "when"; "while"; "with" ]

--- a/astlib/syntax.mli
+++ b/astlib/syntax.mli
@@ -1,0 +1,1 @@
+val keywords : string list


### PR DESCRIPTION
It probably makes more sense to have it here but it also makes it easier for me to reuse it in ppx_view.

We might want to extract a tiny library for generating valid ocaml ids from strings as that's actually the part I want to share with the cinaps helpers but given how little it is I'm happy to only share the list.