### PR TITLE
Produce valid ids when translating constructors in ppx_view

### DIFF
--- a/ppx_view/lib/expand.ml
+++ b/ppx_view/lib/expand.ml
@@ -49,14 +49,24 @@ let predefined_ident ~loc = function
   | "Not" -> Some (Builder.view_lib_ident ~loc "not")
   | _ -> None
 
+let is_keyword s =
+  List.mem_sorted ~compare:String.compare s Astlib.Syntax.keywords
+
+let ctor_viewer s =
+  let lowercase = String.uncapitalize_ascii s in
+  if is_keyword lowercase then
+    lowercase ^ "_"
+  else
+    lowercase
+
 let translate_ctor_ident ~loc (ident : Longident.concrete) =
   match ident with
   | Lident s ->
     (match predefined_ident ~loc s with
      | Some ident -> ident
-     | None -> Located.lident ~loc (String.uncapitalize_ascii s))
+     | None -> Located.lident ~loc (ctor_viewer s))
   | Ldot (li, s) ->
-    Located.longident ~loc (Longident.ldot li (String.uncapitalize_ascii s))
+    Located.longident ~loc (Longident.ldot li (ctor_viewer s))
   | (Lapply _) as li ->
     Located.longident ~loc (Longident.of_concrete li)
 

--- a/ppx_view/test/test.ml
+++ b/ppx_view/test/test.ml
@@ -320,3 +320,11 @@ let%expect_test "shortcut fields pattern" =
      print_int y
    | _ -> assert false);
   [%expect {|123|}]
+
+let%expect_test "constructor translated to keyword" =
+  let open Viewlib in
+  let virtual_ _ = View.ok in
+  (match%view 1 with
+   | Virtual -> print_string "OK"
+   | _ -> print_string "KO");
+  [%expect {|OK|}]


### PR DESCRIPTION
Depends on #46 

This fixes a bug where ppx_view would translate a constructor to a function with a longident equal to a keyword and therefore that would never work.

E.g.
```
match%view x with
| Virtual -> ...
```
would expect a `virtual` function to be available in the scope, which is impossible.