### PR TITLE
Add ppx_view to the bootstrap runner

### DIFF
--- a/ast/builder.ml
+++ b/ast/builder.ml
@@ -688,4 +688,31 @@ module Common = struct
         (Some (ppat_tuple ~loc [pat; list_pat]))
     in
     List.fold_right exprs ~f:cons ~init:nil
+
+  module Error_ext = struct
+    open Versions
+
+    let extension ~loc msg =
+      let pp fmt = Format.pp_print_string fmt msg in
+      let error = Astlib.Location.Error.make ~loc pp in
+      Conversion.ast_of_extension (Astlib.Location.Error.to_extension error)
+
+    let build_ext : 'node 'a .
+      (loc: Astlib.Location.t -> extension -> 'node) ->
+      loc: Astlib.Location.t ->
+      ('a, unit, string, 'node) format4 ->
+      'a
+      =
+      fun f ~loc fmt -> Format.ksprintf (fun msg -> f ~loc (extension ~loc msg)) fmt
+
+    let no_attr = Attributes.create []
+
+    let exprf ~loc fmt = build_ext pexp_extension ~loc fmt
+    let patf ~loc fmt = build_ext ppat_extension ~loc fmt
+    let typf ~loc fmt = build_ext ptyp_extension ~loc fmt
+    let strif ~loc fmt =
+      build_ext (fun ~loc ext -> pstr_extension ~loc ext no_attr) ~loc fmt
+    let sigif ~loc fmt =
+      build_ext (fun ~loc ext -> psig_extension ~loc ext no_attr) ~loc fmt
+  end
 end

--- a/ast/builder.mli
+++ b/ast/builder.mli
@@ -1423,4 +1423,36 @@ module Common : sig
   val pbool : loc: Astlib.Location.t -> bool -> Versions.pattern
   val pnil : loc: Astlib.Location.t -> Versions.pattern
   val plist : loc: Astlib.Location.t -> Versions.pattern list -> Versions.pattern
+
+  module Error_ext : sig
+    (** Functions to build error as extension points. Each of these functions
+        formats the given error message and returns the extension point for
+        the required context, [exprf] for [expression], [patf] for [pattern],
+        etc. *)
+
+    val exprf :
+      loc:Astlib.Location.t ->
+      ('a, unit, string, Versions.expression) format4 ->
+      'a
+
+    val patf :
+      loc:Astlib.Location.t ->
+      ('a, unit, string, Versions.pattern) format4 ->
+      'a
+
+    val typf :
+      loc:Astlib.Location.t ->
+      ('a, unit, string, Versions.core_type) format4 ->
+      'a
+
+    val strif :
+      loc:Astlib.Location.t ->
+      ('a, unit, string, Versions.structure_item) format4 ->
+      'a
+
+    val sigif :
+      loc:Astlib.Location.t ->
+      ('a, unit, string, Versions.signature_item) format4 ->
+      'a
+  end
 end

--- a/bootstrap/ppx_bootstrap.ml
+++ b/bootstrap/ppx_bootstrap.ml
@@ -1,7 +1,10 @@
 open! Stdppx
+open Ppx_ast.V4_07
 
 module Expected = struct
   exception Expected of Astlib.Location.t * string
+
+  let raise_ ~loc msg = raise (Expected (loc, msg))
 end
 
 module Extension = struct
@@ -14,3 +17,30 @@ module Extension = struct
     | Patt of Ppx_ast.pattern    entry
     | Expr of Ppx_ast.expression entry
 end
+
+let single_signature_item_payload payload =
+  match Payload.to_concrete payload with
+  | None | Some (PStr _ | PTyp _ | PPat _) -> None
+  | Some (PSig signature) ->
+    match Signature.to_concrete signature with
+    | None | Some [] | Some (_ :: _ :: _) -> None
+    | Some [item] -> Some item
+
+let single_structure_item_payload payload =
+  match Payload.to_concrete payload with
+  | None | Some (PSig _ | PTyp _ | PPat _) -> None
+  | Some (PStr structure) ->
+    match Structure.to_concrete structure with
+    | None | Some [] | Some (_ :: _ :: _) -> None
+    | Some [item] -> Some item
+
+let single_expression_payload payload =
+  match single_structure_item_payload payload with
+  | None -> None
+  | Some item ->
+    match Structure_item.to_concrete item with
+    | None -> None
+    | Some item ->
+      match Structure_item_desc.to_concrete item.pstr_desc with
+      | Some Pstr_eval (e, attr) -> Some (e, attr)
+      | Some _ | None -> None

--- a/bootstrap/ppx_bootstrap.mli
+++ b/bootstrap/ppx_bootstrap.mli
@@ -2,6 +2,8 @@ open! Stdppx
 
 module Expected : sig
   exception Expected of Astlib.Location.t * string
+
+  val raise_ : loc: Astlib.Location.t -> string -> 'a
 end
 
 module Extension : sig
@@ -14,3 +16,12 @@ module Extension : sig
     | Patt of Ppx_ast.pattern    entry
     | Expr of Ppx_ast.expression entry
 end
+
+val single_expression_payload :
+  Ppx_ast.payload -> (Ppx_ast.expression * Ppx_ast.attributes) option
+
+val single_structure_item_payload :
+  Ppx_ast.payload -> Ppx_ast.structure_item option
+
+val single_signature_item_payload :
+  Ppx_ast.payload -> Ppx_ast.signature_item option

--- a/bootstrap/runner/dune
+++ b/bootstrap/runner/dune
@@ -4,6 +4,7 @@
   ocaml-compiler-libs.common
   ppx.bootstrap
   ppx_metaquot_expander
+  ppx_view_lib
   stdppx)
  (flags (:standard -safe-string))
  (ppx.driver

--- a/bootstrap/runner/ppx_bootstrap_runner.ml
+++ b/bootstrap/runner/ppx_bootstrap_runner.ml
@@ -36,7 +36,8 @@ module Ppx_view = struct
               Driver.assert_no_attributes attrs;
               Ppx_view_lib.Expand.payload ~loc expr
             | _ ->
-              Ppx_bootstrap.Expected.raise_ ~loc "single-expression payload"
+              Builder.Error_ext.exprf ~loc
+                "Invalid view payload: expected a single expression"
       }
 
   let extensions = [expr]

--- a/bootstrap/test/test_ppx_bootstrap.ml
+++ b/bootstrap/test/test_ppx_bootstrap.ml
@@ -19,3 +19,10 @@ let f_stri = function [%stri let x = 1]                  -> true | _ -> false
 let f_str  = function [%str let x = 1 let y = 2]         -> true | _ -> false
 let f_sigi = function [%sigi: module M : S]              -> true | _ -> false
 let f_sig  = function [%sig: module M : S type t = unit] -> true | _ -> false
+
+(* Ppx_view *)
+let f_view x =
+  let open Ppx_ast.Viewer.V4_07 in
+  match%view x with
+  | Pexp_constraint (expr, core_type) -> Some (expr, core_type)
+  | _ -> None

--- a/bootstrap/test/test_ppx_bootstrap.mli
+++ b/bootstrap/test/test_ppx_bootstrap.mli
@@ -15,3 +15,5 @@ val f_stri : Ppx.structure_item -> bool
 val f_str  : Ppx.structure      -> bool
 val f_sigi : Ppx.signature_item -> bool
 val f_sig  : Ppx.signature      -> bool
+
+val f_view : Ppx_ast.expression -> (Ppx_ast.expression * Ppx_ast.core_type) option

--- a/ppx_view/lib/dune
+++ b/ppx_view/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name ppx_view_lib)
  (public_name ppx._ppx_view_lib)
- (libraries astlib ppx_ast ppx_ast_deprecated stdppx))
+ (libraries astlib ppx_ast stdppx))

--- a/ppx_view/lib/expand.ml
+++ b/ppx_view/lib/expand.ml
@@ -307,9 +307,3 @@ let payload ~loc payload_expr =
     translate_match ~loc ~err_loc:pexp_loc match_cases
   | _ ->
     Error.invalid_payload ~loc:pexp_loc
-
-let parsetree_payload ~loc payload_expr =
-  let loc = Astlib.Location.of_location loc in
-  let astlib_payload_expr = Ppx_ast.Conversion.ast_of_expression payload_expr in
-  let expanded = payload ~loc astlib_payload_expr in
-  Ppx_ast.Conversion.ast_to_expression expanded

--- a/ppx_view/lib/expand.mli
+++ b/ppx_view/lib/expand.mli
@@ -2,8 +2,3 @@ val payload :
   loc: Astlib.Location.t ->
   Ppx_ast.V4_07.Expression.t ->
   Ppx_ast.V4_07.Expression.t
-
-val parsetree_payload :
-  loc: Ocaml_common.Location.t ->
-  Ppx_ast_deprecated.Ast.expression ->
-  Ppx_ast_deprecated.Ast.expression

--- a/ppx_view/lib_deprecated/dune
+++ b/ppx_view/lib_deprecated/dune
@@ -1,0 +1,4 @@
+(library
+ (name ppx_view_lib_deprecated)
+ (public_name ppx._ppx_view_lib_deprecated)
+ (libraries ppx_view_lib ppx_ast_deprecated))

--- a/ppx_view/lib_deprecated/ppx_view_lib_deprecated.ml
+++ b/ppx_view/lib_deprecated/ppx_view_lib_deprecated.ml
@@ -1,0 +1,7 @@
+module Expand = struct
+  let parsetree_payload ~loc payload_expr =
+    let loc = Astlib.Location.of_location loc in
+    let astlib_payload_expr = Ppx_ast.Conversion.ast_of_expression payload_expr in
+    let expanded = Ppx_view_lib.Expand.payload ~loc astlib_payload_expr in
+    Ppx_ast.Conversion.ast_to_expression expanded
+end

--- a/ppx_view/lib_deprecated/ppx_view_lib_deprecated.mli
+++ b/ppx_view/lib_deprecated/ppx_view_lib_deprecated.mli
@@ -1,0 +1,6 @@
+module Expand : sig
+  val parsetree_payload :
+    loc: Ocaml_common.Location.t ->
+    Ppx_ast_deprecated.Ast.expression ->
+    Ppx_ast_deprecated.Ast.expression
+end

--- a/ppx_view/rewriter/dune
+++ b/ppx_view/rewriter/dune
@@ -4,6 +4,6 @@
  (kind ppx_rewriter)
  (libraries
   ppx
-  ppx_view_lib)
+  ppx_view_lib_deprecated)
  (flags :standard -open Ocaml_shadow)
  (ppx_runtime_libraries viewlib))

--- a/ppx_view/rewriter/rewriter.ml
+++ b/ppx_view/rewriter/rewriter.ml
@@ -9,7 +9,7 @@ let extension =
     Ast_pattern.(single_expr_payload __)
     (fun ~ctxt payload ->
        let loc = Expansion_context.Extension.extension_point_loc ctxt in
-       Ppx_view_lib.Expand.parsetree_payload ~loc payload)
+       Ppx_view_lib_deprecated.Expand.parsetree_payload ~loc payload)
 
 let rule = Context_free.Rule.extension extension
 

--- a/ppx_view/test/test_rewriter/dune
+++ b/ppx_view/test/test_rewriter/dune
@@ -3,5 +3,5 @@
  (kind ppx_rewriter)
  (libraries
   ppxlib
-  ppx_view_lib)
+  ppx_view_lib_deprecated)
  (ppx_runtime_libraries viewlib))

--- a/ppx_view/test/test_rewriter/rewriter.ml
+++ b/ppx_view/test/test_rewriter/rewriter.ml
@@ -9,7 +9,7 @@ let extension =
     Ast_pattern.(single_expr_payload __)
     (fun ~ctxt payload ->
        let loc = Expansion_context.Extension.extension_point_loc ctxt in
-       Ppx_view_lib.Expand.parsetree_payload ~loc payload)
+       Ppx_view_lib_deprecated.Expand.parsetree_payload ~loc payload)
 
 let rule = Context_free.Rule.extension extension
 


### PR DESCRIPTION
This adds ppx_view to the bootstrap runner.

I add to go through an extra step to split the OMP dependent parts of `ppx_view_lib` into `ppx_view_lib_deprecated` to avoid linking a conflicting ppx driver and confuse dune.

I also added a bunch of helpers in `Builder` to construct error extension points and used it instead of raising on invalid payloads. Next steps on this front would include doing the same for metaquot and
differentiating invalid payloads from payloads we couldn't convert (ie a `to_concrete` returned `None`).

That second case propably isn't worth going through much trouble since `ppx` and the bootstrap runner will always have to use the latest available versioned API because they traverse — and therefore convert — the whole AST.

You'll also note that I decided to keep `ppx_view` independent from the bootstrap lib, I feel like it shouldn't have to depend on that and that the glue code should live in the bootstrap runner or lib.

Let me know what you think!