### PR TITLE
Update grammar to separate Structural and Nominal cases.

### DIFF
--- a/ast/builder.ml
+++ b/ast/builder.ml
@@ -607,9 +607,7 @@ module Common = struct
   open Versions.V4_07
 
   module Located = struct
-    let longident ~loc longident =
-      Longident_loc.create (Astlib.Loc.create ~loc ~txt:longident ())
-
+    let longident ~loc longident = Astlib.Loc.create ~loc ~txt:longident ()
     let lident ~loc x = longident ~loc (Longident.lident x)
   end
 

--- a/ast/builder.mli
+++ b/ast/builder.mli
@@ -1390,8 +1390,9 @@ end
 
 module Common : sig
   module Located : sig
-    val longident : loc: Astlib.Location.t -> Versions.longident -> Versions.longident_loc
-    val lident : loc: Astlib.Location.t -> string -> Versions.longident_loc
+    val longident
+      : loc: Astlib.Location.t -> Versions.longident -> Versions.longident Astlib.Loc.t
+    val lident : loc: Astlib.Location.t -> string -> Versions.longident Astlib.Loc.t
   end
 
   val echar : loc: Astlib.Location.t -> char -> Versions.expression

--- a/ast/cinaps/gen_builder.ml
+++ b/ast/cinaps/gen_builder.ml
@@ -263,13 +263,16 @@ let builders name (grammar : Astlib.Grammar.kind) shortcut =
   | Poly (_, _) -> []
   | Mono decl ->
     match decl with
-    | Alias _ -> []
-    | Record r ->
-      begin match Builder.of_record name r shortcut with
-      | None -> []
-      | Some r -> [r]
-      end
-    | Variant v -> Builder.of_variant name v shortcut
+    | Structural _ -> []
+    | Nominal nominal ->
+      match nominal with
+      | Wrapper _ -> []
+      | Record r ->
+        begin match Builder.of_record name r shortcut with
+        | None -> []
+        | Some r -> [r]
+        end
+      | Variant v -> Builder.of_variant name v shortcut
 
 let print_builder_ml () =
   Print.newline ();

--- a/ast/cinaps/gen_builder.ml
+++ b/ast/cinaps/gen_builder.ml
@@ -263,9 +263,9 @@ let builders name (grammar : Astlib.Grammar.kind) shortcut =
   | Poly (_, _) -> []
   | Mono decl ->
     match decl with
-    | Structural _ -> []
-    | Nominal nominal ->
-      match nominal with
+    | Unversioned _ -> []
+    | Versioned versioned ->
+      match versioned with
       | Wrapper _ -> []
       | Record r ->
         begin match Builder.of_record name r shortcut with

--- a/ast/cinaps/gen_conversion.ml
+++ b/ast/cinaps/gen_conversion.ml
@@ -160,10 +160,10 @@ let output_ty ty ~conv =
 
 let tuple_var i = Ml.id (Printf.sprintf "x%d" (i + 1))
 
-let define_conversion nominal ~node_name ~env ~conv =
+let define_conversion versioned ~node_name ~env ~conv =
   let name = Name.make [concrete_prefix ~conv; node_name] (Poly_env.args env) in
   let node_ty = node_ty ~node_name ~env in
-  match (nominal : Astlib.Grammar.nominal) with
+  match (versioned : Astlib.Grammar.versioned) with
   | Wrapper ty ->
     Print.println "and %s x =" name;
     Print.indented (fun () ->
@@ -223,7 +223,7 @@ let define_conversion nominal ~node_name ~env ~conv =
 
 let print_conversion_impl decl ~node_name ~env ~is_initial =
   match (decl : Astlib.Grammar.decl) with
-  | Structural ty ->
+  | Unversioned ty ->
     Print.println
       "%s %s x ="
       (if is_initial then "let rec" else "and")
@@ -238,7 +238,7 @@ let print_conversion_impl decl ~node_name ~env ~is_initial =
     Print.indented (fun () ->
       Print.println "%s x"
         (fn_value (ty_conversion ~conv:`concrete_to (Poly_env.subst_ty ty ~env))))
-  | Nominal nominal ->
+  | Versioned versioned ->
     Print.println
       "%s %s x ="
       (if is_initial then "let rec" else "and")
@@ -250,7 +250,7 @@ let print_conversion_impl decl ~node_name ~env ~is_initial =
         "of_concrete"
         (Name.make ["concrete_of"; node_name] (Poly_env.args env)));
     Print.newline ();
-    define_conversion nominal ~node_name ~env ~conv:`concrete_of;
+    define_conversion versioned ~node_name ~env ~conv:`concrete_of;
     Print.newline ();
     Print.println "and %s x =" (Name.make ["ast_to"; node_name] (Poly_env.args env));
     Print.indented (fun () ->
@@ -269,7 +269,7 @@ let print_conversion_impl decl ~node_name ~env ~is_initial =
       Print.println "%s concrete"
         (Name.make ["concrete_to"; node_name] (Poly_env.args env)));
     Print.newline ();
-    define_conversion nominal ~node_name ~env ~conv:`concrete_to
+    define_conversion versioned ~node_name ~env ~conv:`concrete_to
 
 let print_conversion_mli () =
   let grammar = Astlib.History.find_grammar Astlib.history ~version in

--- a/ast/cinaps/gen_traverse.ml
+++ b/ast/cinaps/gen_traverse.ml
@@ -203,10 +203,10 @@ let print_method_body
       ~targs
       ~node_name
       ~var
-      (nominal : Astlib.Grammar.nominal)
+      (versioned : Astlib.Grammar.versioned)
   =
   let value_kind = Ast_type {node_name; targs} in
-  match nominal with
+  match versioned with
   | Wrapper ty -> print_method_for_alias ~traversal ~value_kind ~var ty
   | Record fields ->
     let deconstructed = deconstruct_record ~traversal fields in
@@ -482,13 +482,13 @@ let print_to_concrete node_name =
 let print_method_value ~traversal ~targs ~node_name decl =
   let args = traversal.args (Ml.id node_name) in
   match (decl : Astlib.Grammar.decl) with
-  | Structural ty ->
+  | Unversioned ty ->
     Ml.define_anon_fun ~args (fun () ->
       print_method_for_alias ~traversal ~value_kind:Abstract ~var:node_name ty)
-  | Nominal nominal ->
+  | Versioned versioned ->
     Ml.define_anon_fun ~args (fun () ->
       print_to_concrete node_name;
-      print_method_body ~traversal ~targs ~node_name ~var:"concrete" nominal)
+      print_method_body ~traversal ~targs ~node_name ~var:"concrete" versioned)
 
 let declare_node_methods ~env_table ~signature (node_name, kind) =
   match (kind : Astlib.Grammar.kind) with

--- a/ast/cinaps/gen_viewer.ml
+++ b/ast/cinaps/gen_viewer.ml
@@ -142,18 +142,18 @@ let print_viewer ~what ~shortcuts (name, kind) =
     | Poly (targs, decl) -> (targs, decl)
   in
   match targs, decl with
-  | [], Nominal (Variant variants) ->
+  | [], Versioned (Variant variants) ->
     let shortcut = Shortcut.Map.find shortcuts name in
     List.iter variants ~f:(M.print_variant_viewer ~name ~shortcut)
-  | _, Nominal (Variant _) ->
+  | _, Versioned (Variant _) ->
     (* There are no polymorphic variant types in the AST atm. If some are
        added we'll need to handle a few things, including properly generating
        fresh type variables for the input and output type varibales in the
        [View.t] types for empty variants. *)
     assert false
-  | _, Nominal (Record fields) ->
+  | _, Versioned (Record fields) ->
     List.iter fields ~f:(M.print_field_viewer ~targs ~name)
-  | _, (Structural _ | Nominal (Wrapper _)) ->
+  | _, (Unversioned _ | Versioned (Wrapper _)) ->
     ()
 
 let print_viewer_ml () =

--- a/ast/cinaps/gen_viewer.ml
+++ b/ast/cinaps/gen_viewer.ml
@@ -142,18 +142,18 @@ let print_viewer ~what ~shortcuts (name, kind) =
     | Poly (targs, decl) -> (targs, decl)
   in
   match targs, decl with
-  | [], Variant variants ->
+  | [], Nominal (Variant variants) ->
     let shortcut = Shortcut.Map.find shortcuts name in
     List.iter variants ~f:(M.print_variant_viewer ~name ~shortcut)
-  | _, Variant _ ->
+  | _, Nominal (Variant _) ->
     (* There are no polymorphic variant types in the AST atm. If some are
        added we'll need to handle a few things, including properly generating
        fresh type variables for the input and output type varibales in the
        [View.t] types for empty variants. *)
     assert false
-  | _, Record fields ->
+  | _, Nominal (Record fields) ->
     List.iter fields ~f:(M.print_field_viewer ~targs ~name)
-  | _, Alias _ ->
+  | _, (Structural _ | Nominal (Wrapper _)) ->
     ()
 
 let print_viewer_ml () =

--- a/ast/cinaps/poly_env.ml
+++ b/ast/cinaps/poly_env.ml
@@ -78,9 +78,9 @@ let subst_clause ~env clause =
 let subst_variants variants ~env =
   List.map variants ~f:(fun (cname, clause) -> (cname, subst_clause ~env clause))
 
-let subst_nominal nominal ~env =
+let subst_versioned versioned ~env =
   let open Astlib.Grammar in
-  match nominal with
+  match versioned with
   | Wrapper ty -> Wrapper (subst_ty ~env ty)
   | Record fields -> Record (subst_fields ~env fields)
   | Variant variants -> Variant (subst_variants ~env variants)
@@ -88,8 +88,8 @@ let subst_nominal nominal ~env =
 let subst_decl decl ~env =
   let open Astlib.Grammar in
   match decl with
-  | Structural ty -> Structural (subst_ty ~env ty)
-  | Nominal nominal -> Nominal (subst_nominal ~env nominal)
+  | Unversioned ty -> Unversioned (subst_ty ~env ty)
+  | Versioned versioned -> Versioned (subst_versioned ~env versioned)
 
 let rec ty_instances ty =
   match (ty : Astlib.Grammar.ty) with
@@ -113,16 +113,16 @@ let clause_instances clause =
 let variant_instances variant =
   List.concat (List.map variant ~f:(fun (_, clause) -> clause_instances clause))
 
-let nominal_instances nominal =
-  match (nominal : Astlib.Grammar.nominal) with
+let versioned_instances versioned =
+  match (versioned : Astlib.Grammar.versioned) with
   | Wrapper ty -> ty_instances ty
   | Record record -> record_instances record
   | Variant variant -> variant_instances variant
 
 let decl_instances decl =
   match (decl : Astlib.Grammar.decl) with
-  | Structural ty -> ty_instances ty
-  | Nominal nominal -> nominal_instances nominal
+  | Unversioned ty -> ty_instances ty
+  | Versioned versioned -> versioned_instances versioned
 
 let rec transitive_instances decl ~grammar_table =
   let instances = decl_instances decl in

--- a/ast/cinaps/poly_env.mli
+++ b/ast/cinaps/poly_env.mli
@@ -4,6 +4,8 @@ type env_table
 val env_table : Astlib.Grammar.t -> env_table
 val find : env_table -> string -> env list
 
+val create : vars:string list -> args:Astlib.Grammar.ty list -> env
+
 val empty_env : env
 val env_is_empty : env -> bool
 

--- a/ast/cinaps/shortcut.ml
+++ b/ast/cinaps/shortcut.ml
@@ -65,8 +65,8 @@ module Map = struct
         | Poly (_, _) -> acc
         | Mono decl ->
           match decl with
-          | Structural _ | Nominal (Wrapper _ | Variant _) -> acc
-          | Nominal (Record record) ->
+          | Unversioned _ | Versioned (Wrapper _ | Variant _) -> acc
+          | Versioned (Record record) ->
             match from_record ~name record with
             | None -> acc
             | Some ({outter_record; inner_variant; _} as shortcut) ->

--- a/ast/cinaps/shortcut.ml
+++ b/ast/cinaps/shortcut.ml
@@ -65,9 +65,8 @@ module Map = struct
         | Poly (_, _) -> acc
         | Mono decl ->
           match decl with
-          | Alias _
-          | Variant _ -> acc
-          | Record record ->
+          | Structural _ | Nominal (Wrapper _ | Variant _) -> acc
+          | Nominal (Record record) ->
             match from_record ~name record with
             | None -> acc
             | Some ({outter_record; inner_variant; _} as shortcut) ->

--- a/ast/conversion.ml
+++ b/ast/conversion.ml
@@ -63,20 +63,9 @@ and concrete_to_longident x : Compiler_types.longident =
     Lapply (x1, x2)
 
 and ast_of_longident_loc x =
-  Versions.V4_07.Longident_loc.of_concrete (concrete_of_longident_loc x)
-
-and concrete_of_longident_loc x =
   (Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_longident) Astlib.Loc.of_loc) x
 
 and ast_to_longident_loc x =
-  let option = Versions.V4_07.Longident_loc.to_concrete x in
-  let concrete =
-    Helpers.Option.value_exn option
-      ~message:"concrete_to_longident_loc: conversion failed"
-  in
-  concrete_to_longident_loc concrete
-
-and concrete_to_longident_loc x =
   (Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_longident)) x
 
 and ast_of_rec_flag x =
@@ -227,20 +216,9 @@ and concrete_to_closed_flag x : Compiler_types.closed_flag =
   | Open -> Open
 
 and ast_of_label x =
-  Versions.V4_07.Label.of_concrete (concrete_of_label x)
-
-and concrete_of_label x =
   Helpers.Fn.id x
 
 and ast_to_label x =
-  let option = Versions.V4_07.Label.to_concrete x in
-  let concrete =
-    Helpers.Option.value_exn option
-      ~message:"concrete_to_label: conversion failed"
-  in
-  concrete_to_label concrete
-
-and concrete_to_label x =
   Helpers.Fn.id x
 
 and ast_of_arg_label x =
@@ -1681,37 +1659,15 @@ and concrete_to_class_infos_class_type
   ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Compiler_types.class_type Compiler_types.class_infos)
 
 and ast_of_class_description x =
-  Versions.V4_07.Class_description.of_concrete (concrete_of_class_description x)
-
-and concrete_of_class_description x =
   ast_of_class_infos_class_type x
 
 and ast_to_class_description x =
-  let option = Versions.V4_07.Class_description.to_concrete x in
-  let concrete =
-    Helpers.Option.value_exn option
-      ~message:"concrete_to_class_description: conversion failed"
-  in
-  concrete_to_class_description concrete
-
-and concrete_to_class_description x =
   ast_to_class_infos_class_type x
 
 and ast_of_class_type_declaration x =
-  Versions.V4_07.Class_type_declaration.of_concrete (concrete_of_class_type_declaration x)
-
-and concrete_of_class_type_declaration x =
   ast_of_class_infos_class_type x
 
 and ast_to_class_type_declaration x =
-  let option = Versions.V4_07.Class_type_declaration.to_concrete x in
-  let concrete =
-    Helpers.Option.value_exn option
-      ~message:"concrete_to_class_type_declaration: conversion failed"
-  in
-  concrete_to_class_type_declaration concrete
-
-and concrete_to_class_type_declaration x =
   ast_to_class_infos_class_type x
 
 and ast_of_class_expr x =
@@ -1973,20 +1929,9 @@ and concrete_to_class_field_kind x : Compiler_types.class_field_kind =
     Cfk_concrete (x1, x2)
 
 and ast_of_class_declaration x =
-  Versions.V4_07.Class_declaration.of_concrete (concrete_of_class_declaration x)
-
-and concrete_of_class_declaration x =
   ast_of_class_infos_class_expr x
 
 and ast_to_class_declaration x =
-  let option = Versions.V4_07.Class_declaration.to_concrete x in
-  let concrete =
-    Helpers.Option.value_exn option
-      ~message:"concrete_to_class_declaration: conversion failed"
-  in
-  concrete_to_class_declaration concrete
-
-and concrete_to_class_declaration x =
   ast_to_class_infos_class_expr x
 
 and ast_of_module_type x =
@@ -2364,37 +2309,15 @@ and concrete_to_include_infos_module_type
   ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_type Compiler_types.include_infos)
 
 and ast_of_include_description x =
-  Versions.V4_07.Include_description.of_concrete (concrete_of_include_description x)
-
-and concrete_of_include_description x =
   ast_of_include_infos_module_type x
 
 and ast_to_include_description x =
-  let option = Versions.V4_07.Include_description.to_concrete x in
-  let concrete =
-    Helpers.Option.value_exn option
-      ~message:"concrete_to_include_description: conversion failed"
-  in
-  concrete_to_include_description concrete
-
-and concrete_to_include_description x =
   ast_to_include_infos_module_type x
 
 and ast_of_include_declaration x =
-  Versions.V4_07.Include_declaration.of_concrete (concrete_of_include_declaration x)
-
-and concrete_of_include_declaration x =
   ast_of_include_infos_module_expr x
 
 and ast_to_include_declaration x =
-  let option = Versions.V4_07.Include_declaration.to_concrete x in
-  let concrete =
-    Helpers.Option.value_exn option
-      ~message:"concrete_to_include_declaration: conversion failed"
-  in
-  concrete_to_include_declaration concrete
-
-and concrete_to_include_declaration x =
   ast_to_include_infos_module_expr x
 
 and ast_of_with_constraint x =

--- a/ast/test/cinaps/ppx_ast_tests_cinaps.ml
+++ b/ast/test/cinaps/ppx_ast_tests_cinaps.ml
@@ -46,11 +46,11 @@ let print_deriving_type decl ~index ~name ~tvars =
     (Ml.poly_type name ~tvars);
   Print.indented (fun () ->
     match (decl : Astlib.Grammar.decl) with
-    | Structural ty | Nominal (Wrapper ty) -> Print.println "%s" (string_of_ty ty)
-    | Nominal (Record record) ->
+    | Unversioned ty | Versioned (Wrapper ty) -> Print.println "%s" (string_of_ty ty)
+    | Versioned (Record record) ->
       Print.println "%s =" (Ml.poly_type ("Compiler_types." ^ name) ~tvars);
       Ml.print_record_type record ~f:string_of_ty
-    | Nominal (Variant variant) ->
+    | Versioned (Variant variant) ->
       Print.println "%s =" (Ml.poly_type ("Compiler_types." ^ name) ~tvars);
       Ml.print_variant_type variant ~f:(fun clause ->
         match (clause : Astlib.Grammar.clause) with
@@ -135,10 +135,10 @@ let print_quickcheck_generator decl ~index ~name ~tvars =
   Print.indented (fun () ->
     let gen_id name = Ml.id ("gen_" ^ name) in
     match (decl : Astlib.Grammar.decl) with
-    | Structural ty | Nominal (Wrapper ty) ->
+    | Unversioned ty | Versioned (Wrapper ty) ->
       Print.println "let gen = %s in" (generator_string ty);
       Print.println "Generator.generate gen ~size ~random"
-    | Nominal (Record record) ->
+    | Versioned (Record record) ->
       List.iteri record ~f:(fun index (field, ty) ->
         Print.println "%s %s = %s"
           (if index = 0 then "let" else "and")
@@ -151,7 +151,7 @@ let print_quickcheck_generator decl ~index ~name ~tvars =
           (Ml.id field)
           (Ml.id field));
       Print.println "}"
-    | Nominal (Variant variant) ->
+    | Versioned (Variant variant) ->
       List.iteri variant ~f:(fun index (tag, clause) ->
         Print.println "%s %s =" (if index = 0 then "let" else "and") (gen_id tag);
         Print.indented (fun () ->

--- a/ast/test/cinaps/ppx_ast_tests_cinaps.ml
+++ b/ast/test/cinaps/ppx_ast_tests_cinaps.ml
@@ -46,11 +46,11 @@ let print_deriving_type decl ~index ~name ~tvars =
     (Ml.poly_type name ~tvars);
   Print.indented (fun () ->
     match (decl : Astlib.Grammar.decl) with
-    | Alias ty -> Print.println "%s" (string_of_ty ty)
-    | Record record ->
+    | Structural ty | Nominal (Wrapper ty) -> Print.println "%s" (string_of_ty ty)
+    | Nominal (Record record) ->
       Print.println "%s =" (Ml.poly_type ("Compiler_types." ^ name) ~tvars);
       Ml.print_record_type record ~f:string_of_ty
-    | Variant variant ->
+    | Nominal (Variant variant) ->
       Print.println "%s =" (Ml.poly_type ("Compiler_types." ^ name) ~tvars);
       Ml.print_variant_type variant ~f:(fun clause ->
         match (clause : Astlib.Grammar.clause) with
@@ -135,10 +135,10 @@ let print_quickcheck_generator decl ~index ~name ~tvars =
   Print.indented (fun () ->
     let gen_id name = Ml.id ("gen_" ^ name) in
     match (decl : Astlib.Grammar.decl) with
-    | Alias ty ->
+    | Structural ty | Nominal (Wrapper ty) ->
       Print.println "let gen = %s in" (generator_string ty);
       Print.println "Generator.generate gen ~size ~random"
-    | Record record ->
+    | Nominal (Record record) ->
       List.iteri record ~f:(fun index (field, ty) ->
         Print.println "%s %s = %s"
           (if index = 0 then "let" else "and")
@@ -151,7 +151,7 @@ let print_quickcheck_generator decl ~index ~name ~tvars =
           (Ml.id field)
           (Ml.id field));
       Print.println "}"
-    | Variant variant ->
+    | Nominal (Variant variant) ->
       List.iteri variant ~f:(fun index (tag, clause) ->
         Print.println "%s %s =" (if index = 0 then "let" else "and") (gen_id tag);
         Print.indented (fun () ->

--- a/ast/versions.ml
+++ b/ast/versions.ml
@@ -13,8 +13,6 @@ type arg_label_
 type attribute_
 type attributes_
 type case_
-type class_declaration_
-type class_description_
 type class_expr_
 type class_expr_desc_
 type class_field_
@@ -24,7 +22,6 @@ type 'a class_infos_
 type class_signature_
 type class_structure_
 type class_type_
-type class_type_declaration_
 type class_type_desc_
 type class_type_field_
 type class_type_field_desc_
@@ -41,13 +38,9 @@ type expression_desc_
 type extension_
 type extension_constructor_
 type extension_constructor_kind_
-type include_declaration_
-type include_description_
 type 'a include_infos_
-type label_
 type label_declaration_
 type longident_
-type longident_loc_
 type module_binding_
 type module_declaration_
 type module_expr_
@@ -86,8 +79,6 @@ type arg_label = arg_label_ node
 type attribute = attribute_ node
 type attributes = attributes_ node
 type case = case_ node
-type class_declaration = class_declaration_ node
-type class_description = class_description_ node
 type class_expr = class_expr_ node
 type class_expr_desc = class_expr_desc_ node
 type class_field = class_field_ node
@@ -97,7 +88,6 @@ type 'a class_infos = 'a class_infos_ node
 type class_signature = class_signature_ node
 type class_structure = class_structure_ node
 type class_type = class_type_ node
-type class_type_declaration = class_type_declaration_ node
 type class_type_desc = class_type_desc_ node
 type class_type_field = class_type_field_ node
 type class_type_field_desc = class_type_field_desc_ node
@@ -114,13 +104,9 @@ type expression_desc = expression_desc_ node
 type extension = extension_ node
 type extension_constructor = extension_constructor_ node
 type extension_constructor_kind = extension_constructor_kind_ node
-type include_declaration = include_declaration_ node
-type include_description = include_description_ node
 type 'a include_infos = 'a include_infos_ node
-type label = label_ node
 type label_declaration = label_declaration_ node
 type longident = longident_ node
-type longident_loc = longident_loc_ node
 type module_binding = module_binding_ node
 type module_declaration = module_declaration_ node
 type module_expr = module_expr_ node
@@ -154,6 +140,14 @@ type value_description = value_description_ node
 type variance = variance_ node
 type virtual_flag = virtual_flag_ node
 type with_constraint = with_constraint_ node
+
+type class_declaration = class_expr class_infos
+type class_description = class_type class_infos
+type class_type_declaration = class_type class_infos
+type include_declaration = module_expr include_infos
+type include_description = module_type include_infos
+type label = string
+type longident_loc = longident Astlib.Loc.t
 
 module Unstable_for_testing = struct
   let version = "unstable-for-testing"
@@ -739,7 +733,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pmod_ident"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
 
@@ -794,7 +788,7 @@ module Unstable_for_testing = struct
               Some (Pmod_structure (x1))
             )
           | Variant { tag = "Pmod_ident"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pmod_ident (x1))
             )
         | _ -> None
@@ -850,8 +844,8 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pwith_modsubst"
           ; args =
-            [| Data.of_node x1
-             ; Data.of_node x2
+            [| (Data.of_loc ~f:Data.of_node) x1
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let pwith_typesubst x1 x2 =
@@ -860,7 +854,7 @@ module Unstable_for_testing = struct
           { tag = "Pwith_typesubst"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let pwith_module x1 x2 =
@@ -868,8 +862,8 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pwith_module"
           ; args =
-            [| Data.of_node x1
-             ; Data.of_node x2
+            [| (Data.of_loc ~f:Data.of_node) x1
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let pwith_type x1 x2 =
@@ -878,7 +872,7 @@ module Unstable_for_testing = struct
           { tag = "Pwith_type"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
 
@@ -899,23 +893,23 @@ module Unstable_for_testing = struct
         begin
           match data with
           | Variant { tag = "Pwith_modsubst"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pwith_modsubst (x1, x2))
             ))
           | Variant { tag = "Pwith_typesubst"; args = [| x1; x2 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pwith_typesubst (x1, x2))
             ))
           | Variant { tag = "Pwith_module"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pwith_module (x1, x2))
             ))
           | Variant { tag = "Pwith_type"; args = [| x1; x2 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pwith_type (x1, x2))
             ))
         | _ -> None
@@ -924,37 +918,11 @@ module Unstable_for_testing = struct
   end
 
   module Include_declaration = struct
-    type t = include_declaration
-
-    type concrete = module_expr include_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "include_declaration" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "include_declaration"; data } -> Data.to_node data
-      | _ -> None
+    type t = module_expr include_infos
   end
 
   module Include_description = struct
-    type t = include_description
-
-    type concrete = module_type include_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "include_description" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "include_description"; data } -> Data.to_node data
-      | _ -> None
+    type t = module_type include_infos
   end
 
   module Include_infos = struct
@@ -1006,7 +974,7 @@ module Unstable_for_testing = struct
         [| Data.of_node popen_attributes
          ; Data.of_location popen_loc
          ; Data.of_node popen_override
-         ; Data.of_node popen_lid
+         ; (Data.of_loc ~f:Data.of_node) popen_lid
         |]
       in
       node "open_description" (Record fields)
@@ -1022,7 +990,7 @@ module Unstable_for_testing = struct
           Helpers.Option.bind (Data.to_node popen_attributes) ~f:(fun popen_attributes ->
             Helpers.Option.bind (Data.to_location popen_loc) ~f:(fun popen_loc ->
               Helpers.Option.bind (Data.to_node popen_override) ~f:(fun popen_override ->
-                Helpers.Option.bind (Data.to_node popen_lid) ~f:(fun popen_lid ->
+                Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) popen_lid) ~f:(fun popen_lid ->
                   Some { popen_attributes; popen_loc; popen_override; popen_lid }
           ))))
       | _ -> None
@@ -1385,7 +1353,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pmty_alias"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
     let pmty_extension x1 =
@@ -1436,7 +1404,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pmty_ident"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
 
@@ -1463,7 +1431,7 @@ module Unstable_for_testing = struct
         begin
           match data with
           | Variant { tag = "Pmty_alias"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pmty_alias (x1))
             )
           | Variant { tag = "Pmty_extension"; args = [| x1 |] } ->
@@ -1490,7 +1458,7 @@ module Unstable_for_testing = struct
               Some (Pmty_signature (x1))
             )
           | Variant { tag = "Pmty_ident"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pmty_ident (x1))
             )
         | _ -> None
@@ -1533,20 +1501,7 @@ module Unstable_for_testing = struct
   end
 
   module Class_declaration = struct
-    type t = class_declaration
-
-    type concrete = class_expr class_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "class_declaration" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "class_declaration"; data } -> Data.to_node data
-      | _ -> None
+    type t = class_expr class_infos
   end
 
   module Class_field_kind = struct
@@ -1649,7 +1604,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pcf_method"
           ; args =
-            [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_node)) x1
+            [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_string)) x1
             |]
           })
     let pcf_val x1 =
@@ -1657,7 +1612,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pcf_val"
           ; args =
-            [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_node)) x1
+            [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_string)) x1
             |]
           })
     let pcf_inherit x1 x2 x3 =
@@ -1710,11 +1665,11 @@ module Unstable_for_testing = struct
               Some (Pcf_constraint (x1))
             )
           | Variant { tag = "Pcf_method"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
               Some (Pcf_method (x1))
             )
           | Variant { tag = "Pcf_val"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
               Some (Pcf_val (x1))
             )
           | Variant { tag = "Pcf_inherit"; args = [| x1; x2; x3 |] } ->
@@ -1812,7 +1767,7 @@ module Unstable_for_testing = struct
           { tag = "Pcl_open"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
              ; Data.of_node x3
             |]
           })
@@ -1877,7 +1832,7 @@ module Unstable_for_testing = struct
           { tag = "Pcl_constr"
           ; args =
             [| (Data.of_list ~f:Data.of_node) x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
 
@@ -1907,7 +1862,7 @@ module Unstable_for_testing = struct
           match data with
           | Variant { tag = "Pcl_open"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
                   Some (Pcl_open (x1, x2, x3))
             )))
@@ -1944,7 +1899,7 @@ module Unstable_for_testing = struct
             )
           | Variant { tag = "Pcl_constr"; args = [| x1; x2 |] } ->
             Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pcl_constr (x1, x2))
             ))
         | _ -> None
@@ -1987,37 +1942,11 @@ module Unstable_for_testing = struct
   end
 
   module Class_type_declaration = struct
-    type t = class_type_declaration
-
-    type concrete = class_type class_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "class_type_declaration" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "class_type_declaration"; data } -> Data.to_node data
-      | _ -> None
+    type t = class_type class_infos
   end
 
   module Class_description = struct
-    type t = class_description
-
-    type concrete = class_type class_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "class_description" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "class_description"; data } -> Data.to_node data
-      | _ -> None
+    type t = class_type class_infos
   end
 
   module Class_infos = struct
@@ -2103,7 +2032,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pctf_method"
           ; args =
-            [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_node)) x1
+            [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_string)) x1
             |]
           })
     let pctf_val x1 =
@@ -2111,7 +2040,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pctf_val"
           ; args =
-            [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_node)) x1
+            [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_string)) x1
             |]
           })
     let pctf_inherit x1 =
@@ -2156,11 +2085,11 @@ module Unstable_for_testing = struct
               Some (Pctf_constraint (x1))
             )
           | Variant { tag = "Pctf_method"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
               Some (Pctf_method (x1))
             )
           | Variant { tag = "Pctf_val"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
               Some (Pctf_val (x1))
             )
           | Variant { tag = "Pctf_inherit"; args = [| x1 |] } ->
@@ -2253,7 +2182,7 @@ module Unstable_for_testing = struct
           { tag = "Pcty_open"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
              ; Data.of_node x3
             |]
           })
@@ -2289,7 +2218,7 @@ module Unstable_for_testing = struct
           { tag = "Pcty_constr"
           ; args =
             [| (Data.of_list ~f:Data.of_node) x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
 
@@ -2313,7 +2242,7 @@ module Unstable_for_testing = struct
           match data with
           | Variant { tag = "Pcty_open"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
                   Some (Pcty_open (x1, x2, x3))
             )))
@@ -2333,7 +2262,7 @@ module Unstable_for_testing = struct
             )
           | Variant { tag = "Pcty_constr"; args = [| x1; x2 |] } ->
             Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pcty_constr (x1, x2))
             ))
         | _ -> None
@@ -2387,7 +2316,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pext_rebind"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
     let pext_decl x1 x2 =
@@ -2413,7 +2342,7 @@ module Unstable_for_testing = struct
         begin
           match data with
           | Variant { tag = "Pext_rebind"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pext_rebind (x1))
             )
           | Variant { tag = "Pext_decl"; args = [| x1; x2 |] } ->
@@ -2480,7 +2409,7 @@ module Unstable_for_testing = struct
          ; Data.of_node ptyext_private
          ; (Data.of_list ~f:Data.of_node) ptyext_constructors
          ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) ptyext_params
-         ; Data.of_node ptyext_path
+         ; (Data.of_loc ~f:Data.of_node) ptyext_path
         |]
       in
       node "type_extension" (Record fields)
@@ -2497,7 +2426,7 @@ module Unstable_for_testing = struct
             Helpers.Option.bind (Data.to_node ptyext_private) ~f:(fun ptyext_private ->
               Helpers.Option.bind ((Data.to_list ~f:Data.to_node) ptyext_constructors) ~f:(fun ptyext_constructors ->
                 Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) ptyext_params) ~f:(fun ptyext_params ->
-                  Helpers.Option.bind (Data.to_node ptyext_path) ~f:(fun ptyext_path ->
+                  Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) ptyext_path) ~f:(fun ptyext_path ->
                     Some { ptyext_attributes; ptyext_private; ptyext_constructors; ptyext_params; ptyext_path }
           )))))
       | _ -> None
@@ -2871,7 +2800,7 @@ module Unstable_for_testing = struct
           { tag = "Pexp_open"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
              ; Data.of_node x3
             |]
           })
@@ -2949,7 +2878,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pexp_override"
           ; args =
-            [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_node))) x1
+            [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_string))) x1
             |]
           })
     let pexp_setinstvar x1 x2 =
@@ -2958,7 +2887,7 @@ module Unstable_for_testing = struct
           { tag = "Pexp_setinstvar"
           ; args =
             [| Data.of_node x1
-             ; (Data.of_loc ~f:Data.of_node) x2
+             ; (Data.of_loc ~f:Data.of_string) x2
             |]
           })
     let pexp_new x1 =
@@ -2966,7 +2895,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pexp_new"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
     let pexp_send x1 x2 =
@@ -2974,7 +2903,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pexp_send"
           ; args =
-            [| (Data.of_loc ~f:Data.of_node) x1
+            [| (Data.of_loc ~f:Data.of_string) x1
              ; Data.of_node x2
             |]
           })
@@ -3051,7 +2980,7 @@ module Unstable_for_testing = struct
           { tag = "Pexp_setfield"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
              ; Data.of_node x3
             |]
           })
@@ -3060,7 +2989,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pexp_field"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; Data.of_node x2
             |]
           })
@@ -3070,7 +2999,7 @@ module Unstable_for_testing = struct
           { tag = "Pexp_record"
           ; args =
             [| (Data.of_option ~f:Data.of_node) x1
-             ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) x2
+             ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_node))) x2
             |]
           })
     let pexp_variant x1 x2 =
@@ -3079,7 +3008,7 @@ module Unstable_for_testing = struct
           { tag = "Pexp_variant"
           ; args =
             [| (Data.of_option ~f:Data.of_node) x1
-             ; Data.of_node x2
+             ; Data.of_string x2
             |]
           })
     let pexp_construct x1 x2 =
@@ -3088,7 +3017,7 @@ module Unstable_for_testing = struct
           { tag = "Pexp_construct"
           ; args =
             [| (Data.of_option ~f:Data.of_node) x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let pexp_tuple x1 =
@@ -3168,7 +3097,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Pexp_ident"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
 
@@ -3258,7 +3187,7 @@ module Unstable_for_testing = struct
             )
           | Variant { tag = "Pexp_open"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
                   Some (Pexp_open (x1, x2, x3))
             )))
@@ -3300,20 +3229,20 @@ module Unstable_for_testing = struct
                   Some (Pexp_letmodule (x1, x2, x3))
             )))
           | Variant { tag = "Pexp_override"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_node))) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_string))) x1) ~f:(fun x1 ->
               Some (Pexp_override (x1))
             )
           | Variant { tag = "Pexp_setinstvar"; args = [| x1; x2 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_string) x2) ~f:(fun x2 ->
                 Some (Pexp_setinstvar (x1, x2))
             ))
           | Variant { tag = "Pexp_new"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pexp_new (x1))
             )
           | Variant { tag = "Pexp_send"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_string) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Some (Pexp_send (x1, x2))
             ))
@@ -3358,28 +3287,28 @@ module Unstable_for_testing = struct
             )
           | Variant { tag = "Pexp_setfield"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
                   Some (Pexp_setfield (x1, x2, x3))
             )))
           | Variant { tag = "Pexp_field"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Some (Pexp_field (x1, x2))
             ))
           | Variant { tag = "Pexp_record"; args = [| x1; x2 |] } ->
             Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-              Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_node))) x2) ~f:(fun x2 ->
                 Some (Pexp_record (x1, x2))
             ))
           | Variant { tag = "Pexp_variant"; args = [| x1; x2 |] } ->
             Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind (Data.to_string x2) ~f:(fun x2 ->
                 Some (Pexp_variant (x1, x2))
             ))
           | Variant { tag = "Pexp_construct"; args = [| x1; x2 |] } ->
             Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pexp_construct (x1, x2))
             ))
           | Variant { tag = "Pexp_tuple"; args = [| x1 |] } ->
@@ -3423,7 +3352,7 @@ module Unstable_for_testing = struct
               Some (Pexp_constant (x1))
             )
           | Variant { tag = "Pexp_ident"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pexp_ident (x1))
             )
         | _ -> None
@@ -3494,7 +3423,7 @@ module Unstable_for_testing = struct
           { tag = "Ppat_open"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let ppat_extension x1 =
@@ -3534,7 +3463,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Ppat_type"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
     let ppat_constraint x1 x2 =
@@ -3569,7 +3498,7 @@ module Unstable_for_testing = struct
           { tag = "Ppat_record"
           ; args =
             [| Data.of_node x1
-             ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) x2
+             ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_node))) x2
             |]
           })
     let ppat_variant x1 x2 =
@@ -3578,7 +3507,7 @@ module Unstable_for_testing = struct
           { tag = "Ppat_variant"
           ; args =
             [| (Data.of_option ~f:Data.of_node) x1
-             ; Data.of_node x2
+             ; Data.of_string x2
             |]
           })
     let ppat_construct x1 x2 =
@@ -3587,7 +3516,7 @@ module Unstable_for_testing = struct
           { tag = "Ppat_construct"
           ; args =
             [| (Data.of_option ~f:Data.of_node) x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let ppat_tuple x1 =
@@ -3680,7 +3609,7 @@ module Unstable_for_testing = struct
           match data with
           | Variant { tag = "Ppat_open"; args = [| x1; x2 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Ppat_open (x1, x2))
             ))
           | Variant { tag = "Ppat_extension"; args = [| x1 |] } ->
@@ -3700,7 +3629,7 @@ module Unstable_for_testing = struct
               Some (Ppat_lazy (x1))
             )
           | Variant { tag = "Ppat_type"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Ppat_type (x1))
             )
           | Variant { tag = "Ppat_constraint"; args = [| x1; x2 |] } ->
@@ -3719,17 +3648,17 @@ module Unstable_for_testing = struct
             )
           | Variant { tag = "Ppat_record"; args = [| x1; x2 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_node))) x2) ~f:(fun x2 ->
                 Some (Ppat_record (x1, x2))
             ))
           | Variant { tag = "Ppat_variant"; args = [| x1; x2 |] } ->
             Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind (Data.to_string x2) ~f:(fun x2 ->
                 Some (Ppat_variant (x1, x2))
             ))
           | Variant { tag = "Ppat_construct"; args = [| x1; x2 |] } ->
             Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Ppat_construct (x1, x2))
             ))
           | Variant { tag = "Ppat_tuple"; args = [| x1 |] } ->
@@ -3816,7 +3745,7 @@ module Unstable_for_testing = struct
           ; args =
             [| Data.of_node x1
              ; Data.of_node x2
-             ; (Data.of_loc ~f:Data.of_node) x3
+             ; (Data.of_loc ~f:Data.of_string) x3
             |]
           })
 
@@ -3839,7 +3768,7 @@ module Unstable_for_testing = struct
           | Variant { tag = "Otag"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
-                Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x3) ~f:(fun x3 ->
+                Helpers.Option.bind ((Data.to_loc ~f:Data.to_string) x3) ~f:(fun x3 ->
                   Some (Otag (x1, x2, x3))
             )))
         | _ -> None
@@ -3870,7 +3799,7 @@ module Unstable_for_testing = struct
             [| (Data.of_list ~f:Data.of_node) x1
              ; Data.of_bool x2
              ; Data.of_node x3
-             ; (Data.of_loc ~f:Data.of_node) x4
+             ; (Data.of_loc ~f:Data.of_string) x4
             |]
           })
 
@@ -3894,7 +3823,7 @@ module Unstable_for_testing = struct
             Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_bool x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
-                  Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x4) ~f:(fun x4 ->
+                  Helpers.Option.bind ((Data.to_loc ~f:Data.to_string) x4) ~f:(fun x4 ->
                     Some (Rtag (x1, x2, x3, x4))
             ))))
         | _ -> None
@@ -3908,14 +3837,14 @@ module Unstable_for_testing = struct
     type concrete = ((core_type * longident_loc) list * longident_loc)
 
     let create =
-      let data = (Data.of_tuple2 ~f1:(Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) ~f2:Data.of_node) in
+      let data = (Data.of_tuple2 ~f1:(Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_node))) ~f2:(Data.of_loc ~f:Data.of_node)) in
       fun x -> node "package_type" (data x)
 
     let of_concrete = create
 
     let to_concrete t =
       match Node.to_node t ~version with
-      | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) ~f2:Data.to_node) data
+      | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_node))) ~f2:(Data.to_loc ~f:Data.to_node)) data
       | _ -> None
   end
 
@@ -3966,7 +3895,7 @@ module Unstable_for_testing = struct
         (Variant
           { tag = "Ptyp_variant"
           ; args =
-            [| (Data.of_option ~f:(Data.of_list ~f:Data.of_node)) x1
+            [| (Data.of_option ~f:(Data.of_list ~f:Data.of_string)) x1
              ; Data.of_node x2
              ; (Data.of_list ~f:Data.of_node) x3
             |]
@@ -3986,7 +3915,7 @@ module Unstable_for_testing = struct
           { tag = "Ptyp_class"
           ; args =
             [| (Data.of_list ~f:Data.of_node) x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let ptyp_object x1 x2 =
@@ -4004,7 +3933,7 @@ module Unstable_for_testing = struct
           { tag = "Ptyp_constr"
           ; args =
             [| (Data.of_list ~f:Data.of_node) x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let ptyp_tuple x1 =
@@ -4081,7 +4010,7 @@ module Unstable_for_testing = struct
                 Some (Ptyp_poly (x1, x2))
             ))
           | Variant { tag = "Ptyp_variant"; args = [| x1; x2; x3 |] } ->
-            Helpers.Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_node)) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_string)) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x3) ~f:(fun x3 ->
                   Some (Ptyp_variant (x1, x2, x3))
@@ -4093,7 +4022,7 @@ module Unstable_for_testing = struct
             ))
           | Variant { tag = "Ptyp_class"; args = [| x1; x2 |] } ->
             Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Ptyp_class (x1, x2))
             ))
           | Variant { tag = "Ptyp_object"; args = [| x1; x2 |] } ->
@@ -4103,7 +4032,7 @@ module Unstable_for_testing = struct
             ))
           | Variant { tag = "Ptyp_constr"; args = [| x1; x2 |] } ->
             Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Ptyp_constr (x1, x2))
             ))
           | Variant { tag = "Ptyp_tuple"; args = [| x1 |] } ->
@@ -4466,20 +4395,7 @@ module Unstable_for_testing = struct
   end
 
   module Label = struct
-    type t = label
-
-    type concrete = string
-
-    let create =
-      let data = Data.of_string in
-      fun x -> node "label" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "label"; data } -> Data.to_string data
-      | _ -> None
+    type t = string
   end
 
   module Closed_flag = struct
@@ -4686,20 +4602,7 @@ module Unstable_for_testing = struct
   end
 
   module Longident_loc = struct
-    type t = longident_loc
-
-    type concrete = longident Astlib.Loc.t
-
-    let create =
-      let data = (Data.of_loc ~f:Data.of_node) in
-      fun x -> node "longident_loc" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
-      | _ -> None
+    type t = longident Astlib.Loc.t
   end
 
   module Longident = struct
@@ -4844,20 +4747,7 @@ module V4_07 = struct
   end
 
   module Longident_loc = struct
-    type t = longident_loc
-
-    type concrete = longident Astlib.Loc.t
-
-    let create =
-      let data = (Data.of_loc ~f:Data.of_node) in
-      fun x -> node "longident_loc" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
-      | _ -> None
+    type t = longident Astlib.Loc.t
   end
 
   module Rec_flag = struct
@@ -5064,20 +4954,7 @@ module V4_07 = struct
   end
 
   module Label = struct
-    type t = label
-
-    type concrete = string
-
-    let create =
-      let data = Data.of_string in
-      fun x -> node "label" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "label"; data } -> Data.to_string data
-      | _ -> None
+    type t = string
   end
 
   module Arg_label = struct
@@ -5469,7 +5346,7 @@ module V4_07 = struct
         (Variant
           { tag = "Ptyp_constr"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; (Data.of_list ~f:Data.of_node) x2
             |]
           })
@@ -5487,7 +5364,7 @@ module V4_07 = struct
         (Variant
           { tag = "Ptyp_class"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; (Data.of_list ~f:Data.of_node) x2
             |]
           })
@@ -5507,7 +5384,7 @@ module V4_07 = struct
           ; args =
             [| (Data.of_list ~f:Data.of_node) x1
              ; Data.of_node x2
-             ; (Data.of_option ~f:(Data.of_list ~f:Data.of_node)) x3
+             ; (Data.of_option ~f:(Data.of_list ~f:Data.of_string)) x3
             |]
           })
     let ptyp_poly x1 x2 =
@@ -5583,7 +5460,7 @@ module V4_07 = struct
               Some (Ptyp_tuple (x1))
             )
           | Variant { tag = "Ptyp_constr"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Ptyp_constr (x1, x2))
             ))
@@ -5593,7 +5470,7 @@ module V4_07 = struct
                 Some (Ptyp_object (x1, x2))
             ))
           | Variant { tag = "Ptyp_class"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Ptyp_class (x1, x2))
             ))
@@ -5605,7 +5482,7 @@ module V4_07 = struct
           | Variant { tag = "Ptyp_variant"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
-                Helpers.Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_node)) x3) ~f:(fun x3 ->
+                Helpers.Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_string)) x3) ~f:(fun x3 ->
                   Some (Ptyp_variant (x1, x2, x3))
             )))
           | Variant { tag = "Ptyp_poly"; args = [| x1; x2 |] } ->
@@ -5632,14 +5509,14 @@ module V4_07 = struct
     type concrete = (longident_loc * (longident_loc * core_type) list)
 
     let create =
-      let data = (Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node))) in
+      let data = (Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:(Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node))) in
       fun x -> node "package_type" (data x)
 
     let of_concrete = create
 
     let to_concrete t =
       match Node.to_node t ~version with
-      | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node))) data
+      | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:(Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node))) data
       | _ -> None
   end
 
@@ -5655,7 +5532,7 @@ module V4_07 = struct
         (Variant
           { tag = "Rtag"
           ; args =
-            [| (Data.of_loc ~f:Data.of_node) x1
+            [| (Data.of_loc ~f:Data.of_string) x1
              ; Data.of_node x2
              ; Data.of_bool x3
              ; (Data.of_list ~f:Data.of_node) x4
@@ -5683,7 +5560,7 @@ module V4_07 = struct
         begin
           match data with
           | Variant { tag = "Rtag"; args = [| x1; x2; x3; x4 |] } ->
-            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_string) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_bool x3) ~f:(fun x3 ->
                   Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x4) ~f:(fun x4 ->
@@ -5710,7 +5587,7 @@ module V4_07 = struct
         (Variant
           { tag = "Otag"
           ; args =
-            [| (Data.of_loc ~f:Data.of_node) x1
+            [| (Data.of_loc ~f:Data.of_string) x1
              ; Data.of_node x2
              ; Data.of_node x3
             |]
@@ -5737,7 +5614,7 @@ module V4_07 = struct
         begin
           match data with
           | Variant { tag = "Otag"; args = [| x1; x2; x3 |] } ->
-            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_string) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
                   Some (Otag (x1, x2, x3))
@@ -5857,7 +5734,7 @@ module V4_07 = struct
         (Variant
           { tag = "Ppat_construct"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; (Data.of_option ~f:Data.of_node) x2
             |]
           })
@@ -5866,7 +5743,7 @@ module V4_07 = struct
         (Variant
           { tag = "Ppat_variant"
           ; args =
-            [| Data.of_node x1
+            [| Data.of_string x1
              ; (Data.of_option ~f:Data.of_node) x2
             |]
           })
@@ -5875,7 +5752,7 @@ module V4_07 = struct
         (Variant
           { tag = "Ppat_record"
           ; args =
-            [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) x1
+            [| (Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node)) x1
              ; Data.of_node x2
             |]
           })
@@ -5910,7 +5787,7 @@ module V4_07 = struct
         (Variant
           { tag = "Ppat_type"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
     let ppat_lazy x1 =
@@ -5950,7 +5827,7 @@ module V4_07 = struct
         (Variant
           { tag = "Ppat_open"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; Data.of_node x2
             |]
           })
@@ -6022,17 +5899,17 @@ module V4_07 = struct
               Some (Ppat_tuple (x1))
             )
           | Variant { tag = "Ppat_construct"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Ppat_construct (x1, x2))
             ))
           | Variant { tag = "Ppat_variant"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind (Data.to_string x1) ~f:(fun x1 ->
               Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Ppat_variant (x1, x2))
             ))
           | Variant { tag = "Ppat_record"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node)) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Some (Ppat_record (x1, x2))
             ))
@@ -6051,7 +5928,7 @@ module V4_07 = struct
                 Some (Ppat_constraint (x1, x2))
             ))
           | Variant { tag = "Ppat_type"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Ppat_type (x1))
             )
           | Variant { tag = "Ppat_lazy"; args = [| x1 |] } ->
@@ -6071,7 +5948,7 @@ module V4_07 = struct
               Some (Ppat_extension (x1))
             )
           | Variant { tag = "Ppat_open"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Some (Ppat_open (x1, x2))
             ))
@@ -6160,7 +6037,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pexp_ident"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
     let pexp_constant x1 =
@@ -6240,7 +6117,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pexp_construct"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; (Data.of_option ~f:Data.of_node) x2
             |]
           })
@@ -6249,7 +6126,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pexp_variant"
           ; args =
-            [| Data.of_node x1
+            [| Data.of_string x1
              ; (Data.of_option ~f:Data.of_node) x2
             |]
           })
@@ -6258,7 +6135,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pexp_record"
           ; args =
-            [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) x1
+            [| (Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node)) x1
              ; (Data.of_option ~f:Data.of_node) x2
             |]
           })
@@ -6268,7 +6145,7 @@ module V4_07 = struct
           { tag = "Pexp_field"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let pexp_setfield x1 x2 x3 =
@@ -6277,7 +6154,7 @@ module V4_07 = struct
           { tag = "Pexp_setfield"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
              ; Data.of_node x3
             |]
           })
@@ -6354,7 +6231,7 @@ module V4_07 = struct
           { tag = "Pexp_send"
           ; args =
             [| Data.of_node x1
-             ; (Data.of_loc ~f:Data.of_node) x2
+             ; (Data.of_loc ~f:Data.of_string) x2
             |]
           })
     let pexp_new x1 =
@@ -6362,7 +6239,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pexp_new"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
     let pexp_setinstvar x1 x2 =
@@ -6370,7 +6247,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pexp_setinstvar"
           ; args =
-            [| (Data.of_loc ~f:Data.of_node) x1
+            [| (Data.of_loc ~f:Data.of_string) x1
              ; Data.of_node x2
             |]
           })
@@ -6379,7 +6256,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pexp_override"
           ; args =
-            [| (Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node)) x1
+            [| (Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node)) x1
             |]
           })
     let pexp_letmodule x1 x2 x3 =
@@ -6457,7 +6334,7 @@ module V4_07 = struct
           { tag = "Pexp_open"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
              ; Data.of_node x3
             |]
           })
@@ -6552,7 +6429,7 @@ module V4_07 = struct
         begin
           match data with
           | Variant { tag = "Pexp_ident"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pexp_ident (x1))
             )
           | Variant { tag = "Pexp_constant"; args = [| x1 |] } ->
@@ -6596,28 +6473,28 @@ module V4_07 = struct
               Some (Pexp_tuple (x1))
             )
           | Variant { tag = "Pexp_construct"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pexp_construct (x1, x2))
             ))
           | Variant { tag = "Pexp_variant"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind (Data.to_string x1) ~f:(fun x1 ->
               Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pexp_variant (x1, x2))
             ))
           | Variant { tag = "Pexp_record"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node)) x1) ~f:(fun x1 ->
               Helpers.Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pexp_record (x1, x2))
             ))
           | Variant { tag = "Pexp_field"; args = [| x1; x2 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pexp_field (x1, x2))
             ))
           | Variant { tag = "Pexp_setfield"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
                   Some (Pexp_setfield (x1, x2, x3))
             )))
@@ -6662,20 +6539,20 @@ module V4_07 = struct
             )))
           | Variant { tag = "Pexp_send"; args = [| x1; x2 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_string) x2) ~f:(fun x2 ->
                 Some (Pexp_send (x1, x2))
             ))
           | Variant { tag = "Pexp_new"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pexp_new (x1))
             )
           | Variant { tag = "Pexp_setinstvar"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_string) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Some (Pexp_setinstvar (x1, x2))
             ))
           | Variant { tag = "Pexp_override"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node)) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node)) x1) ~f:(fun x1 ->
               Some (Pexp_override (x1))
             )
           | Variant { tag = "Pexp_letmodule"; args = [| x1; x2; x3 |] } ->
@@ -6717,7 +6594,7 @@ module V4_07 = struct
             )
           | Variant { tag = "Pexp_open"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
                   Some (Pexp_open (x1, x2, x3))
             )))
@@ -7055,7 +6932,7 @@ module V4_07 = struct
 
     let create ~ptyext_path ~ptyext_params ~ptyext_constructors ~ptyext_private ~ptyext_attributes =
       let fields =
-        [| Data.of_node ptyext_path
+        [| (Data.of_loc ~f:Data.of_node) ptyext_path
          ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) ptyext_params
          ; (Data.of_list ~f:Data.of_node) ptyext_constructors
          ; Data.of_node ptyext_private
@@ -7072,7 +6949,7 @@ module V4_07 = struct
       | { name = "type_extension"
         ; data = Record [| ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes |]
         } ->
-          Helpers.Option.bind (Data.to_node ptyext_path) ~f:(fun ptyext_path ->
+          Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) ptyext_path) ~f:(fun ptyext_path ->
             Helpers.Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) ptyext_params) ~f:(fun ptyext_params ->
               Helpers.Option.bind ((Data.to_list ~f:Data.to_node) ptyext_constructors) ~f:(fun ptyext_constructors ->
                 Helpers.Option.bind (Data.to_node ptyext_private) ~f:(fun ptyext_private ->
@@ -7140,7 +7017,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pext_rebind"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
 
@@ -7162,7 +7039,7 @@ module V4_07 = struct
                 Some (Pext_decl (x1, x2))
             ))
           | Variant { tag = "Pext_rebind"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pext_rebind (x1))
             )
         | _ -> None
@@ -7219,7 +7096,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pcty_constr"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; (Data.of_list ~f:Data.of_node) x2
             |]
           })
@@ -7255,7 +7132,7 @@ module V4_07 = struct
           { tag = "Pcty_open"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
              ; Data.of_node x3
             |]
           })
@@ -7279,7 +7156,7 @@ module V4_07 = struct
         begin
           match data with
           | Variant { tag = "Pcty_constr"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pcty_constr (x1, x2))
             ))
@@ -7299,7 +7176,7 @@ module V4_07 = struct
             )
           | Variant { tag = "Pcty_open"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
                   Some (Pcty_open (x1, x2, x3))
             )))
@@ -7397,7 +7274,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pctf_val"
           ; args =
-            [| (Data.of_tuple4 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node ~f3:Data.of_node ~f4:Data.of_node) x1
+            [| (Data.of_tuple4 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node ~f3:Data.of_node ~f4:Data.of_node) x1
             |]
           })
     let pctf_method x1 =
@@ -7405,7 +7282,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pctf_method"
           ; args =
-            [| (Data.of_tuple4 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node ~f3:Data.of_node ~f4:Data.of_node) x1
+            [| (Data.of_tuple4 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node ~f3:Data.of_node ~f4:Data.of_node) x1
             |]
           })
     let pctf_constraint x1 =
@@ -7458,11 +7335,11 @@ module V4_07 = struct
               Some (Pctf_inherit (x1))
             )
           | Variant { tag = "Pctf_val"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_tuple4 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node ~f3:Data.to_node ~f4:Data.to_node) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_tuple4 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node ~f3:Data.to_node ~f4:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pctf_val (x1))
             )
           | Variant { tag = "Pctf_method"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_tuple4 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node ~f3:Data.to_node ~f4:Data.to_node) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_tuple4 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node ~f3:Data.to_node ~f4:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pctf_method (x1))
             )
           | Variant { tag = "Pctf_constraint"; args = [| x1 |] } ->
@@ -7526,37 +7403,11 @@ module V4_07 = struct
   end
 
   module Class_description = struct
-    type t = class_description
-
-    type concrete = class_type class_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "class_description" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "class_description"; data } -> Data.to_node data
-      | _ -> None
+    type t = class_type class_infos
   end
 
   module Class_type_declaration = struct
-    type t = class_type_declaration
-
-    type concrete = class_type class_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "class_type_declaration" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "class_type_declaration"; data } -> Data.to_node data
-      | _ -> None
+    type t = class_type class_infos
   end
 
   module Class_expr = struct
@@ -7611,7 +7462,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pcl_constr"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; (Data.of_list ~f:Data.of_node) x2
             |]
           })
@@ -7676,7 +7527,7 @@ module V4_07 = struct
           { tag = "Pcl_open"
           ; args =
             [| Data.of_node x1
-             ; Data.of_node x2
+             ; (Data.of_loc ~f:Data.of_node) x2
              ; Data.of_node x3
             |]
           })
@@ -7706,7 +7557,7 @@ module V4_07 = struct
         begin
           match data with
           | Variant { tag = "Pcl_constr"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind ((Data.to_list ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pcl_constr (x1, x2))
             ))
@@ -7743,7 +7594,7 @@ module V4_07 = struct
             )
           | Variant { tag = "Pcl_open"; args = [| x1; x2; x3 |] } ->
             Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Helpers.Option.bind (Data.to_node x3) ~f:(fun x3 ->
                   Some (Pcl_open (x1, x2, x3))
             )))
@@ -7844,7 +7695,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pcf_val"
           ; args =
-            [| (Data.of_tuple3 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node ~f3:Data.of_node) x1
+            [| (Data.of_tuple3 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node ~f3:Data.of_node) x1
             |]
           })
     let pcf_method x1 =
@@ -7852,7 +7703,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pcf_method"
           ; args =
-            [| (Data.of_tuple3 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node ~f3:Data.of_node) x1
+            [| (Data.of_tuple3 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node ~f3:Data.of_node) x1
             |]
           })
     let pcf_constraint x1 =
@@ -7917,11 +7768,11 @@ module V4_07 = struct
                   Some (Pcf_inherit (x1, x2, x3))
             )))
           | Variant { tag = "Pcf_val"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_tuple3 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node ~f3:Data.to_node) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_tuple3 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node ~f3:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pcf_val (x1))
             )
           | Variant { tag = "Pcf_method"; args = [| x1 |] } ->
-            Helpers.Option.bind ((Data.to_tuple3 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node ~f3:Data.to_node) x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_tuple3 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node ~f3:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pcf_method (x1))
             )
           | Variant { tag = "Pcf_constraint"; args = [| x1 |] } ->
@@ -7997,20 +7848,7 @@ module V4_07 = struct
   end
 
   module Class_declaration = struct
-    type t = class_declaration
-
-    type concrete = class_expr class_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "class_declaration" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "class_declaration"; data } -> Data.to_node data
-      | _ -> None
+    type t = class_expr class_infos
   end
 
   module Module_type = struct
@@ -8064,7 +7902,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pmty_ident"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
     let pmty_signature x1 =
@@ -8115,7 +7953,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pmty_alias"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
 
@@ -8142,7 +7980,7 @@ module V4_07 = struct
         begin
           match data with
           | Variant { tag = "Pmty_ident"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pmty_ident (x1))
             )
           | Variant { tag = "Pmty_signature"; args = [| x1 |] } ->
@@ -8169,7 +8007,7 @@ module V4_07 = struct
               Some (Pmty_extension (x1))
             )
           | Variant { tag = "Pmty_alias"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pmty_alias (x1))
             )
         | _ -> None
@@ -8529,7 +8367,7 @@ module V4_07 = struct
 
     let create ~popen_lid ~popen_override ~popen_loc ~popen_attributes =
       let fields =
-        [| Data.of_node popen_lid
+        [| (Data.of_loc ~f:Data.of_node) popen_lid
          ; Data.of_node popen_override
          ; Data.of_location popen_loc
          ; Data.of_node popen_attributes
@@ -8545,7 +8383,7 @@ module V4_07 = struct
       | { name = "open_description"
         ; data = Record [| popen_lid; popen_override; popen_loc; popen_attributes |]
         } ->
-          Helpers.Option.bind (Data.to_node popen_lid) ~f:(fun popen_lid ->
+          Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) popen_lid) ~f:(fun popen_lid ->
             Helpers.Option.bind (Data.to_node popen_override) ~f:(fun popen_override ->
               Helpers.Option.bind (Data.to_location popen_loc) ~f:(fun popen_loc ->
                 Helpers.Option.bind (Data.to_node popen_attributes) ~f:(fun popen_attributes ->
@@ -8589,37 +8427,11 @@ module V4_07 = struct
   end
 
   module Include_description = struct
-    type t = include_description
-
-    type concrete = module_type include_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "include_description" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "include_description"; data } -> Data.to_node data
-      | _ -> None
+    type t = module_type include_infos
   end
 
   module Include_declaration = struct
-    type t = include_declaration
-
-    type concrete = module_expr include_infos
-
-    let create =
-      let data = Data.of_node in
-      fun x -> node "include_declaration" (data x)
-
-    let of_concrete = create
-
-    let to_concrete t =
-      match Node.to_node t ~version with
-      | { name = "include_declaration"; data } -> Data.to_node data
-      | _ -> None
+    type t = module_expr include_infos
   end
 
   module With_constraint = struct
@@ -8636,7 +8448,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pwith_type"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; Data.of_node x2
             |]
           })
@@ -8645,8 +8457,8 @@ module V4_07 = struct
         (Variant
           { tag = "Pwith_module"
           ; args =
-            [| Data.of_node x1
-             ; Data.of_node x2
+            [| (Data.of_loc ~f:Data.of_node) x1
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
     let pwith_typesubst x1 x2 =
@@ -8654,7 +8466,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pwith_typesubst"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
              ; Data.of_node x2
             |]
           })
@@ -8663,8 +8475,8 @@ module V4_07 = struct
         (Variant
           { tag = "Pwith_modsubst"
           ; args =
-            [| Data.of_node x1
-             ; Data.of_node x2
+            [| (Data.of_loc ~f:Data.of_node) x1
+             ; (Data.of_loc ~f:Data.of_node) x2
             |]
           })
 
@@ -8685,23 +8497,23 @@ module V4_07 = struct
         begin
           match data with
           | Variant { tag = "Pwith_type"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Some (Pwith_type (x1, x2))
             ))
           | Variant { tag = "Pwith_module"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pwith_module (x1, x2))
             ))
           | Variant { tag = "Pwith_typesubst"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
                 Some (Pwith_typesubst (x1, x2))
             ))
           | Variant { tag = "Pwith_modsubst"; args = [| x1; x2 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
-              Helpers.Option.bind (Data.to_node x2) ~f:(fun x2 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+              Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
                 Some (Pwith_modsubst (x1, x2))
             ))
         | _ -> None
@@ -8760,7 +8572,7 @@ module V4_07 = struct
         (Variant
           { tag = "Pmod_ident"
           ; args =
-            [| Data.of_node x1
+            [| (Data.of_loc ~f:Data.of_node) x1
             |]
           })
     let pmod_structure x1 =
@@ -8839,7 +8651,7 @@ module V4_07 = struct
         begin
           match data with
           | Variant { tag = "Pmod_ident"; args = [| x1 |] } ->
-            Helpers.Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Helpers.Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
               Some (Pmod_ident (x1))
             )
           | Variant { tag = "Pmod_structure"; args = [| x1 |] } ->

--- a/ast/versions.mli
+++ b/ast/versions.mli
@@ -5,8 +5,6 @@ type arg_label_
 type attribute_
 type attributes_
 type case_
-type class_declaration_
-type class_description_
 type class_expr_
 type class_expr_desc_
 type class_field_
@@ -16,7 +14,6 @@ type 'a class_infos_
 type class_signature_
 type class_structure_
 type class_type_
-type class_type_declaration_
 type class_type_desc_
 type class_type_field_
 type class_type_field_desc_
@@ -33,13 +30,9 @@ type expression_desc_
 type extension_
 type extension_constructor_
 type extension_constructor_kind_
-type include_declaration_
-type include_description_
 type 'a include_infos_
-type label_
 type label_declaration_
 type longident_
-type longident_loc_
 type module_binding_
 type module_declaration_
 type module_expr_
@@ -78,8 +71,6 @@ type arg_label = arg_label_ node
 type attribute = attribute_ node
 type attributes = attributes_ node
 type case = case_ node
-type class_declaration = class_declaration_ node
-type class_description = class_description_ node
 type class_expr = class_expr_ node
 type class_expr_desc = class_expr_desc_ node
 type class_field = class_field_ node
@@ -89,7 +80,6 @@ type 'a class_infos = 'a class_infos_ node
 type class_signature = class_signature_ node
 type class_structure = class_structure_ node
 type class_type = class_type_ node
-type class_type_declaration = class_type_declaration_ node
 type class_type_desc = class_type_desc_ node
 type class_type_field = class_type_field_ node
 type class_type_field_desc = class_type_field_desc_ node
@@ -106,13 +96,9 @@ type expression_desc = expression_desc_ node
 type extension = extension_ node
 type extension_constructor = extension_constructor_ node
 type extension_constructor_kind = extension_constructor_kind_ node
-type include_declaration = include_declaration_ node
-type include_description = include_description_ node
 type 'a include_infos = 'a include_infos_ node
-type label = label_ node
 type label_declaration = label_declaration_ node
 type longident = longident_ node
-type longident_loc = longident_loc_ node
 type module_binding = module_binding_ node
 type module_declaration = module_declaration_ node
 type module_expr = module_expr_ node
@@ -146,6 +132,14 @@ type value_description = value_description_ node
 type variance = variance_ node
 type virtual_flag = virtual_flag_ node
 type with_constraint = with_constraint_ node
+
+type class_declaration = class_expr class_infos
+type class_description = class_type class_infos
+type class_type_declaration = class_type class_infos
+type include_declaration = module_expr include_infos
+type include_description = module_type include_infos
+type label = string
+type longident_loc = longident Astlib.Loc.t
 
 module Unstable_for_testing : sig
   module rec Directive_argument : sig
@@ -432,25 +426,11 @@ module Unstable_for_testing : sig
   end
 
   and Include_declaration : sig
-    type t = include_declaration
-
-    type concrete = Module_expr.t Include_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Module_expr.t Include_infos.t -> t
+    type t = Module_expr.t Include_infos.t
   end
 
   and Include_description : sig
-    type t = include_description
-
-    type concrete = Module_type.t Include_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Module_type.t Include_infos.t -> t
+    type t = Module_type.t Include_infos.t
   end
 
   and Include_infos : sig
@@ -688,14 +668,7 @@ module Unstable_for_testing : sig
   end
 
   and Class_declaration : sig
-    type t = class_declaration
-
-    type concrete = Class_expr.t Class_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Class_expr.t Class_infos.t -> t
+    type t = Class_expr.t Class_infos.t
   end
 
   and Class_field_kind : sig
@@ -865,25 +838,11 @@ module Unstable_for_testing : sig
   end
 
   and Class_type_declaration : sig
-    type t = class_type_declaration
-
-    type concrete = Class_type.t Class_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Class_type.t Class_infos.t -> t
+    type t = Class_type.t Class_infos.t
   end
 
   and Class_description : sig
-    type t = class_description
-
-    type concrete = Class_type.t Class_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Class_type.t Class_infos.t -> t
+    type t = Class_type.t Class_infos.t
   end
 
   and Class_infos : sig
@@ -1829,14 +1788,7 @@ module Unstable_for_testing : sig
   end
 
   and Label : sig
-    type t = label
-
-    type concrete = string
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : string -> t
+    type t = string
   end
 
   and Closed_flag : sig
@@ -1938,14 +1890,7 @@ module Unstable_for_testing : sig
   end
 
   and Longident_loc : sig
-    type t = longident_loc
-
-    type concrete = Longident.t Astlib.Loc.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Longident.t Astlib.Loc.t -> t
+    type t = Longident.t Astlib.Loc.t
   end
 
   and Longident : sig
@@ -1999,14 +1944,7 @@ module V4_07 : sig
   end
 
   and Longident_loc : sig
-    type t = longident_loc
-
-    type concrete = Longident.t Astlib.Loc.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Longident.t Astlib.Loc.t -> t
+    type t = Longident.t Astlib.Loc.t
   end
 
   and Rec_flag : sig
@@ -2108,14 +2046,7 @@ module V4_07 : sig
   end
 
   and Label : sig
-    type t = label
-
-    type concrete = string
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : string -> t
+    type t = string
   end
 
   and Arg_label : sig
@@ -3061,25 +2992,11 @@ module V4_07 : sig
   end
 
   and Class_description : sig
-    type t = class_description
-
-    type concrete = Class_type.t Class_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Class_type.t Class_infos.t -> t
+    type t = Class_type.t Class_infos.t
   end
 
   and Class_type_declaration : sig
-    type t = class_type_declaration
-
-    type concrete = Class_type.t Class_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Class_type.t Class_infos.t -> t
+    type t = Class_type.t Class_infos.t
   end
 
   and Class_expr : sig
@@ -3249,14 +3166,7 @@ module V4_07 : sig
   end
 
   and Class_declaration : sig
-    type t = class_declaration
-
-    type concrete = Class_expr.t Class_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Class_expr.t Class_infos.t -> t
+    type t = Class_expr.t Class_infos.t
   end
 
   and Module_type : sig
@@ -3494,25 +3404,11 @@ module V4_07 : sig
   end
 
   and Include_description : sig
-    type t = include_description
-
-    type concrete = Module_type.t Include_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Module_type.t Include_infos.t -> t
+    type t = Module_type.t Include_infos.t
   end
 
   and Include_declaration : sig
-    type t = include_declaration
-
-    type concrete = Module_expr.t Include_infos.t
-
-    val of_concrete : concrete -> t
-    val to_concrete : t -> concrete option
-
-    val create : Module_expr.t Include_infos.t -> t
+    type t = Module_expr.t Include_infos.t
   end
 
   and With_constraint : sig

--- a/ast/virtual_traverse.ml
+++ b/ast/virtual_traverse.ml
@@ -226,22 +226,12 @@ module Unstable_for_testing = struct
             With_constraint.of_concrete (Pwith_type (x0, x1))
       method include_declaration : Include_declaration.t -> Include_declaration.t  =
         fun include_declaration ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_expr concrete in
-          Include_declaration.of_concrete concrete
+          let include_declaration = self#include_infos_module_expr include_declaration in
+          include_declaration
       method include_description : Include_description.t -> Include_description.t  =
         fun include_description ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_type concrete in
-          Include_description.of_concrete concrete
+          let include_description = self#include_infos_module_type include_description in
+          include_description
       method include_infos_module_expr : Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t  =
         fun include_infos ->
           let concrete =
@@ -420,13 +410,8 @@ module Unstable_for_testing = struct
           Module_type.of_concrete { pmty_attributes; pmty_loc; pmty_desc }
       method class_declaration : Class_declaration.t -> Class_declaration.t  =
         fun class_declaration ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_expr concrete in
-          Class_declaration.of_concrete concrete
+          let class_declaration = self#class_infos_class_expr class_declaration in
+          class_declaration
       method class_field_kind : Class_field_kind.t -> Class_field_kind.t  =
         fun class_field_kind ->
           let concrete =
@@ -552,22 +537,12 @@ module Unstable_for_testing = struct
           Class_expr.of_concrete { pcl_attributes; pcl_loc; pcl_desc }
       method class_type_declaration : Class_type_declaration.t -> Class_type_declaration.t  =
         fun class_type_declaration ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type concrete in
-          Class_type_declaration.of_concrete concrete
+          let class_type_declaration = self#class_infos_class_type class_type_declaration in
+          class_type_declaration
       method class_description : Class_description.t -> Class_description.t  =
         fun class_description ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type concrete in
-          Class_description.of_concrete concrete
+          let class_description = self#class_infos_class_type class_description in
+          class_description
       method class_infos_class_expr : Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t  =
         fun class_infos ->
           let concrete =
@@ -1289,13 +1264,8 @@ module Unstable_for_testing = struct
             Arg_label.of_concrete Nolabel
       method label : Label.t -> Label.t  =
         fun label ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let concrete = self#string concrete in
-          Label.of_concrete concrete
+          let label = self#string label in
+          label
       method closed_flag : Closed_flag.t -> Closed_flag.t  =
         fun closed_flag ->
           let concrete =
@@ -1382,13 +1352,8 @@ module Unstable_for_testing = struct
             Rec_flag.of_concrete Nonrecursive
       method longident_loc : Longident_loc.t -> Longident_loc.t  =
         fun longident_loc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let concrete = self#loc self#longident concrete in
-          Longident_loc.of_concrete concrete
+          let longident_loc = self#loc self#longident longident_loc in
+          longident_loc
       method longident : Longident.t -> Longident.t  =
         fun longident ->
           let concrete =
@@ -1595,20 +1560,10 @@ module Unstable_for_testing = struct
             self#longident_loc x1
       method include_declaration : Include_declaration.t -> unit  =
         fun include_declaration ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          self#include_infos_module_expr concrete
+          self#include_infos_module_expr include_declaration
       method include_description : Include_description.t -> unit  =
         fun include_description ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          self#include_infos_module_type concrete
+          self#include_infos_module_type include_description
       method include_infos_module_expr : Module_expr.t Include_infos.t -> unit  =
         fun include_infos ->
           let concrete =
@@ -1759,12 +1714,7 @@ module Unstable_for_testing = struct
           self#module_type_desc pmty_desc
       method class_declaration : Class_declaration.t -> unit  =
         fun class_declaration ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          self#class_infos_class_expr concrete
+          self#class_infos_class_expr class_declaration
       method class_field_kind : Class_field_kind.t -> unit  =
         fun class_field_kind ->
           let concrete =
@@ -1870,20 +1820,10 @@ module Unstable_for_testing = struct
           self#class_expr_desc pcl_desc
       method class_type_declaration : Class_type_declaration.t -> unit  =
         fun class_type_declaration ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          self#class_infos_class_type concrete
+          self#class_infos_class_type class_type_declaration
       method class_description : Class_description.t -> unit  =
         fun class_description ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          self#class_infos_class_type concrete
+          self#class_infos_class_type class_description
       method class_infos_class_expr : Class_expr.t Class_infos.t -> unit  =
         fun class_infos ->
           let concrete =
@@ -2492,12 +2432,7 @@ module Unstable_for_testing = struct
             ()
       method label : Label.t -> unit  =
         fun label ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          self#string concrete
+          self#string label
       method closed_flag : Closed_flag.t -> unit  =
         fun closed_flag ->
           let concrete =
@@ -2584,12 +2519,7 @@ module Unstable_for_testing = struct
             ()
       method longident_loc : Longident_loc.t -> unit  =
         fun longident_loc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          self#loc self#longident concrete
+          self#loc self#longident longident_loc
       method longident : Longident.t -> unit  =
         fun longident ->
           let concrete =
@@ -2830,21 +2760,11 @@ module Unstable_for_testing = struct
             acc
       method include_declaration : Include_declaration.t -> 'acc -> 'acc  =
         fun include_declaration acc ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let acc = self#include_infos_module_expr concrete acc in
+          let acc = self#include_infos_module_expr include_declaration acc in
           acc
       method include_description : Include_description.t -> 'acc -> 'acc  =
         fun include_description acc ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let acc = self#include_infos_module_type concrete acc in
+          let acc = self#include_infos_module_type include_description acc in
           acc
       method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> 'acc  =
         fun include_infos acc ->
@@ -3024,12 +2944,7 @@ module Unstable_for_testing = struct
           acc
       method class_declaration : Class_declaration.t -> 'acc -> 'acc  =
         fun class_declaration acc ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let acc = self#class_infos_class_expr concrete acc in
+          let acc = self#class_infos_class_expr class_declaration acc in
           acc
       method class_field_kind : Class_field_kind.t -> 'acc -> 'acc  =
         fun class_field_kind acc ->
@@ -3156,21 +3071,11 @@ module Unstable_for_testing = struct
           acc
       method class_type_declaration : Class_type_declaration.t -> 'acc -> 'acc  =
         fun class_type_declaration acc ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let acc = self#class_infos_class_type concrete acc in
+          let acc = self#class_infos_class_type class_type_declaration acc in
           acc
       method class_description : Class_description.t -> 'acc -> 'acc  =
         fun class_description acc ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let acc = self#class_infos_class_type concrete acc in
+          let acc = self#class_infos_class_type class_description acc in
           acc
       method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> 'acc  =
         fun class_infos acc ->
@@ -3893,12 +3798,7 @@ module Unstable_for_testing = struct
             acc
       method label : Label.t -> 'acc -> 'acc  =
         fun label acc ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let acc = self#string concrete acc in
+          let acc = self#string label acc in
           acc
       method closed_flag : Closed_flag.t -> 'acc -> 'acc  =
         fun closed_flag acc ->
@@ -3986,12 +3886,7 @@ module Unstable_for_testing = struct
             acc
       method longident_loc : Longident_loc.t -> 'acc -> 'acc  =
         fun longident_loc acc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let acc = self#loc self#longident concrete acc in
+          let acc = self#loc self#longident longident_loc acc in
           acc
       method longident : Longident.t -> 'acc -> 'acc  =
         fun longident acc ->
@@ -4236,22 +4131,12 @@ module Unstable_for_testing = struct
             (With_constraint.of_concrete (Pwith_type (x0, x1)), acc)
       method include_declaration : Include_declaration.t -> 'acc -> (Include_declaration.t * 'acc)  =
         fun include_declaration acc ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#include_infos_module_expr concrete acc in
-          (Include_declaration.of_concrete concrete, acc)
+          let (include_declaration, acc) = self#include_infos_module_expr include_declaration acc in
+          (include_declaration, acc)
       method include_description : Include_description.t -> 'acc -> (Include_description.t * 'acc)  =
         fun include_description acc ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#include_infos_module_type concrete acc in
-          (Include_description.of_concrete concrete, acc)
+          let (include_description, acc) = self#include_infos_module_type include_description acc in
+          (include_description, acc)
       method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> (Module_expr.t Include_infos.t * 'acc)  =
         fun include_infos acc ->
           let concrete =
@@ -4430,13 +4315,8 @@ module Unstable_for_testing = struct
           (Module_type.of_concrete { pmty_attributes; pmty_loc; pmty_desc }, acc)
       method class_declaration : Class_declaration.t -> 'acc -> (Class_declaration.t * 'acc)  =
         fun class_declaration acc ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#class_infos_class_expr concrete acc in
-          (Class_declaration.of_concrete concrete, acc)
+          let (class_declaration, acc) = self#class_infos_class_expr class_declaration acc in
+          (class_declaration, acc)
       method class_field_kind : Class_field_kind.t -> 'acc -> (Class_field_kind.t * 'acc)  =
         fun class_field_kind acc ->
           let concrete =
@@ -4562,22 +4442,12 @@ module Unstable_for_testing = struct
           (Class_expr.of_concrete { pcl_attributes; pcl_loc; pcl_desc }, acc)
       method class_type_declaration : Class_type_declaration.t -> 'acc -> (Class_type_declaration.t * 'acc)  =
         fun class_type_declaration acc ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#class_infos_class_type concrete acc in
-          (Class_type_declaration.of_concrete concrete, acc)
+          let (class_type_declaration, acc) = self#class_infos_class_type class_type_declaration acc in
+          (class_type_declaration, acc)
       method class_description : Class_description.t -> 'acc -> (Class_description.t * 'acc)  =
         fun class_description acc ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#class_infos_class_type concrete acc in
-          (Class_description.of_concrete concrete, acc)
+          let (class_description, acc) = self#class_infos_class_type class_description acc in
+          (class_description, acc)
       method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> (Class_expr.t Class_infos.t * 'acc)  =
         fun class_infos acc ->
           let concrete =
@@ -5299,13 +5169,8 @@ module Unstable_for_testing = struct
             (Arg_label.of_concrete Nolabel, acc)
       method label : Label.t -> 'acc -> (Label.t * 'acc)  =
         fun label acc ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#string concrete acc in
-          (Label.of_concrete concrete, acc)
+          let (label, acc) = self#string label acc in
+          (label, acc)
       method closed_flag : Closed_flag.t -> 'acc -> (Closed_flag.t * 'acc)  =
         fun closed_flag acc ->
           let concrete =
@@ -5392,13 +5257,8 @@ module Unstable_for_testing = struct
             (Rec_flag.of_concrete Nonrecursive, acc)
       method longident_loc : Longident_loc.t -> 'acc -> (Longident_loc.t * 'acc)  =
         fun longident_loc acc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#loc self#longident concrete acc in
-          (Longident_loc.of_concrete concrete, acc)
+          let (longident_loc, acc) = self#loc self#longident longident_loc acc in
+          (longident_loc, acc)
       method longident : Longident.t -> 'acc -> (Longident.t * 'acc)  =
         fun longident acc ->
           let concrete =
@@ -5642,22 +5502,12 @@ module Unstable_for_testing = struct
             With_constraint.of_concrete (Pwith_type (x0, x1))
       method include_declaration : 'ctx -> Include_declaration.t -> Include_declaration.t  =
         fun _ctx include_declaration ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_expr _ctx concrete in
-          Include_declaration.of_concrete concrete
+          let include_declaration = self#include_infos_module_expr _ctx include_declaration in
+          include_declaration
       method include_description : 'ctx -> Include_description.t -> Include_description.t  =
         fun _ctx include_description ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_type _ctx concrete in
-          Include_description.of_concrete concrete
+          let include_description = self#include_infos_module_type _ctx include_description in
+          include_description
       method include_infos_module_expr : 'ctx -> Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t  =
         fun _ctx include_infos ->
           let concrete =
@@ -5836,13 +5686,8 @@ module Unstable_for_testing = struct
           Module_type.of_concrete { pmty_attributes; pmty_loc; pmty_desc }
       method class_declaration : 'ctx -> Class_declaration.t -> Class_declaration.t  =
         fun _ctx class_declaration ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_expr _ctx concrete in
-          Class_declaration.of_concrete concrete
+          let class_declaration = self#class_infos_class_expr _ctx class_declaration in
+          class_declaration
       method class_field_kind : 'ctx -> Class_field_kind.t -> Class_field_kind.t  =
         fun _ctx class_field_kind ->
           let concrete =
@@ -5968,22 +5813,12 @@ module Unstable_for_testing = struct
           Class_expr.of_concrete { pcl_attributes; pcl_loc; pcl_desc }
       method class_type_declaration : 'ctx -> Class_type_declaration.t -> Class_type_declaration.t  =
         fun _ctx class_type_declaration ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type _ctx concrete in
-          Class_type_declaration.of_concrete concrete
+          let class_type_declaration = self#class_infos_class_type _ctx class_type_declaration in
+          class_type_declaration
       method class_description : 'ctx -> Class_description.t -> Class_description.t  =
         fun _ctx class_description ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type _ctx concrete in
-          Class_description.of_concrete concrete
+          let class_description = self#class_infos_class_type _ctx class_description in
+          class_description
       method class_infos_class_expr : 'ctx -> Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t  =
         fun _ctx class_infos ->
           let concrete =
@@ -6705,13 +6540,8 @@ module Unstable_for_testing = struct
             Arg_label.of_concrete Nolabel
       method label : 'ctx -> Label.t -> Label.t  =
         fun _ctx label ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let concrete = self#string _ctx concrete in
-          Label.of_concrete concrete
+          let label = self#string _ctx label in
+          label
       method closed_flag : 'ctx -> Closed_flag.t -> Closed_flag.t  =
         fun _ctx closed_flag ->
           let concrete =
@@ -6798,13 +6628,8 @@ module Unstable_for_testing = struct
             Rec_flag.of_concrete Nonrecursive
       method longident_loc : 'ctx -> Longident_loc.t -> Longident_loc.t  =
         fun _ctx longident_loc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let concrete = self#loc self#longident _ctx concrete in
-          Longident_loc.of_concrete concrete
+          let longident_loc = self#loc self#longident _ctx longident_loc in
+          longident_loc
       method longident : 'ctx -> Longident.t -> Longident.t  =
         fun _ctx longident ->
           let concrete =
@@ -7051,22 +6876,12 @@ module Unstable_for_testing = struct
             self#constr (Some ("with_constraint", 0)) "Pwith_type" [x0; x1]
       method include_declaration : Include_declaration.t -> 'res  =
         fun include_declaration ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_expr concrete in
-          concrete
+          let include_declaration = self#include_infos_module_expr include_declaration in
+          include_declaration
       method include_description : Include_description.t -> 'res  =
         fun include_description ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_type concrete in
-          concrete
+          let include_description = self#include_infos_module_type include_description in
+          include_description
       method include_infos_module_expr : Module_expr.t Include_infos.t -> 'res  =
         fun include_infos ->
           let concrete =
@@ -7245,13 +7060,8 @@ module Unstable_for_testing = struct
           self#record (Some ("module_type", 0)) [("pmty_attributes", pmty_attributes); ("pmty_loc", pmty_loc); ("pmty_desc", pmty_desc)]
       method class_declaration : Class_declaration.t -> 'res  =
         fun class_declaration ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_expr concrete in
-          concrete
+          let class_declaration = self#class_infos_class_expr class_declaration in
+          class_declaration
       method class_field_kind : Class_field_kind.t -> 'res  =
         fun class_field_kind ->
           let concrete =
@@ -7377,22 +7187,12 @@ module Unstable_for_testing = struct
           self#record (Some ("class_expr", 0)) [("pcl_attributes", pcl_attributes); ("pcl_loc", pcl_loc); ("pcl_desc", pcl_desc)]
       method class_type_declaration : Class_type_declaration.t -> 'res  =
         fun class_type_declaration ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type concrete in
-          concrete
+          let class_type_declaration = self#class_infos_class_type class_type_declaration in
+          class_type_declaration
       method class_description : Class_description.t -> 'res  =
         fun class_description ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type concrete in
-          concrete
+          let class_description = self#class_infos_class_type class_description in
+          class_description
       method class_infos_class_expr : Class_expr.t Class_infos.t -> 'res  =
         fun class_infos ->
           let concrete =
@@ -8114,13 +7914,8 @@ module Unstable_for_testing = struct
             self#constr (Some ("arg_label", 0)) "Nolabel" []
       method label : Label.t -> 'res  =
         fun label ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let concrete = self#string concrete in
-          concrete
+          let label = self#string label in
+          label
       method closed_flag : Closed_flag.t -> 'res  =
         fun closed_flag ->
           let concrete =
@@ -8207,13 +8002,8 @@ module Unstable_for_testing = struct
             self#constr (Some ("rec_flag", 0)) "Nonrecursive" []
       method longident_loc : Longident_loc.t -> 'res  =
         fun longident_loc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let concrete = self#loc self#longident concrete in
-          concrete
+          let longident_loc = self#loc self#longident longident_loc in
+          longident_loc
       method longident : Longident.t -> 'res  =
         fun longident ->
           let concrete =
@@ -8272,13 +8062,8 @@ module V4_07 = struct
             Longident.of_concrete (Lapply (x0, x1))
       method longident_loc : Longident_loc.t -> Longident_loc.t  =
         fun longident_loc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let concrete = self#loc self#longident concrete in
-          Longident_loc.of_concrete concrete
+          let longident_loc = self#loc self#longident longident_loc in
+          longident_loc
       method rec_flag : Rec_flag.t -> Rec_flag.t  =
         fun rec_flag ->
           let concrete =
@@ -8365,13 +8150,8 @@ module V4_07 = struct
             Closed_flag.of_concrete Open
       method label : Label.t -> Label.t  =
         fun label ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let concrete = self#string concrete in
-          Label.of_concrete concrete
+          let label = self#string label in
+          label
       method arg_label : Arg_label.t -> Arg_label.t  =
         fun arg_label ->
           let concrete =
@@ -9093,22 +8873,12 @@ module V4_07 = struct
           Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
       method class_description : Class_description.t -> Class_description.t  =
         fun class_description ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type concrete in
-          Class_description.of_concrete concrete
+          let class_description = self#class_infos_class_type class_description in
+          class_description
       method class_type_declaration : Class_type_declaration.t -> Class_type_declaration.t  =
         fun class_type_declaration ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type concrete in
-          Class_type_declaration.of_concrete concrete
+          let class_type_declaration = self#class_infos_class_type class_type_declaration in
+          class_type_declaration
       method class_expr : Class_expr.t -> Class_expr.t  =
         fun class_expr ->
           let concrete =
@@ -9234,13 +9004,8 @@ module V4_07 = struct
             Class_field_kind.of_concrete (Cfk_concrete (x0, x1))
       method class_declaration : Class_declaration.t -> Class_declaration.t  =
         fun class_declaration ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_expr concrete in
-          Class_declaration.of_concrete concrete
+          let class_declaration = self#class_infos_class_expr class_declaration in
+          class_declaration
       method module_type : Module_type.t -> Module_type.t  =
         fun module_type ->
           let concrete =
@@ -9419,22 +9184,12 @@ module V4_07 = struct
           Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }
       method include_description : Include_description.t -> Include_description.t  =
         fun include_description ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_type concrete in
-          Include_description.of_concrete concrete
+          let include_description = self#include_infos_module_type include_description in
+          include_description
       method include_declaration : Include_declaration.t -> Include_declaration.t  =
         fun include_declaration ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_expr concrete in
-          Include_declaration.of_concrete concrete
+          let include_declaration = self#include_infos_module_expr include_declaration in
+          include_declaration
       method with_constraint : With_constraint.t -> With_constraint.t  =
         fun with_constraint ->
           let concrete =
@@ -9675,12 +9430,7 @@ module V4_07 = struct
             self#longident x1
       method longident_loc : Longident_loc.t -> unit  =
         fun longident_loc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          self#loc self#longident concrete
+          self#loc self#longident longident_loc
       method rec_flag : Rec_flag.t -> unit  =
         fun rec_flag ->
           let concrete =
@@ -9767,12 +9517,7 @@ module V4_07 = struct
             ()
       method label : Label.t -> unit  =
         fun label ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          self#string concrete
+          self#string label
       method arg_label : Arg_label.t -> unit  =
         fun arg_label ->
           let concrete =
@@ -10381,20 +10126,10 @@ module V4_07 = struct
           self#attributes pci_attributes
       method class_description : Class_description.t -> unit  =
         fun class_description ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          self#class_infos_class_type concrete
+          self#class_infos_class_type class_description
       method class_type_declaration : Class_type_declaration.t -> unit  =
         fun class_type_declaration ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          self#class_infos_class_type concrete
+          self#class_infos_class_type class_type_declaration
       method class_expr : Class_expr.t -> unit  =
         fun class_expr ->
           let concrete =
@@ -10500,12 +10235,7 @@ module V4_07 = struct
             self#expression x1
       method class_declaration : Class_declaration.t -> unit  =
         fun class_declaration ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          self#class_infos_class_expr concrete
+          self#class_infos_class_expr class_declaration
       method module_type : Module_type.t -> unit  =
         fun module_type ->
           let concrete =
@@ -10656,20 +10386,10 @@ module V4_07 = struct
           self#attributes pincl_attributes
       method include_description : Include_description.t -> unit  =
         fun include_description ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          self#include_infos_module_type concrete
+          self#include_infos_module_type include_description
       method include_declaration : Include_declaration.t -> unit  =
         fun include_declaration ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          self#include_infos_module_expr concrete
+          self#include_infos_module_expr include_declaration
       method with_constraint : With_constraint.t -> unit  =
         fun with_constraint ->
           let concrete =
@@ -10876,12 +10596,7 @@ module V4_07 = struct
             acc
       method longident_loc : Longident_loc.t -> 'acc -> 'acc  =
         fun longident_loc acc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let acc = self#loc self#longident concrete acc in
+          let acc = self#loc self#longident longident_loc acc in
           acc
       method rec_flag : Rec_flag.t -> 'acc -> 'acc  =
         fun rec_flag acc ->
@@ -10969,12 +10684,7 @@ module V4_07 = struct
             acc
       method label : Label.t -> 'acc -> 'acc  =
         fun label acc ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let acc = self#string concrete acc in
+          let acc = self#string label acc in
           acc
       method arg_label : Arg_label.t -> 'acc -> 'acc  =
         fun arg_label acc ->
@@ -11697,21 +11407,11 @@ module V4_07 = struct
           acc
       method class_description : Class_description.t -> 'acc -> 'acc  =
         fun class_description acc ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let acc = self#class_infos_class_type concrete acc in
+          let acc = self#class_infos_class_type class_description acc in
           acc
       method class_type_declaration : Class_type_declaration.t -> 'acc -> 'acc  =
         fun class_type_declaration acc ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let acc = self#class_infos_class_type concrete acc in
+          let acc = self#class_infos_class_type class_type_declaration acc in
           acc
       method class_expr : Class_expr.t -> 'acc -> 'acc  =
         fun class_expr acc ->
@@ -11838,12 +11538,7 @@ module V4_07 = struct
             acc
       method class_declaration : Class_declaration.t -> 'acc -> 'acc  =
         fun class_declaration acc ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let acc = self#class_infos_class_expr concrete acc in
+          let acc = self#class_infos_class_expr class_declaration acc in
           acc
       method module_type : Module_type.t -> 'acc -> 'acc  =
         fun module_type acc ->
@@ -12023,21 +11718,11 @@ module V4_07 = struct
           acc
       method include_description : Include_description.t -> 'acc -> 'acc  =
         fun include_description acc ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let acc = self#include_infos_module_type concrete acc in
+          let acc = self#include_infos_module_type include_description acc in
           acc
       method include_declaration : Include_declaration.t -> 'acc -> 'acc  =
         fun include_declaration acc ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let acc = self#include_infos_module_expr concrete acc in
+          let acc = self#include_infos_module_expr include_declaration acc in
           acc
       method with_constraint : With_constraint.t -> 'acc -> 'acc  =
         fun with_constraint acc ->
@@ -12282,13 +11967,8 @@ module V4_07 = struct
             (Longident.of_concrete (Lapply (x0, x1)), acc)
       method longident_loc : Longident_loc.t -> 'acc -> (Longident_loc.t * 'acc)  =
         fun longident_loc acc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#loc self#longident concrete acc in
-          (Longident_loc.of_concrete concrete, acc)
+          let (longident_loc, acc) = self#loc self#longident longident_loc acc in
+          (longident_loc, acc)
       method rec_flag : Rec_flag.t -> 'acc -> (Rec_flag.t * 'acc)  =
         fun rec_flag acc ->
           let concrete =
@@ -12375,13 +12055,8 @@ module V4_07 = struct
             (Closed_flag.of_concrete Open, acc)
       method label : Label.t -> 'acc -> (Label.t * 'acc)  =
         fun label acc ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#string concrete acc in
-          (Label.of_concrete concrete, acc)
+          let (label, acc) = self#string label acc in
+          (label, acc)
       method arg_label : Arg_label.t -> 'acc -> (Arg_label.t * 'acc)  =
         fun arg_label acc ->
           let concrete =
@@ -13103,22 +12778,12 @@ module V4_07 = struct
           (Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }, acc)
       method class_description : Class_description.t -> 'acc -> (Class_description.t * 'acc)  =
         fun class_description acc ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#class_infos_class_type concrete acc in
-          (Class_description.of_concrete concrete, acc)
+          let (class_description, acc) = self#class_infos_class_type class_description acc in
+          (class_description, acc)
       method class_type_declaration : Class_type_declaration.t -> 'acc -> (Class_type_declaration.t * 'acc)  =
         fun class_type_declaration acc ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#class_infos_class_type concrete acc in
-          (Class_type_declaration.of_concrete concrete, acc)
+          let (class_type_declaration, acc) = self#class_infos_class_type class_type_declaration acc in
+          (class_type_declaration, acc)
       method class_expr : Class_expr.t -> 'acc -> (Class_expr.t * 'acc)  =
         fun class_expr acc ->
           let concrete =
@@ -13244,13 +12909,8 @@ module V4_07 = struct
             (Class_field_kind.of_concrete (Cfk_concrete (x0, x1)), acc)
       method class_declaration : Class_declaration.t -> 'acc -> (Class_declaration.t * 'acc)  =
         fun class_declaration acc ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#class_infos_class_expr concrete acc in
-          (Class_declaration.of_concrete concrete, acc)
+          let (class_declaration, acc) = self#class_infos_class_expr class_declaration acc in
+          (class_declaration, acc)
       method module_type : Module_type.t -> 'acc -> (Module_type.t * 'acc)  =
         fun module_type acc ->
           let concrete =
@@ -13429,22 +13089,12 @@ module V4_07 = struct
           (Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }, acc)
       method include_description : Include_description.t -> 'acc -> (Include_description.t * 'acc)  =
         fun include_description acc ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#include_infos_module_type concrete acc in
-          (Include_description.of_concrete concrete, acc)
+          let (include_description, acc) = self#include_infos_module_type include_description acc in
+          (include_description, acc)
       method include_declaration : Include_declaration.t -> 'acc -> (Include_declaration.t * 'acc)  =
         fun include_declaration acc ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let (concrete, acc) = self#include_infos_module_expr concrete acc in
-          (Include_declaration.of_concrete concrete, acc)
+          let (include_declaration, acc) = self#include_infos_module_expr include_declaration acc in
+          (include_declaration, acc)
       method with_constraint : With_constraint.t -> 'acc -> (With_constraint.t * 'acc)  =
         fun with_constraint acc ->
           let concrete =
@@ -13688,13 +13338,8 @@ module V4_07 = struct
             Longident.of_concrete (Lapply (x0, x1))
       method longident_loc : 'ctx -> Longident_loc.t -> Longident_loc.t  =
         fun _ctx longident_loc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let concrete = self#loc self#longident _ctx concrete in
-          Longident_loc.of_concrete concrete
+          let longident_loc = self#loc self#longident _ctx longident_loc in
+          longident_loc
       method rec_flag : 'ctx -> Rec_flag.t -> Rec_flag.t  =
         fun _ctx rec_flag ->
           let concrete =
@@ -13781,13 +13426,8 @@ module V4_07 = struct
             Closed_flag.of_concrete Open
       method label : 'ctx -> Label.t -> Label.t  =
         fun _ctx label ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let concrete = self#string _ctx concrete in
-          Label.of_concrete concrete
+          let label = self#string _ctx label in
+          label
       method arg_label : 'ctx -> Arg_label.t -> Arg_label.t  =
         fun _ctx arg_label ->
           let concrete =
@@ -14509,22 +14149,12 @@ module V4_07 = struct
           Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
       method class_description : 'ctx -> Class_description.t -> Class_description.t  =
         fun _ctx class_description ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type _ctx concrete in
-          Class_description.of_concrete concrete
+          let class_description = self#class_infos_class_type _ctx class_description in
+          class_description
       method class_type_declaration : 'ctx -> Class_type_declaration.t -> Class_type_declaration.t  =
         fun _ctx class_type_declaration ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type _ctx concrete in
-          Class_type_declaration.of_concrete concrete
+          let class_type_declaration = self#class_infos_class_type _ctx class_type_declaration in
+          class_type_declaration
       method class_expr : 'ctx -> Class_expr.t -> Class_expr.t  =
         fun _ctx class_expr ->
           let concrete =
@@ -14650,13 +14280,8 @@ module V4_07 = struct
             Class_field_kind.of_concrete (Cfk_concrete (x0, x1))
       method class_declaration : 'ctx -> Class_declaration.t -> Class_declaration.t  =
         fun _ctx class_declaration ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_expr _ctx concrete in
-          Class_declaration.of_concrete concrete
+          let class_declaration = self#class_infos_class_expr _ctx class_declaration in
+          class_declaration
       method module_type : 'ctx -> Module_type.t -> Module_type.t  =
         fun _ctx module_type ->
           let concrete =
@@ -14835,22 +14460,12 @@ module V4_07 = struct
           Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }
       method include_description : 'ctx -> Include_description.t -> Include_description.t  =
         fun _ctx include_description ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_type _ctx concrete in
-          Include_description.of_concrete concrete
+          let include_description = self#include_infos_module_type _ctx include_description in
+          include_description
       method include_declaration : 'ctx -> Include_declaration.t -> Include_declaration.t  =
         fun _ctx include_declaration ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_expr _ctx concrete in
-          Include_declaration.of_concrete concrete
+          let include_declaration = self#include_infos_module_expr _ctx include_declaration in
+          include_declaration
       method with_constraint : 'ctx -> With_constraint.t -> With_constraint.t  =
         fun _ctx with_constraint ->
           let concrete =
@@ -15097,13 +14712,8 @@ module V4_07 = struct
             self#constr (Some ("longident", 0)) "Lapply" [x0; x1]
       method longident_loc : Longident_loc.t -> 'res  =
         fun longident_loc ->
-          let concrete =
-            match Longident_loc.to_concrete longident_loc with
-            | None -> conversion_failed "longident_loc"
-            | Some n -> n
-          in
-          let concrete = self#loc self#longident concrete in
-          concrete
+          let longident_loc = self#loc self#longident longident_loc in
+          longident_loc
       method rec_flag : Rec_flag.t -> 'res  =
         fun rec_flag ->
           let concrete =
@@ -15190,13 +14800,8 @@ module V4_07 = struct
             self#constr (Some ("closed_flag", 0)) "Open" []
       method label : Label.t -> 'res  =
         fun label ->
-          let concrete =
-            match Label.to_concrete label with
-            | None -> conversion_failed "label"
-            | Some n -> n
-          in
-          let concrete = self#string concrete in
-          concrete
+          let label = self#string label in
+          label
       method arg_label : Arg_label.t -> 'res  =
         fun arg_label ->
           let concrete =
@@ -15918,22 +15523,12 @@ module V4_07 = struct
           self#record (Some ("class_infos", 1)) [("pci_virt", pci_virt); ("pci_params", pci_params); ("pci_name", pci_name); ("pci_expr", pci_expr); ("pci_loc", pci_loc); ("pci_attributes", pci_attributes)]
       method class_description : Class_description.t -> 'res  =
         fun class_description ->
-          let concrete =
-            match Class_description.to_concrete class_description with
-            | None -> conversion_failed "class_description"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type concrete in
-          concrete
+          let class_description = self#class_infos_class_type class_description in
+          class_description
       method class_type_declaration : Class_type_declaration.t -> 'res  =
         fun class_type_declaration ->
-          let concrete =
-            match Class_type_declaration.to_concrete class_type_declaration with
-            | None -> conversion_failed "class_type_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_type concrete in
-          concrete
+          let class_type_declaration = self#class_infos_class_type class_type_declaration in
+          class_type_declaration
       method class_expr : Class_expr.t -> 'res  =
         fun class_expr ->
           let concrete =
@@ -16059,13 +15654,8 @@ module V4_07 = struct
             self#constr (Some ("class_field_kind", 0)) "Cfk_concrete" [x0; x1]
       method class_declaration : Class_declaration.t -> 'res  =
         fun class_declaration ->
-          let concrete =
-            match Class_declaration.to_concrete class_declaration with
-            | None -> conversion_failed "class_declaration"
-            | Some n -> n
-          in
-          let concrete = self#class_infos_class_expr concrete in
-          concrete
+          let class_declaration = self#class_infos_class_expr class_declaration in
+          class_declaration
       method module_type : Module_type.t -> 'res  =
         fun module_type ->
           let concrete =
@@ -16244,22 +15834,12 @@ module V4_07 = struct
           self#record (Some ("include_infos", 1)) [("pincl_mod", pincl_mod); ("pincl_loc", pincl_loc); ("pincl_attributes", pincl_attributes)]
       method include_description : Include_description.t -> 'res  =
         fun include_description ->
-          let concrete =
-            match Include_description.to_concrete include_description with
-            | None -> conversion_failed "include_description"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_type concrete in
-          concrete
+          let include_description = self#include_infos_module_type include_description in
+          include_description
       method include_declaration : Include_declaration.t -> 'res  =
         fun include_declaration ->
-          let concrete =
-            match Include_declaration.to_concrete include_declaration with
-            | None -> conversion_failed "include_declaration"
-            | Some n -> n
-          in
-          let concrete = self#include_infos_module_expr concrete in
-          concrete
+          let include_declaration = self#include_infos_module_expr include_declaration in
+          include_declaration
       method with_constraint : With_constraint.t -> 'res  =
         fun with_constraint ->
           let concrete =

--- a/astlib/grammar.ml
+++ b/astlib/grammar.ml
@@ -59,15 +59,15 @@ type clause =
 type variant = (string * clause) list
 
 (** A nominal type may contain a structural type, a record type, or a variant type. *)
-type nominal =
+type versioned =
   | Wrapper of ty
   | Record of record
   | Variant of variant
 
-(** A declaration may be a structural type or a nominal type. *)
+(** A declaration may be an unversioned structure type or a versioned node type. *)
 type decl =
-  | Structural of ty
-  | Nominal of nominal
+  | Unversioned of ty
+  | Versioned of versioned
 
 (** The "kind" of a type determines its type arguments. [Mono]morphic types have no type
     arguments; [Poly]morphic types have one or more type arguments. *)

--- a/astlib/grammar.ml
+++ b/astlib/grammar.ml
@@ -58,11 +58,16 @@ type clause =
 
 type variant = (string * clause) list
 
-(** A declaration may be an alias for a structural type, or a record or variant type. *)
-type decl =
-  | Alias of ty
+(** A nominal type may contain a structural type, a record type, or a variant type. *)
+type nominal =
+  | Wrapper of ty
   | Record of record
   | Variant of variant
+
+(** A declaration may be a structural type or a nominal type. *)
+type decl =
+  | Structural of ty
+  | Nominal of nominal
 
 (** The "kind" of a type determines its type arguments. [Mono]morphic types have no type
     arguments; [Poly]morphic types have one or more type arguments. *)

--- a/astlib/latest_version.ml
+++ b/astlib/latest_version.ml
@@ -3,643 +3,678 @@ let version = "v4.07"
 let conversions : History.conversion list = []
 
 let grammar : Grammar.t =
-  [ "longident",
-    Mono
-      (Variant
-         [ "Lident", Tuple [String]
-         ; "Ldot", Tuple [Name "longident"; String]
-         ; "Lapply", Tuple [Name "longident"; Name "longident"]
-         ])
-  ; "longident_loc", Mono (Alias (Loc (Name "longident")))
-  ; "rec_flag", Mono (Variant ["Nonrecursive", Empty; "Recursive", Empty])
-  ; "direction_flag", Mono (Variant ["Upto", Empty; "Downto", Empty])
-  ; "private_flag", Mono (Variant ["Private", Empty; "Public", Empty])
-  ; "mutable_flag", Mono (Variant ["Immutable", Empty; "Mutable", Empty])
-  ; "virtual_flag", Mono (Variant ["Virtual", Empty; "Concrete", Empty])
-  ; "override_flag", Mono (Variant ["Override", Empty; "Fresh", Empty])
-  ; "closed_flag", Mono (Variant ["Closed", Empty; "Open", Empty])
-  ; "label", Mono (Alias String)
-  ; "arg_label",
-    Mono
-      (Variant
-         [ "Nolabel", Empty
-         ; "Labelled", Tuple [String]
-         ; "Optional", Tuple [String]
-         ])
-  ; "variance",
-    Mono
-      (Variant
-         [ "Covariant", Empty
-         ; "Contravariant", Empty
-         ; "Invariant", Empty
-         ])
-  ; "constant",
-    Mono
-      (Variant
-         [ "Pconst_integer", Tuple [String; Option Char]
-         ; "Pconst_char", Tuple [Char]
-         ; "Pconst_string", Tuple [String; Option String]
-         ; "Pconst_float", Tuple [String; Option Char]
-         ])
-  ; "attribute", Mono (Alias (Tuple [Loc String; Name "payload"]))
-  ; "extension", Mono (Alias (Tuple [Loc String; Name "payload"]))
-  ; "attributes", Mono (Alias (List (Name "attribute")))
-  ; "payload",
-    Mono
-      (Variant
-         [ "PStr", Tuple [Name "structure"]
-         ; "PSig", Tuple [Name "signature"]
-         ; "PTyp", Tuple [Name "core_type"]
-         ; "PPat", Tuple [Name "pattern"; Option (Name "expression")]
-         ])
-  ; "core_type",
-    Mono
-      (Record
-         [ "ptyp_desc", Name "core_type_desc"
-         ; "ptyp_loc", Location
-         ; "ptyp_attributes", Name "attributes"
-         ])
-  ; "core_type_desc",
-    Mono
-      (Variant
-         [ "Ptyp_any", Empty
-         ; "Ptyp_var", Tuple [String]
-         ; "Ptyp_arrow", Tuple [Name "arg_label"; Name "core_type"; Name "core_type"]
-         ; "Ptyp_tuple", Tuple [List (Name "core_type")]
-         ; "Ptyp_constr", Tuple [Name "longident_loc"; List (Name "core_type")]
-         ; "Ptyp_object", Tuple [List (Name "object_field"); Name "closed_flag"]
-         ; "Ptyp_class", Tuple [Name "longident_loc"; List (Name "core_type")]
-         ; "Ptyp_alias", Tuple [Name "core_type"; String]
-         ; "Ptyp_variant",
-           Tuple
-             [ List (Name "row_field")
-             ; Name "closed_flag"
-             ; Option (List (Name "label"))
-             ]
-         ; "Ptyp_poly", Tuple [List (Loc String); Name "core_type"]
-         ; "Ptyp_package", Tuple [Name "package_type"]
-         ; "Ptyp_extension", Tuple [Name "extension"]
-         ])
-  ; "package_type",
-    Mono
-      (Alias
-         (Tuple
-            [ Name "longident_loc"
-            ; List (Tuple [Name "longident_loc"; Name "core_type"])
-            ]))
-  ; "row_field",
-    Mono
-      (Variant
-         [ "Rtag",
-           Tuple
-             [ Loc (Name "label")
-             ; Name "attributes"
-             ; Bool
-             ; List (Name "core_type")
-             ]
-         ; "Rinherit", Tuple [Name "core_type"]
-         ])
-  ; "object_field",
-    Mono
-      (Variant
-         [ "Otag", Tuple [Loc (Name "label"); Name "attributes"; Name "core_type"]
-         ; "Oinherit", Tuple [Name "core_type"]
-         ])
-  ; "pattern",
-    Mono (
-      Record
-        [ "ppat_desc", Name "pattern_desc"
-        ; "ppat_loc", Location
-        ; "ppat_attributes", Name "attributes"
-        ])
-  ; "pattern_desc",
-    Mono
-      (Variant
-         [ "Ppat_any", Empty
-         ; "Ppat_var", Tuple [Loc String]
-         ; "Ppat_alias", Tuple [Name "pattern"; Loc String]
-         ; "Ppat_constant", Tuple [Name "constant"]
-         ; "Ppat_interval", Tuple [Name "constant"; Name "constant"]
-         ; "Ppat_tuple", Tuple [List (Name "pattern")]
-         ; "Ppat_construct", Tuple [Name "longident_loc"; Option (Name "pattern")]
-         ; "Ppat_variant", Tuple [Name "label"; Option (Name "pattern")]
-         ; "Ppat_record",
-           Tuple
-             [ List (Tuple [Name "longident_loc"; Name "pattern"])
-             ; Name "closed_flag"
-             ]
-         ; "Ppat_array", Tuple [List (Name "pattern")]
-         ; "Ppat_or", Tuple [Name "pattern"; Name "pattern"]
-         ; "Ppat_constraint", Tuple [Name "pattern"; Name "core_type"]
-         ; "Ppat_type", Tuple [Name "longident_loc"]
-         ; "Ppat_lazy", Tuple [Name "pattern"]
-         ; "Ppat_unpack", Tuple [Loc String]
-         ; "Ppat_exception", Tuple [Name "pattern"]
-         ; "Ppat_extension", Tuple [Name "extension"]
-         ; "Ppat_open", Tuple [Name "longident_loc"; Name "pattern"]
-         ])
-  ; "expression",
-    Mono
-      (Record
-         [ "pexp_desc", Name "expression_desc"
-         ; "pexp_loc", Location
-         ; "pexp_attributes", Name "attributes"
-         ])
-  ; "expression_desc",
-    Mono
-      (Variant
-         [ "Pexp_ident", Tuple [Name "longident_loc"]
-         ; "Pexp_constant", Tuple [Name "constant"]
-         ; "Pexp_let",
-           Tuple
-             [ Name "rec_flag"
-             ; List (Name "value_binding")
-             ; Name "expression"
-             ]
-         ; "Pexp_function", Tuple [List (Name "case")]
-         ; "Pexp_fun",
-           Tuple
-             [ Name "arg_label"
-             ; Option (Name "expression")
-             ; Name "pattern"
-             ; Name "expression"
-             ]
-         ; "Pexp_apply",
-           Tuple
-             [ Name "expression"
-             ; List (Tuple [Name "arg_label"; Name "expression"])
-             ]
-         ; "Pexp_match", Tuple [Name "expression"; List (Name "case")]
-         ; "Pexp_try", Tuple [Name "expression"; List (Name "case")]
-         ; "Pexp_tuple", Tuple [List (Name "expression")]
-         ; "Pexp_construct", Tuple [Name "longident_loc"; Option (Name "expression")]
-         ; "Pexp_variant", Tuple [Name "label"; Option (Name "expression")]
-         ; "Pexp_record",
-           Tuple
-             [ List (Tuple [Name "longident_loc"; Name "expression"])
-             ; Option (Name "expression")
-             ]
-         ; "Pexp_field", Tuple [Name "expression"; Name "longident_loc"]
-         ; "Pexp_setfield",
-           Tuple
-             [ Name "expression"
-             ; Name "longident_loc"
-             ; Name "expression"
-             ]
-         ; "Pexp_array", Tuple [List (Name "expression")]
-         ; "Pexp_ifthenelse",
-           Tuple
-             [ Name "expression"
-             ; Name "expression"
-             ; Option (Name "expression")
-             ]
-         ; "Pexp_sequence", Tuple [Name "expression"; Name "expression"]
-         ; "Pexp_while", Tuple [Name "expression"; Name "expression"]
-         ; "Pexp_for",
-           Tuple
-             [ Name "pattern"
-             ; Name "expression"
-             ; Name "expression"
-             ; Name "direction_flag"
-             ; Name "expression"
-             ]
-         ; "Pexp_constraint", Tuple [Name "expression"; Name "core_type"]
-         ; "Pexp_coerce",
-           Tuple
-             [ Name "expression"
-             ; Option (Name "core_type")
-             ; Name "core_type"
-             ]
-         ; "Pexp_send", Tuple [Name "expression"; Loc (Name "label")]
-         ; "Pexp_new", Tuple [Name "longident_loc"]
-         ; "Pexp_setinstvar", Tuple [Loc (Name "label"); Name "expression"]
-         ; "Pexp_override", Tuple [List (Tuple [Loc (Name "label"); Name "expression"])]
-         ; "Pexp_letmodule", Tuple [Loc String; Name "module_expr"; Name "expression"]
-         ; "Pexp_letexception", Tuple [Name "extension_constructor"; Name "expression"]
-         ; "Pexp_assert", Tuple [Name "expression"]
-         ; "Pexp_lazy", Tuple [Name "expression"]
-         ; "Pexp_poly", Tuple [Name "expression"; Option (Name "core_type")]
-         ; "Pexp_object", Tuple [Name "class_structure"]
-         ; "Pexp_newtype", Tuple [Loc String; Name "expression"]
-         ; "Pexp_pack", Tuple [Name "module_expr"]
-         ; "Pexp_open",
-           Tuple
-             [ Name "override_flag"
-             ; Name "longident_loc"
-             ; Name "expression"
-             ]
-         ; "Pexp_extension", Tuple [Name "extension"]
-         ; "Pexp_unreachable", Empty
-         ])
-  ; "case",
-    Mono
-      (Record
-         [ "pc_lhs", Name "pattern"
-         ; "pc_guard", Option (Name "expression")
-         ; "pc_rhs", Name "expression"
-         ])
-  ; "value_description",
-    Mono
-      (Record
-         [ "pval_name", Loc String
-         ; "pval_type", Name "core_type"
-         ; "pval_prim", List String
-         ; "pval_attributes", Name "attributes"
-         ; "pval_loc", Location
-         ])
-  ; "type_declaration",
-    Mono
-      (Record
-         [ "ptype_name", Loc String
-         ; "ptype_params", List (Tuple [Name "core_type"; Name "variance"])
-         ; "ptype_cstrs", List (Tuple [Name "core_type"; Name "core_type"; Location])
-         ; "ptype_kind", Name "type_kind"
-         ; "ptype_private", Name "private_flag"
-         ; "ptype_manifest", Option (Name "core_type")
-         ; "ptype_attributes", Name "attributes"
-         ; "ptype_loc", Location
-         ])
-  ; "type_kind",
-    Mono
-      (Variant
-         [ "Ptype_abstract", Empty
-         ; "Ptype_variant", Tuple [List (Name "constructor_declaration")]
-         ; "Ptype_record", Tuple [List (Name "label_declaration")]
-         ; "Ptype_open", Empty
-         ])
-  ; "label_declaration",
-    Mono
-      (Record
-         [ "pld_name", Loc String
-         ; "pld_mutable", Name "mutable_flag"
-         ; "pld_type", Name "core_type"
-         ; "pld_loc", Location
-         ; "pld_attributes", Name "attributes"
-         ])
-  ; "constructor_declaration",
-    Mono
-      (Record
-         [ "pcd_name", Loc String
-         ; "pcd_args", Name "constructor_arguments"
-         ; "pcd_res", Option (Name "core_type")
-         ; "pcd_loc", Location
-         ; "pcd_attributes", Name "attributes"
-         ])
-  ; "constructor_arguments",
-    Mono
-      (Variant
-         [ "Pcstr_tuple", Tuple [List (Name "core_type")]
-         ; "Pcstr_record", Tuple [List (Name "label_declaration")]
-         ])
-  ; "type_extension",
-    Mono
-      (Record
-         [ "ptyext_path", Name "longident_loc"
-         ; "ptyext_params", List (Tuple [Name "core_type"; Name "variance"])
-         ; "ptyext_constructors", List (Name "extension_constructor")
-         ; "ptyext_private", Name "private_flag"
-         ; "ptyext_attributes", Name "attributes"
-         ])
-  ; "extension_constructor",
-    Mono
-      (Record
-         [ "pext_name", Loc String
-         ; "pext_kind", Name "extension_constructor_kind"
-         ; "pext_loc", Location
-         ; "pext_attributes", Name "attributes"
-         ])
-  ; "extension_constructor_kind",
-    Mono
-      (Variant
-         [ "Pext_decl", Tuple [Name "constructor_arguments"; Option (Name "core_type")]
-         ; "Pext_rebind", Tuple [Name "longident_loc"]
-         ])
-  ; "class_type",
-    Mono
-      (Record
-         [ "pcty_desc", Name "class_type_desc"
-         ; "pcty_loc", Location
-         ; "pcty_attributes", Name "attributes"
-         ])
-  ; "class_type_desc",
-    Mono
-      (Variant
-         [ "Pcty_constr", Tuple [Name "longident_loc"; List (Name "core_type")]
-         ; "Pcty_signature", Tuple [Name "class_signature"]
-         ; "Pcty_arrow", Tuple [Name "arg_label"; Name "core_type"; Name "class_type"]
-         ; "Pcty_extension", Tuple [Name "extension"]
-         ; "Pcty_open",
-           Tuple
-             [ Name "override_flag"
-             ; Name "longident_loc"
-             ; Name "class_type"
-             ]
-         ])
-  ; "class_signature",
-    Mono
-      (Record
-         [ "pcsig_self", Name "core_type"
-         ; "pcsig_fields", List (Name "class_type_field")
-         ])
-  ; "class_type_field",
-    Mono
-      (Record
-         [ "pctf_desc", Name "class_type_field_desc"
-         ; "pctf_loc", Location
-         ; "pctf_attributes", Name "attributes"
-         ])
-  ; "class_type_field_desc",
-    Mono
-      (Variant
-         [ "Pctf_inherit", Tuple [Name "class_type"]
-         ; "Pctf_val",
-           Tuple
-             [ Tuple
-                 [ Loc (Name "label")
-                 ; Name "mutable_flag"
-                 ; Name "virtual_flag"
-                 ; Name "core_type"
-                 ]
-             ]
-         ; "Pctf_method",
-           Tuple
-             [ Tuple
-                 [ Loc (Name "label")
-                 ; Name "private_flag"
-                 ; Name "virtual_flag"
-                 ; Name "core_type"
-                 ]
-             ]
-         ; "Pctf_constraint", Tuple [Tuple [Name "core_type"; Name "core_type"]]
-         ; "Pctf_attribute", Tuple [Name "attribute"]
-         ; "Pctf_extension", Tuple [Name "extension"]
-         ])
-  ; "class_infos",
-    Poly
-      (["a"],
-       Record
-         [ "pci_virt", Name "virtual_flag"
-         ; "pci_params", List (Tuple [Name "core_type"; Name "variance"])
-         ; "pci_name", Loc String
-         ; "pci_expr", Var "a"
-         ; "pci_loc", Location
-         ; "pci_attributes", Name "attributes"
-         ])
-  ; "class_description", Mono (Alias (Instance ("class_infos", [Name "class_type"])))
-  ; "class_type_declaration", Mono (Alias (Instance ("class_infos", [Name "class_type"])))
-  ; "class_expr",
-    Mono
-      (Record
-         [ "pcl_desc", Name "class_expr_desc"
-         ; "pcl_loc", Location
-         ; "pcl_attributes", Name "attributes"
-         ])
-  ; "class_expr_desc",
-    Mono
-      (Variant
-         [ "Pcl_constr", Tuple [Name "longident_loc"; List (Name "core_type")]
-         ; "Pcl_structure", Tuple [Name "class_structure"]
-         ; "Pcl_fun",
-           Tuple
-             [ Name "arg_label"
-             ; Option (Name "expression")
-             ; Name "pattern"
-             ; Name "class_expr"
-             ]
-         ; "Pcl_apply",
-           Tuple [Name "class_expr"; List (Tuple [Name "arg_label"; Name "expression"])]
-         ; "Pcl_let",
-           Tuple
-             [ Name "rec_flag"
-             ; List (Name "value_binding")
-             ; Name "class_expr"
-             ]
-         ; "Pcl_constraint", Tuple [Name "class_expr"; Name "class_type"]
-         ; "Pcl_extension", Tuple [Name "extension"]
-         ; "Pcl_open",
-           Tuple
-             [ Name "override_flag"
-             ; Name "longident_loc"
-             ; Name "class_expr"
-             ]
-         ])
-  ; "class_structure",
-    Mono
-      (Record
-         [ "pcstr_self", Name "pattern"
-         ; "pcstr_fields", List (Name "class_field")
-         ])
-  ; "class_field",
-    Mono
-      (Record
-         [ "pcf_desc", Name "class_field_desc"
-         ; "pcf_loc", Location
-         ; "pcf_attributes", Name "attributes"
-         ])
-  ; "class_field_desc",
-    Mono
-      (Variant
-         [ "Pcf_inherit",
-           Tuple
-             [ Name "override_flag"
-             ; Name "class_expr"
-             ; Option (Loc String)
-             ]
-         ; "Pcf_val",
-           Tuple
-             [ Tuple
-                 [ Loc (Name "label")
-                 ; Name "mutable_flag"
-                 ; Name "class_field_kind"
-                 ]
-             ]
-         ; "Pcf_method",
-           Tuple
-             [ Tuple
-                 [ Loc (Name "label")
-                 ; Name "private_flag"
-                 ; Name "class_field_kind"
-                 ]
-             ]
-         ; "Pcf_constraint", Tuple [Tuple [Name "core_type"; Name "core_type"]]
-         ; "Pcf_initializer", Tuple [Name "expression"]
-         ; "Pcf_attribute", Tuple [Name "attribute"]
-         ; "Pcf_extension", Tuple [Name "extension"]
-         ])
-  ; "class_field_kind",
-    Mono
-      (Variant
-         [ "Cfk_virtual", Tuple [Name "core_type"]
-         ; "Cfk_concrete", Tuple [Name "override_flag"; Name "expression"]
-         ])
-  ; "class_declaration", Mono (Alias (Instance ("class_infos", [Name "class_expr"])))
-  ; "module_type",
-    Mono
-      (Record
-         [ "pmty_desc", Name "module_type_desc"
-         ; "pmty_loc", Location
-         ; "pmty_attributes", Name "attributes"
-         ])
-  ; "module_type_desc",
-    Mono
-      (Variant
-         [ "Pmty_ident", Tuple [Name "longident_loc"]
-         ; "Pmty_signature", Tuple [Name "signature"]
-         ; "Pmty_functor",
-           Tuple
-             [ Loc String
-             ; Option (Name "module_type")
-             ; Name "module_type"
-             ]
-         ; "Pmty_with", Tuple [Name "module_type"; List (Name "with_constraint")]
-         ; "Pmty_typeof", Tuple [Name "module_expr"]
-         ; "Pmty_extension", Tuple [Name "extension"]
-         ; "Pmty_alias", Tuple [Name "longident_loc"]
-         ])
-  ; "signature", Mono (Alias (List (Name "signature_item")))
-  ; "signature_item",
-    Mono
-      (Record
-         [ "psig_desc", Name "signature_item_desc"
-         ; "psig_loc", Location
-         ])
-  ; "signature_item_desc",
-    Mono
-      (Variant
-         [ "Psig_value", Tuple [Name "value_description"]
-         ; "Psig_type", Tuple [Name "rec_flag"; List (Name "type_declaration")]
-         ; "Psig_typext", Tuple [Name "type_extension"]
-         ; "Psig_exception", Tuple [Name "extension_constructor"]
-         ; "Psig_module", Tuple [Name "module_declaration"]
-         ; "Psig_recmodule", Tuple [List (Name "module_declaration")]
-         ; "Psig_modtype", Tuple [Name "module_type_declaration"]
-         ; "Psig_open", Tuple [Name "open_description"]
-         ; "Psig_include", Tuple [Name "include_description"]
-         ; "Psig_class", Tuple [List (Name "class_description")]
-         ; "Psig_class_type", Tuple [List (Name "class_type_declaration")]
-         ; "Psig_attribute", Tuple [Name "attribute"]
-         ; "Psig_extension", Tuple [Name "extension"; Name "attributes"]
-         ])
-  ; "module_declaration",
-    Mono
-      (Record
-         [ "pmd_name", Loc String
-         ; "pmd_type", Name "module_type"
-         ; "pmd_attributes", Name "attributes"
-         ; "pmd_loc", Location
-         ])
-  ; "module_type_declaration",
-    Mono
-      (Record
-         [ "pmtd_name", Loc String
-         ; "pmtd_type", Option (Name "module_type")
-         ; "pmtd_attributes", Name "attributes"
-         ; "pmtd_loc", Location
-         ])
-  ; "open_description",
-    Mono
-      (Record
-         [ "popen_lid", Name "longident_loc"
-         ; "popen_override", Name "override_flag"
-         ; "popen_loc", Location
-         ; "popen_attributes", Name "attributes"
-         ])
-  ; "include_infos",
-    Poly
-      (["a"],
-       Record
-         [ "pincl_mod", Var "a"
-         ; "pincl_loc", Location
-         ; "pincl_attributes", Name "attributes"
-         ])
-  ; "include_description", Mono (Alias (Instance ("include_infos", [Name "module_type"])))
-  ; "include_declaration", Mono (Alias (Instance ("include_infos", [Name "module_expr"])))
-  ; "with_constraint",
-    Mono
-      (Variant
-         [ "Pwith_type", Tuple [Name "longident_loc"; Name "type_declaration"]
-         ; "Pwith_module", Tuple [Name "longident_loc"; Name "longident_loc"]
-         ; "Pwith_typesubst", Tuple [Name "longident_loc"; Name "type_declaration"]
-         ; "Pwith_modsubst", Tuple [Name "longident_loc"; Name "longident_loc"]
-         ])
-  ; "module_expr",
-    Mono
-      (Record
-         [ "pmod_desc", Name "module_expr_desc"
-         ; "pmod_loc", Location
-         ; "pmod_attributes", Name "attributes"
-         ])
-  ; "module_expr_desc",
-    Mono
-      (Variant
-         [ "Pmod_ident", Tuple [Name "longident_loc"]
-         ; "Pmod_structure", Tuple [Name "structure"]
-         ; "Pmod_functor",
-           Tuple
-             [ Loc String
-             ; Option (Name "module_type")
-             ; Name "module_expr"
-             ]
-         ; "Pmod_apply", Tuple [Name "module_expr"; Name "module_expr"]
-         ; "Pmod_constraint", Tuple [Name "module_expr"; Name "module_type"]
-         ; "Pmod_unpack", Tuple [Name "expression"]
-         ; "Pmod_extension", Tuple [Name "extension"]
-         ])
-  ; "structure", Mono (Alias (List (Name "structure_item")))
-  ; "structure_item",
-    Mono
-      (Record
-         [ "pstr_desc", Name "structure_item_desc"
-         ; "pstr_loc", Location
-         ])
-  ; "structure_item_desc",
-    Mono
-      (Variant
-         [ "Pstr_eval", Tuple [Name "expression"; Name "attributes"]
-         ; "Pstr_value", Tuple [Name "rec_flag"; List (Name "value_binding")]
-         ; "Pstr_primitive", Tuple [Name "value_description"]
-         ; "Pstr_type", Tuple [Name "rec_flag"; List (Name "type_declaration")]
-         ; "Pstr_typext", Tuple [Name "type_extension"]
-         ; "Pstr_exception", Tuple [Name "extension_constructor"]
-         ; "Pstr_module", Tuple [Name "module_binding"]
-         ; "Pstr_recmodule", Tuple [List (Name "module_binding")]
-         ; "Pstr_modtype", Tuple [Name "module_type_declaration"]
-         ; "Pstr_open", Tuple [Name "open_description"]
-         ; "Pstr_class", Tuple [List (Name "class_declaration")]
-         ; "Pstr_class_type", Tuple [List (Name "class_type_declaration")]
-         ; "Pstr_include", Tuple [Name "include_declaration"]
-         ; "Pstr_attribute", Tuple [Name "attribute"]
-         ; "Pstr_extension", Tuple [Name "extension"; Name "attributes"]
-         ])
-  ; "value_binding",
-    Mono
-      (Record
-         [ "pvb_pat", Name "pattern"
-         ; "pvb_expr", Name "expression"
-         ; "pvb_attributes", Name "attributes"
-         ; "pvb_loc", Location
-         ])
-  ; "module_binding",
-    Mono
-      (Record
-         [ "pmb_name", Loc String
-         ; "pmb_expr", Name "module_expr"
-         ; "pmb_attributes", Name "attributes"
-         ; "pmb_loc", Location
-         ])
-  ; "toplevel_phrase",
-    Mono
-      (Variant
-         [ "Ptop_def", Tuple [Name "structure"]
-         ; "Ptop_dir", Tuple [String; Name "directive_argument"]
-         ])
-  ; "directive_argument",
-    Mono
-      (Variant
-         [ "Pdir_none", Empty
-         ; "Pdir_string", Tuple [String]
-         ; "Pdir_int", Tuple [String; Option Char]
-         ; "Pdir_ident", Tuple [Name "longident"]
-         ; "Pdir_bool", Tuple [Bool]
-         ])
-  ]
+  [ ( "longident"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Lident", Tuple [String])
+              ; ("Ldot", Tuple [Name "longident"; String])
+              ; ("Lapply", Tuple [Name "longident"; Name "longident"]) ])) )
+  ; ("longident_loc", Mono (Structural (Loc (Name "longident"))))
+  ; ( "rec_flag"
+    , Mono (Nominal (Variant [("Nonrecursive", Empty); ("Recursive", Empty)]))
+    )
+  ; ( "direction_flag"
+    , Mono (Nominal (Variant [("Upto", Empty); ("Downto", Empty)])) )
+  ; ( "private_flag"
+    , Mono (Nominal (Variant [("Private", Empty); ("Public", Empty)])) )
+  ; ( "mutable_flag"
+    , Mono (Nominal (Variant [("Immutable", Empty); ("Mutable", Empty)])) )
+  ; ( "virtual_flag"
+    , Mono (Nominal (Variant [("Virtual", Empty); ("Concrete", Empty)])) )
+  ; ( "override_flag"
+    , Mono (Nominal (Variant [("Override", Empty); ("Fresh", Empty)])) )
+  ; ( "closed_flag"
+    , Mono (Nominal (Variant [("Closed", Empty); ("Open", Empty)])) )
+  ; ("label", Mono (Structural String))
+  ; ( "arg_label"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Nolabel", Empty)
+              ; ("Labelled", Tuple [String])
+              ; ("Optional", Tuple [String]) ])) )
+  ; ( "variance"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Covariant", Empty)
+              ; ("Contravariant", Empty)
+              ; ("Invariant", Empty) ])) )
+  ; ( "constant"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Pconst_integer", Tuple [String; Option Char])
+              ; ("Pconst_char", Tuple [Char])
+              ; ("Pconst_string", Tuple [String; Option String])
+              ; ("Pconst_float", Tuple [String; Option Char]) ])) )
+  ; ("attribute", Mono (Nominal (Wrapper (Tuple [Loc String; Name "payload"]))))
+  ; ("extension", Mono (Nominal (Wrapper (Tuple [Loc String; Name "payload"]))))
+  ; ("attributes", Mono (Nominal (Wrapper (List (Name "attribute")))))
+  ; ( "payload"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("PStr", Tuple [Name "structure"])
+              ; ("PSig", Tuple [Name "signature"])
+              ; ("PTyp", Tuple [Name "core_type"])
+              ; ("PPat", Tuple [Name "pattern"; Option (Name "expression")]) ]))
+    )
+  ; ( "core_type"
+    , Mono
+        (Nominal
+           (Record
+              [ ("ptyp_desc", Name "core_type_desc")
+              ; ("ptyp_loc", Location)
+              ; ("ptyp_attributes", Name "attributes") ])) )
+  ; ( "core_type_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Ptyp_any", Empty)
+              ; ("Ptyp_var", Tuple [String])
+              ; ( "Ptyp_arrow"
+                , Tuple [Name "arg_label"; Name "core_type"; Name "core_type"]
+                )
+              ; ("Ptyp_tuple", Tuple [List (Name "core_type")])
+              ; ( "Ptyp_constr"
+                , Tuple [Name "longident_loc"; List (Name "core_type")] )
+              ; ( "Ptyp_object"
+                , Tuple [List (Name "object_field"); Name "closed_flag"] )
+              ; ( "Ptyp_class"
+                , Tuple [Name "longident_loc"; List (Name "core_type")] )
+              ; ("Ptyp_alias", Tuple [Name "core_type"; String])
+              ; ( "Ptyp_variant"
+                , Tuple
+                    [ List (Name "row_field")
+                    ; Name "closed_flag"
+                    ; Option (List (Name "label")) ] )
+              ; ("Ptyp_poly", Tuple [List (Loc String); Name "core_type"])
+              ; ("Ptyp_package", Tuple [Name "package_type"])
+              ; ("Ptyp_extension", Tuple [Name "extension"]) ])) )
+  ; ( "package_type"
+    , Mono
+        (Nominal
+           (Wrapper
+              (Tuple
+                 [ Name "longident_loc"
+                 ; List (Tuple [Name "longident_loc"; Name "core_type"]) ])))
+    )
+  ; ( "row_field"
+    , Mono
+        (Nominal
+           (Variant
+              [ ( "Rtag"
+                , Tuple
+                    [ Loc (Name "label")
+                    ; Name "attributes"
+                    ; Bool
+                    ; List (Name "core_type") ] )
+              ; ("Rinherit", Tuple [Name "core_type"]) ])) )
+  ; ( "object_field"
+    , Mono
+        (Nominal
+           (Variant
+              [ ( "Otag"
+                , Tuple
+                    [Loc (Name "label"); Name "attributes"; Name "core_type"]
+                )
+              ; ("Oinherit", Tuple [Name "core_type"]) ])) )
+  ; ( "pattern"
+    , Mono
+        (Nominal
+           (Record
+              [ ("ppat_desc", Name "pattern_desc")
+              ; ("ppat_loc", Location)
+              ; ("ppat_attributes", Name "attributes") ])) )
+  ; ( "pattern_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Ppat_any", Empty)
+              ; ("Ppat_var", Tuple [Loc String])
+              ; ("Ppat_alias", Tuple [Name "pattern"; Loc String])
+              ; ("Ppat_constant", Tuple [Name "constant"])
+              ; ("Ppat_interval", Tuple [Name "constant"; Name "constant"])
+              ; ("Ppat_tuple", Tuple [List (Name "pattern")])
+              ; ( "Ppat_construct"
+                , Tuple [Name "longident_loc"; Option (Name "pattern")] )
+              ; ("Ppat_variant", Tuple [Name "label"; Option (Name "pattern")])
+              ; ( "Ppat_record"
+                , Tuple
+                    [ List (Tuple [Name "longident_loc"; Name "pattern"])
+                    ; Name "closed_flag" ] )
+              ; ("Ppat_array", Tuple [List (Name "pattern")])
+              ; ("Ppat_or", Tuple [Name "pattern"; Name "pattern"])
+              ; ("Ppat_constraint", Tuple [Name "pattern"; Name "core_type"])
+              ; ("Ppat_type", Tuple [Name "longident_loc"])
+              ; ("Ppat_lazy", Tuple [Name "pattern"])
+              ; ("Ppat_unpack", Tuple [Loc String])
+              ; ("Ppat_exception", Tuple [Name "pattern"])
+              ; ("Ppat_extension", Tuple [Name "extension"])
+              ; ("Ppat_open", Tuple [Name "longident_loc"; Name "pattern"]) ]))
+    )
+  ; ( "expression"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pexp_desc", Name "expression_desc")
+              ; ("pexp_loc", Location)
+              ; ("pexp_attributes", Name "attributes") ])) )
+  ; ( "expression_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Pexp_ident", Tuple [Name "longident_loc"])
+              ; ("Pexp_constant", Tuple [Name "constant"])
+              ; ( "Pexp_let"
+                , Tuple
+                    [ Name "rec_flag"
+                    ; List (Name "value_binding")
+                    ; Name "expression" ] )
+              ; ("Pexp_function", Tuple [List (Name "case")])
+              ; ( "Pexp_fun"
+                , Tuple
+                    [ Name "arg_label"
+                    ; Option (Name "expression")
+                    ; Name "pattern"
+                    ; Name "expression" ] )
+              ; ( "Pexp_apply"
+                , Tuple
+                    [ Name "expression"
+                    ; List (Tuple [Name "arg_label"; Name "expression"]) ] )
+              ; ("Pexp_match", Tuple [Name "expression"; List (Name "case")])
+              ; ("Pexp_try", Tuple [Name "expression"; List (Name "case")])
+              ; ("Pexp_tuple", Tuple [List (Name "expression")])
+              ; ( "Pexp_construct"
+                , Tuple [Name "longident_loc"; Option (Name "expression")] )
+              ; ( "Pexp_variant"
+                , Tuple [Name "label"; Option (Name "expression")] )
+              ; ( "Pexp_record"
+                , Tuple
+                    [ List (Tuple [Name "longident_loc"; Name "expression"])
+                    ; Option (Name "expression") ] )
+              ; ("Pexp_field", Tuple [Name "expression"; Name "longident_loc"])
+              ; ( "Pexp_setfield"
+                , Tuple
+                    [Name "expression"; Name "longident_loc"; Name "expression"]
+                )
+              ; ("Pexp_array", Tuple [List (Name "expression")])
+              ; ( "Pexp_ifthenelse"
+                , Tuple
+                    [ Name "expression"
+                    ; Name "expression"
+                    ; Option (Name "expression") ] )
+              ; ("Pexp_sequence", Tuple [Name "expression"; Name "expression"])
+              ; ("Pexp_while", Tuple [Name "expression"; Name "expression"])
+              ; ( "Pexp_for"
+                , Tuple
+                    [ Name "pattern"
+                    ; Name "expression"
+                    ; Name "expression"
+                    ; Name "direction_flag"
+                    ; Name "expression" ] )
+              ; ("Pexp_constraint", Tuple [Name "expression"; Name "core_type"])
+              ; ( "Pexp_coerce"
+                , Tuple
+                    [ Name "expression"
+                    ; Option (Name "core_type")
+                    ; Name "core_type" ] )
+              ; ("Pexp_send", Tuple [Name "expression"; Loc (Name "label")])
+              ; ("Pexp_new", Tuple [Name "longident_loc"])
+              ; ( "Pexp_setinstvar"
+                , Tuple [Loc (Name "label"); Name "expression"] )
+              ; ( "Pexp_override"
+                , Tuple [List (Tuple [Loc (Name "label"); Name "expression"])]
+                )
+              ; ( "Pexp_letmodule"
+                , Tuple [Loc String; Name "module_expr"; Name "expression"] )
+              ; ( "Pexp_letexception"
+                , Tuple [Name "extension_constructor"; Name "expression"] )
+              ; ("Pexp_assert", Tuple [Name "expression"])
+              ; ("Pexp_lazy", Tuple [Name "expression"])
+              ; ( "Pexp_poly"
+                , Tuple [Name "expression"; Option (Name "core_type")] )
+              ; ("Pexp_object", Tuple [Name "class_structure"])
+              ; ("Pexp_newtype", Tuple [Loc String; Name "expression"])
+              ; ("Pexp_pack", Tuple [Name "module_expr"])
+              ; ( "Pexp_open"
+                , Tuple
+                    [ Name "override_flag"
+                    ; Name "longident_loc"
+                    ; Name "expression" ] )
+              ; ("Pexp_extension", Tuple [Name "extension"])
+              ; ("Pexp_unreachable", Empty) ])) )
+  ; ( "case"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pc_lhs", Name "pattern")
+              ; ("pc_guard", Option (Name "expression"))
+              ; ("pc_rhs", Name "expression") ])) )
+  ; ( "value_description"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pval_name", Loc String)
+              ; ("pval_type", Name "core_type")
+              ; ("pval_prim", List String)
+              ; ("pval_attributes", Name "attributes")
+              ; ("pval_loc", Location) ])) )
+  ; ( "type_declaration"
+    , Mono
+        (Nominal
+           (Record
+              [ ("ptype_name", Loc String)
+              ; ( "ptype_params"
+                , List (Tuple [Name "core_type"; Name "variance"]) )
+              ; ( "ptype_cstrs"
+                , List (Tuple [Name "core_type"; Name "core_type"; Location])
+                )
+              ; ("ptype_kind", Name "type_kind")
+              ; ("ptype_private", Name "private_flag")
+              ; ("ptype_manifest", Option (Name "core_type"))
+              ; ("ptype_attributes", Name "attributes")
+              ; ("ptype_loc", Location) ])) )
+  ; ( "type_kind"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Ptype_abstract", Empty)
+              ; ("Ptype_variant", Tuple [List (Name "constructor_declaration")])
+              ; ("Ptype_record", Tuple [List (Name "label_declaration")])
+              ; ("Ptype_open", Empty) ])) )
+  ; ( "label_declaration"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pld_name", Loc String)
+              ; ("pld_mutable", Name "mutable_flag")
+              ; ("pld_type", Name "core_type")
+              ; ("pld_loc", Location)
+              ; ("pld_attributes", Name "attributes") ])) )
+  ; ( "constructor_declaration"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pcd_name", Loc String)
+              ; ("pcd_args", Name "constructor_arguments")
+              ; ("pcd_res", Option (Name "core_type"))
+              ; ("pcd_loc", Location)
+              ; ("pcd_attributes", Name "attributes") ])) )
+  ; ( "constructor_arguments"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Pcstr_tuple", Tuple [List (Name "core_type")])
+              ; ("Pcstr_record", Tuple [List (Name "label_declaration")]) ]))
+    )
+  ; ( "type_extension"
+    , Mono
+        (Nominal
+           (Record
+              [ ("ptyext_path", Name "longident_loc")
+              ; ( "ptyext_params"
+                , List (Tuple [Name "core_type"; Name "variance"]) )
+              ; ("ptyext_constructors", List (Name "extension_constructor"))
+              ; ("ptyext_private", Name "private_flag")
+              ; ("ptyext_attributes", Name "attributes") ])) )
+  ; ( "extension_constructor"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pext_name", Loc String)
+              ; ("pext_kind", Name "extension_constructor_kind")
+              ; ("pext_loc", Location)
+              ; ("pext_attributes", Name "attributes") ])) )
+  ; ( "extension_constructor_kind"
+    , Mono
+        (Nominal
+           (Variant
+              [ ( "Pext_decl"
+                , Tuple
+                    [Name "constructor_arguments"; Option (Name "core_type")]
+                )
+              ; ("Pext_rebind", Tuple [Name "longident_loc"]) ])) )
+  ; ( "class_type"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pcty_desc", Name "class_type_desc")
+              ; ("pcty_loc", Location)
+              ; ("pcty_attributes", Name "attributes") ])) )
+  ; ( "class_type_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ( "Pcty_constr"
+                , Tuple [Name "longident_loc"; List (Name "core_type")] )
+              ; ("Pcty_signature", Tuple [Name "class_signature"])
+              ; ( "Pcty_arrow"
+                , Tuple [Name "arg_label"; Name "core_type"; Name "class_type"]
+                )
+              ; ("Pcty_extension", Tuple [Name "extension"])
+              ; ( "Pcty_open"
+                , Tuple
+                    [ Name "override_flag"
+                    ; Name "longident_loc"
+                    ; Name "class_type" ] ) ])) )
+  ; ( "class_signature"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pcsig_self", Name "core_type")
+              ; ("pcsig_fields", List (Name "class_type_field")) ])) )
+  ; ( "class_type_field"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pctf_desc", Name "class_type_field_desc")
+              ; ("pctf_loc", Location)
+              ; ("pctf_attributes", Name "attributes") ])) )
+  ; ( "class_type_field_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Pctf_inherit", Tuple [Name "class_type"])
+              ; ( "Pctf_val"
+                , Tuple
+                    [ Tuple
+                        [ Loc (Name "label")
+                        ; Name "mutable_flag"
+                        ; Name "virtual_flag"
+                        ; Name "core_type" ] ] )
+              ; ( "Pctf_method"
+                , Tuple
+                    [ Tuple
+                        [ Loc (Name "label")
+                        ; Name "private_flag"
+                        ; Name "virtual_flag"
+                        ; Name "core_type" ] ] )
+              ; ( "Pctf_constraint"
+                , Tuple [Tuple [Name "core_type"; Name "core_type"]] )
+              ; ("Pctf_attribute", Tuple [Name "attribute"])
+              ; ("Pctf_extension", Tuple [Name "extension"]) ])) )
+  ; ( "class_infos"
+    , Poly
+        ( ["a"]
+        , Nominal
+            (Record
+               [ ("pci_virt", Name "virtual_flag")
+               ; ( "pci_params"
+                 , List (Tuple [Name "core_type"; Name "variance"]) )
+               ; ("pci_name", Loc String)
+               ; ("pci_expr", Var "a")
+               ; ("pci_loc", Location)
+               ; ("pci_attributes", Name "attributes") ]) ) )
+  ; ( "class_description"
+    , Mono (Structural (Instance ("class_infos", [Name "class_type"]))) )
+  ; ( "class_type_declaration"
+    , Mono (Structural (Instance ("class_infos", [Name "class_type"]))) )
+  ; ( "class_expr"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pcl_desc", Name "class_expr_desc")
+              ; ("pcl_loc", Location)
+              ; ("pcl_attributes", Name "attributes") ])) )
+  ; ( "class_expr_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ( "Pcl_constr"
+                , Tuple [Name "longident_loc"; List (Name "core_type")] )
+              ; ("Pcl_structure", Tuple [Name "class_structure"])
+              ; ( "Pcl_fun"
+                , Tuple
+                    [ Name "arg_label"
+                    ; Option (Name "expression")
+                    ; Name "pattern"
+                    ; Name "class_expr" ] )
+              ; ( "Pcl_apply"
+                , Tuple
+                    [ Name "class_expr"
+                    ; List (Tuple [Name "arg_label"; Name "expression"]) ] )
+              ; ( "Pcl_let"
+                , Tuple
+                    [ Name "rec_flag"
+                    ; List (Name "value_binding")
+                    ; Name "class_expr" ] )
+              ; ("Pcl_constraint", Tuple [Name "class_expr"; Name "class_type"])
+              ; ("Pcl_extension", Tuple [Name "extension"])
+              ; ( "Pcl_open"
+                , Tuple
+                    [ Name "override_flag"
+                    ; Name "longident_loc"
+                    ; Name "class_expr" ] ) ])) )
+  ; ( "class_structure"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pcstr_self", Name "pattern")
+              ; ("pcstr_fields", List (Name "class_field")) ])) )
+  ; ( "class_field"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pcf_desc", Name "class_field_desc")
+              ; ("pcf_loc", Location)
+              ; ("pcf_attributes", Name "attributes") ])) )
+  ; ( "class_field_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ( "Pcf_inherit"
+                , Tuple
+                    [ Name "override_flag"
+                    ; Name "class_expr"
+                    ; Option (Loc String) ] )
+              ; ( "Pcf_val"
+                , Tuple
+                    [ Tuple
+                        [ Loc (Name "label")
+                        ; Name "mutable_flag"
+                        ; Name "class_field_kind" ] ] )
+              ; ( "Pcf_method"
+                , Tuple
+                    [ Tuple
+                        [ Loc (Name "label")
+                        ; Name "private_flag"
+                        ; Name "class_field_kind" ] ] )
+              ; ( "Pcf_constraint"
+                , Tuple [Tuple [Name "core_type"; Name "core_type"]] )
+              ; ("Pcf_initializer", Tuple [Name "expression"])
+              ; ("Pcf_attribute", Tuple [Name "attribute"])
+              ; ("Pcf_extension", Tuple [Name "extension"]) ])) )
+  ; ( "class_field_kind"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Cfk_virtual", Tuple [Name "core_type"])
+              ; ( "Cfk_concrete"
+                , Tuple [Name "override_flag"; Name "expression"] ) ])) )
+  ; ( "class_declaration"
+    , Mono (Structural (Instance ("class_infos", [Name "class_expr"]))) )
+  ; ( "module_type"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pmty_desc", Name "module_type_desc")
+              ; ("pmty_loc", Location)
+              ; ("pmty_attributes", Name "attributes") ])) )
+  ; ( "module_type_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Pmty_ident", Tuple [Name "longident_loc"])
+              ; ("Pmty_signature", Tuple [Name "signature"])
+              ; ( "Pmty_functor"
+                , Tuple
+                    [ Loc String
+                    ; Option (Name "module_type")
+                    ; Name "module_type" ] )
+              ; ( "Pmty_with"
+                , Tuple [Name "module_type"; List (Name "with_constraint")] )
+              ; ("Pmty_typeof", Tuple [Name "module_expr"])
+              ; ("Pmty_extension", Tuple [Name "extension"])
+              ; ("Pmty_alias", Tuple [Name "longident_loc"]) ])) )
+  ; ("signature", Mono (Nominal (Wrapper (List (Name "signature_item")))))
+  ; ( "signature_item"
+    , Mono
+        (Nominal
+           (Record
+              [ ("psig_desc", Name "signature_item_desc")
+              ; ("psig_loc", Location) ])) )
+  ; ( "signature_item_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Psig_value", Tuple [Name "value_description"])
+              ; ( "Psig_type"
+                , Tuple [Name "rec_flag"; List (Name "type_declaration")] )
+              ; ("Psig_typext", Tuple [Name "type_extension"])
+              ; ("Psig_exception", Tuple [Name "extension_constructor"])
+              ; ("Psig_module", Tuple [Name "module_declaration"])
+              ; ("Psig_recmodule", Tuple [List (Name "module_declaration")])
+              ; ("Psig_modtype", Tuple [Name "module_type_declaration"])
+              ; ("Psig_open", Tuple [Name "open_description"])
+              ; ("Psig_include", Tuple [Name "include_description"])
+              ; ("Psig_class", Tuple [List (Name "class_description")])
+              ; ( "Psig_class_type"
+                , Tuple [List (Name "class_type_declaration")] )
+              ; ("Psig_attribute", Tuple [Name "attribute"])
+              ; ("Psig_extension", Tuple [Name "extension"; Name "attributes"])
+              ])) )
+  ; ( "module_declaration"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pmd_name", Loc String)
+              ; ("pmd_type", Name "module_type")
+              ; ("pmd_attributes", Name "attributes")
+              ; ("pmd_loc", Location) ])) )
+  ; ( "module_type_declaration"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pmtd_name", Loc String)
+              ; ("pmtd_type", Option (Name "module_type"))
+              ; ("pmtd_attributes", Name "attributes")
+              ; ("pmtd_loc", Location) ])) )
+  ; ( "open_description"
+    , Mono
+        (Nominal
+           (Record
+              [ ("popen_lid", Name "longident_loc")
+              ; ("popen_override", Name "override_flag")
+              ; ("popen_loc", Location)
+              ; ("popen_attributes", Name "attributes") ])) )
+  ; ( "include_infos"
+    , Poly
+        ( ["a"]
+        , Nominal
+            (Record
+               [ ("pincl_mod", Var "a")
+               ; ("pincl_loc", Location)
+               ; ("pincl_attributes", Name "attributes") ]) ) )
+  ; ( "include_description"
+    , Mono (Structural (Instance ("include_infos", [Name "module_type"]))) )
+  ; ( "include_declaration"
+    , Mono (Structural (Instance ("include_infos", [Name "module_expr"]))) )
+  ; ( "with_constraint"
+    , Mono
+        (Nominal
+           (Variant
+              [ ( "Pwith_type"
+                , Tuple [Name "longident_loc"; Name "type_declaration"] )
+              ; ( "Pwith_module"
+                , Tuple [Name "longident_loc"; Name "longident_loc"] )
+              ; ( "Pwith_typesubst"
+                , Tuple [Name "longident_loc"; Name "type_declaration"] )
+              ; ( "Pwith_modsubst"
+                , Tuple [Name "longident_loc"; Name "longident_loc"] ) ])) )
+  ; ( "module_expr"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pmod_desc", Name "module_expr_desc")
+              ; ("pmod_loc", Location)
+              ; ("pmod_attributes", Name "attributes") ])) )
+  ; ( "module_expr_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Pmod_ident", Tuple [Name "longident_loc"])
+              ; ("Pmod_structure", Tuple [Name "structure"])
+              ; ( "Pmod_functor"
+                , Tuple
+                    [ Loc String
+                    ; Option (Name "module_type")
+                    ; Name "module_expr" ] )
+              ; ("Pmod_apply", Tuple [Name "module_expr"; Name "module_expr"])
+              ; ( "Pmod_constraint"
+                , Tuple [Name "module_expr"; Name "module_type"] )
+              ; ("Pmod_unpack", Tuple [Name "expression"])
+              ; ("Pmod_extension", Tuple [Name "extension"]) ])) )
+  ; ("structure", Mono (Nominal (Wrapper (List (Name "structure_item")))))
+  ; ( "structure_item"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pstr_desc", Name "structure_item_desc")
+              ; ("pstr_loc", Location) ])) )
+  ; ( "structure_item_desc"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Pstr_eval", Tuple [Name "expression"; Name "attributes"])
+              ; ( "Pstr_value"
+                , Tuple [Name "rec_flag"; List (Name "value_binding")] )
+              ; ("Pstr_primitive", Tuple [Name "value_description"])
+              ; ( "Pstr_type"
+                , Tuple [Name "rec_flag"; List (Name "type_declaration")] )
+              ; ("Pstr_typext", Tuple [Name "type_extension"])
+              ; ("Pstr_exception", Tuple [Name "extension_constructor"])
+              ; ("Pstr_module", Tuple [Name "module_binding"])
+              ; ("Pstr_recmodule", Tuple [List (Name "module_binding")])
+              ; ("Pstr_modtype", Tuple [Name "module_type_declaration"])
+              ; ("Pstr_open", Tuple [Name "open_description"])
+              ; ("Pstr_class", Tuple [List (Name "class_declaration")])
+              ; ( "Pstr_class_type"
+                , Tuple [List (Name "class_type_declaration")] )
+              ; ("Pstr_include", Tuple [Name "include_declaration"])
+              ; ("Pstr_attribute", Tuple [Name "attribute"])
+              ; ("Pstr_extension", Tuple [Name "extension"; Name "attributes"])
+              ])) )
+  ; ( "value_binding"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pvb_pat", Name "pattern")
+              ; ("pvb_expr", Name "expression")
+              ; ("pvb_attributes", Name "attributes")
+              ; ("pvb_loc", Location) ])) )
+  ; ( "module_binding"
+    , Mono
+        (Nominal
+           (Record
+              [ ("pmb_name", Loc String)
+              ; ("pmb_expr", Name "module_expr")
+              ; ("pmb_attributes", Name "attributes")
+              ; ("pmb_loc", Location) ])) )
+  ; ( "toplevel_phrase"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Ptop_def", Tuple [Name "structure"])
+              ; ("Ptop_dir", Tuple [String; Name "directive_argument"]) ])) )
+  ; ( "directive_argument"
+    , Mono
+        (Nominal
+           (Variant
+              [ ("Pdir_none", Empty)
+              ; ("Pdir_string", Tuple [String])
+              ; ("Pdir_int", Tuple [String; Option Char])
+              ; ("Pdir_ident", Tuple [Name "longident"])
+              ; ("Pdir_bool", Tuple [Bool]) ])) ) ]

--- a/astlib/latest_version.ml
+++ b/astlib/latest_version.ml
@@ -5,56 +5,59 @@ let conversions : History.conversion list = []
 let grammar : Grammar.t =
   [ ( "longident"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Lident", Tuple [String])
               ; ("Ldot", Tuple [Name "longident"; String])
               ; ("Lapply", Tuple [Name "longident"; Name "longident"]) ])) )
-  ; ("longident_loc", Mono (Structural (Loc (Name "longident"))))
+  ; ("longident_loc", Mono (Unversioned (Loc (Name "longident"))))
   ; ( "rec_flag"
-    , Mono (Nominal (Variant [("Nonrecursive", Empty); ("Recursive", Empty)]))
+    , Mono
+        (Versioned (Variant [("Nonrecursive", Empty); ("Recursive", Empty)]))
     )
   ; ( "direction_flag"
-    , Mono (Nominal (Variant [("Upto", Empty); ("Downto", Empty)])) )
+    , Mono (Versioned (Variant [("Upto", Empty); ("Downto", Empty)])) )
   ; ( "private_flag"
-    , Mono (Nominal (Variant [("Private", Empty); ("Public", Empty)])) )
+    , Mono (Versioned (Variant [("Private", Empty); ("Public", Empty)])) )
   ; ( "mutable_flag"
-    , Mono (Nominal (Variant [("Immutable", Empty); ("Mutable", Empty)])) )
+    , Mono (Versioned (Variant [("Immutable", Empty); ("Mutable", Empty)])) )
   ; ( "virtual_flag"
-    , Mono (Nominal (Variant [("Virtual", Empty); ("Concrete", Empty)])) )
+    , Mono (Versioned (Variant [("Virtual", Empty); ("Concrete", Empty)])) )
   ; ( "override_flag"
-    , Mono (Nominal (Variant [("Override", Empty); ("Fresh", Empty)])) )
+    , Mono (Versioned (Variant [("Override", Empty); ("Fresh", Empty)])) )
   ; ( "closed_flag"
-    , Mono (Nominal (Variant [("Closed", Empty); ("Open", Empty)])) )
-  ; ("label", Mono (Structural String))
+    , Mono (Versioned (Variant [("Closed", Empty); ("Open", Empty)])) )
+  ; ("label", Mono (Unversioned String))
   ; ( "arg_label"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Nolabel", Empty)
               ; ("Labelled", Tuple [String])
               ; ("Optional", Tuple [String]) ])) )
   ; ( "variance"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Covariant", Empty)
               ; ("Contravariant", Empty)
               ; ("Invariant", Empty) ])) )
   ; ( "constant"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Pconst_integer", Tuple [String; Option Char])
               ; ("Pconst_char", Tuple [Char])
               ; ("Pconst_string", Tuple [String; Option String])
               ; ("Pconst_float", Tuple [String; Option Char]) ])) )
-  ; ("attribute", Mono (Nominal (Wrapper (Tuple [Loc String; Name "payload"]))))
-  ; ("extension", Mono (Nominal (Wrapper (Tuple [Loc String; Name "payload"]))))
-  ; ("attributes", Mono (Nominal (Wrapper (List (Name "attribute")))))
+  ; ( "attribute"
+    , Mono (Versioned (Wrapper (Tuple [Loc String; Name "payload"]))) )
+  ; ( "extension"
+    , Mono (Versioned (Wrapper (Tuple [Loc String; Name "payload"]))) )
+  ; ("attributes", Mono (Versioned (Wrapper (List (Name "attribute")))))
   ; ( "payload"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("PStr", Tuple [Name "structure"])
               ; ("PSig", Tuple [Name "signature"])
@@ -63,14 +66,14 @@ let grammar : Grammar.t =
     )
   ; ( "core_type"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("ptyp_desc", Name "core_type_desc")
               ; ("ptyp_loc", Location)
               ; ("ptyp_attributes", Name "attributes") ])) )
   ; ( "core_type_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Ptyp_any", Empty)
               ; ("Ptyp_var", Tuple [String])
@@ -95,7 +98,7 @@ let grammar : Grammar.t =
               ; ("Ptyp_extension", Tuple [Name "extension"]) ])) )
   ; ( "package_type"
     , Mono
-        (Nominal
+        (Versioned
            (Wrapper
               (Tuple
                  [ Name "longident_loc"
@@ -103,7 +106,7 @@ let grammar : Grammar.t =
     )
   ; ( "row_field"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ( "Rtag"
                 , Tuple
@@ -114,7 +117,7 @@ let grammar : Grammar.t =
               ; ("Rinherit", Tuple [Name "core_type"]) ])) )
   ; ( "object_field"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ( "Otag"
                 , Tuple
@@ -123,14 +126,14 @@ let grammar : Grammar.t =
               ; ("Oinherit", Tuple [Name "core_type"]) ])) )
   ; ( "pattern"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("ppat_desc", Name "pattern_desc")
               ; ("ppat_loc", Location)
               ; ("ppat_attributes", Name "attributes") ])) )
   ; ( "pattern_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Ppat_any", Empty)
               ; ("Ppat_var", Tuple [Loc String])
@@ -157,14 +160,14 @@ let grammar : Grammar.t =
     )
   ; ( "expression"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pexp_desc", Name "expression_desc")
               ; ("pexp_loc", Location)
               ; ("pexp_attributes", Name "attributes") ])) )
   ; ( "expression_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Pexp_ident", Tuple [Name "longident_loc"])
               ; ("Pexp_constant", Tuple [Name "constant"])
@@ -248,14 +251,14 @@ let grammar : Grammar.t =
               ; ("Pexp_unreachable", Empty) ])) )
   ; ( "case"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pc_lhs", Name "pattern")
               ; ("pc_guard", Option (Name "expression"))
               ; ("pc_rhs", Name "expression") ])) )
   ; ( "value_description"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pval_name", Loc String)
               ; ("pval_type", Name "core_type")
@@ -264,7 +267,7 @@ let grammar : Grammar.t =
               ; ("pval_loc", Location) ])) )
   ; ( "type_declaration"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("ptype_name", Loc String)
               ; ( "ptype_params"
@@ -279,7 +282,7 @@ let grammar : Grammar.t =
               ; ("ptype_loc", Location) ])) )
   ; ( "type_kind"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Ptype_abstract", Empty)
               ; ("Ptype_variant", Tuple [List (Name "constructor_declaration")])
@@ -287,7 +290,7 @@ let grammar : Grammar.t =
               ; ("Ptype_open", Empty) ])) )
   ; ( "label_declaration"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pld_name", Loc String)
               ; ("pld_mutable", Name "mutable_flag")
@@ -296,7 +299,7 @@ let grammar : Grammar.t =
               ; ("pld_attributes", Name "attributes") ])) )
   ; ( "constructor_declaration"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pcd_name", Loc String)
               ; ("pcd_args", Name "constructor_arguments")
@@ -305,14 +308,14 @@ let grammar : Grammar.t =
               ; ("pcd_attributes", Name "attributes") ])) )
   ; ( "constructor_arguments"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Pcstr_tuple", Tuple [List (Name "core_type")])
               ; ("Pcstr_record", Tuple [List (Name "label_declaration")]) ]))
     )
   ; ( "type_extension"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("ptyext_path", Name "longident_loc")
               ; ( "ptyext_params"
@@ -322,7 +325,7 @@ let grammar : Grammar.t =
               ; ("ptyext_attributes", Name "attributes") ])) )
   ; ( "extension_constructor"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pext_name", Loc String)
               ; ("pext_kind", Name "extension_constructor_kind")
@@ -330,7 +333,7 @@ let grammar : Grammar.t =
               ; ("pext_attributes", Name "attributes") ])) )
   ; ( "extension_constructor_kind"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ( "Pext_decl"
                 , Tuple
@@ -339,14 +342,14 @@ let grammar : Grammar.t =
               ; ("Pext_rebind", Tuple [Name "longident_loc"]) ])) )
   ; ( "class_type"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pcty_desc", Name "class_type_desc")
               ; ("pcty_loc", Location)
               ; ("pcty_attributes", Name "attributes") ])) )
   ; ( "class_type_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ( "Pcty_constr"
                 , Tuple [Name "longident_loc"; List (Name "core_type")] )
@@ -362,20 +365,20 @@ let grammar : Grammar.t =
                     ; Name "class_type" ] ) ])) )
   ; ( "class_signature"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pcsig_self", Name "core_type")
               ; ("pcsig_fields", List (Name "class_type_field")) ])) )
   ; ( "class_type_field"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pctf_desc", Name "class_type_field_desc")
               ; ("pctf_loc", Location)
               ; ("pctf_attributes", Name "attributes") ])) )
   ; ( "class_type_field_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Pctf_inherit", Tuple [Name "class_type"])
               ; ( "Pctf_val"
@@ -399,7 +402,7 @@ let grammar : Grammar.t =
   ; ( "class_infos"
     , Poly
         ( ["a"]
-        , Nominal
+        , Versioned
             (Record
                [ ("pci_virt", Name "virtual_flag")
                ; ( "pci_params"
@@ -409,19 +412,19 @@ let grammar : Grammar.t =
                ; ("pci_loc", Location)
                ; ("pci_attributes", Name "attributes") ]) ) )
   ; ( "class_description"
-    , Mono (Structural (Instance ("class_infos", [Name "class_type"]))) )
+    , Mono (Unversioned (Instance ("class_infos", [Name "class_type"]))) )
   ; ( "class_type_declaration"
-    , Mono (Structural (Instance ("class_infos", [Name "class_type"]))) )
+    , Mono (Unversioned (Instance ("class_infos", [Name "class_type"]))) )
   ; ( "class_expr"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pcl_desc", Name "class_expr_desc")
               ; ("pcl_loc", Location)
               ; ("pcl_attributes", Name "attributes") ])) )
   ; ( "class_expr_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ( "Pcl_constr"
                 , Tuple [Name "longident_loc"; List (Name "core_type")] )
@@ -450,20 +453,20 @@ let grammar : Grammar.t =
                     ; Name "class_expr" ] ) ])) )
   ; ( "class_structure"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pcstr_self", Name "pattern")
               ; ("pcstr_fields", List (Name "class_field")) ])) )
   ; ( "class_field"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pcf_desc", Name "class_field_desc")
               ; ("pcf_loc", Location)
               ; ("pcf_attributes", Name "attributes") ])) )
   ; ( "class_field_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ( "Pcf_inherit"
                 , Tuple
@@ -489,23 +492,23 @@ let grammar : Grammar.t =
               ; ("Pcf_extension", Tuple [Name "extension"]) ])) )
   ; ( "class_field_kind"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Cfk_virtual", Tuple [Name "core_type"])
               ; ( "Cfk_concrete"
                 , Tuple [Name "override_flag"; Name "expression"] ) ])) )
   ; ( "class_declaration"
-    , Mono (Structural (Instance ("class_infos", [Name "class_expr"]))) )
+    , Mono (Unversioned (Instance ("class_infos", [Name "class_expr"]))) )
   ; ( "module_type"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pmty_desc", Name "module_type_desc")
               ; ("pmty_loc", Location)
               ; ("pmty_attributes", Name "attributes") ])) )
   ; ( "module_type_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Pmty_ident", Tuple [Name "longident_loc"])
               ; ("Pmty_signature", Tuple [Name "signature"])
@@ -519,16 +522,16 @@ let grammar : Grammar.t =
               ; ("Pmty_typeof", Tuple [Name "module_expr"])
               ; ("Pmty_extension", Tuple [Name "extension"])
               ; ("Pmty_alias", Tuple [Name "longident_loc"]) ])) )
-  ; ("signature", Mono (Nominal (Wrapper (List (Name "signature_item")))))
+  ; ("signature", Mono (Versioned (Wrapper (List (Name "signature_item")))))
   ; ( "signature_item"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("psig_desc", Name "signature_item_desc")
               ; ("psig_loc", Location) ])) )
   ; ( "signature_item_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Psig_value", Tuple [Name "value_description"])
               ; ( "Psig_type"
@@ -548,7 +551,7 @@ let grammar : Grammar.t =
               ])) )
   ; ( "module_declaration"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pmd_name", Loc String)
               ; ("pmd_type", Name "module_type")
@@ -556,7 +559,7 @@ let grammar : Grammar.t =
               ; ("pmd_loc", Location) ])) )
   ; ( "module_type_declaration"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pmtd_name", Loc String)
               ; ("pmtd_type", Option (Name "module_type"))
@@ -564,7 +567,7 @@ let grammar : Grammar.t =
               ; ("pmtd_loc", Location) ])) )
   ; ( "open_description"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("popen_lid", Name "longident_loc")
               ; ("popen_override", Name "override_flag")
@@ -573,18 +576,18 @@ let grammar : Grammar.t =
   ; ( "include_infos"
     , Poly
         ( ["a"]
-        , Nominal
+        , Versioned
             (Record
                [ ("pincl_mod", Var "a")
                ; ("pincl_loc", Location)
                ; ("pincl_attributes", Name "attributes") ]) ) )
   ; ( "include_description"
-    , Mono (Structural (Instance ("include_infos", [Name "module_type"]))) )
+    , Mono (Unversioned (Instance ("include_infos", [Name "module_type"]))) )
   ; ( "include_declaration"
-    , Mono (Structural (Instance ("include_infos", [Name "module_expr"]))) )
+    , Mono (Unversioned (Instance ("include_infos", [Name "module_expr"]))) )
   ; ( "with_constraint"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ( "Pwith_type"
                 , Tuple [Name "longident_loc"; Name "type_declaration"] )
@@ -596,14 +599,14 @@ let grammar : Grammar.t =
                 , Tuple [Name "longident_loc"; Name "longident_loc"] ) ])) )
   ; ( "module_expr"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pmod_desc", Name "module_expr_desc")
               ; ("pmod_loc", Location)
               ; ("pmod_attributes", Name "attributes") ])) )
   ; ( "module_expr_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Pmod_ident", Tuple [Name "longident_loc"])
               ; ("Pmod_structure", Tuple [Name "structure"])
@@ -617,16 +620,16 @@ let grammar : Grammar.t =
                 , Tuple [Name "module_expr"; Name "module_type"] )
               ; ("Pmod_unpack", Tuple [Name "expression"])
               ; ("Pmod_extension", Tuple [Name "extension"]) ])) )
-  ; ("structure", Mono (Nominal (Wrapper (List (Name "structure_item")))))
+  ; ("structure", Mono (Versioned (Wrapper (List (Name "structure_item")))))
   ; ( "structure_item"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pstr_desc", Name "structure_item_desc")
               ; ("pstr_loc", Location) ])) )
   ; ( "structure_item_desc"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Pstr_eval", Tuple [Name "expression"; Name "attributes"])
               ; ( "Pstr_value"
@@ -649,7 +652,7 @@ let grammar : Grammar.t =
               ])) )
   ; ( "value_binding"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pvb_pat", Name "pattern")
               ; ("pvb_expr", Name "expression")
@@ -657,7 +660,7 @@ let grammar : Grammar.t =
               ; ("pvb_loc", Location) ])) )
   ; ( "module_binding"
     , Mono
-        (Nominal
+        (Versioned
            (Record
               [ ("pmb_name", Loc String)
               ; ("pmb_expr", Name "module_expr")
@@ -665,13 +668,13 @@ let grammar : Grammar.t =
               ; ("pmb_loc", Location) ])) )
   ; ( "toplevel_phrase"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Ptop_def", Tuple [Name "structure"])
               ; ("Ptop_dir", Tuple [String; Name "directive_argument"]) ])) )
   ; ( "directive_argument"
     , Mono
-        (Nominal
+        (Versioned
            (Variant
               [ ("Pdir_none", Empty)
               ; ("Pdir_string", Tuple [String])

--- a/astlib/unstable_for_testing.ml
+++ b/astlib/unstable_for_testing.ml
@@ -33,16 +33,16 @@ let update_variant variant =
   List.rev_map variant ~f:(fun (name, clause) ->
     name, update_clause clause)
 
-let update_nominal nominal : Grammar.nominal =
-  match (nominal : Grammar.nominal) with
+let update_versioned versioned : Grammar.versioned =
+  match (versioned : Grammar.versioned) with
   | Wrapper ty -> Wrapper (update_ty ty)
   | Record record -> Record (update_record record)
   | Variant variant -> Variant (update_variant variant)
 
 let update_decl decl : Grammar.decl =
   match (decl : Grammar.decl) with
-  | Structural ty -> Structural (update_ty ty)
-  | Nominal nominal -> Nominal (update_nominal nominal)
+  | Unversioned ty -> Unversioned (update_ty ty)
+  | Versioned versioned -> Versioned (update_versioned versioned)
 
 let update_kind kind : Grammar.kind =
   match (kind : Grammar.kind) with

--- a/astlib/unstable_for_testing.ml
+++ b/astlib/unstable_for_testing.ml
@@ -33,11 +33,16 @@ let update_variant variant =
   List.rev_map variant ~f:(fun (name, clause) ->
     name, update_clause clause)
 
-let update_decl decl : Grammar.decl =
-  match (decl : Grammar.decl) with
-  | Alias ty -> Alias (update_ty ty)
+let update_nominal nominal : Grammar.nominal =
+  match (nominal : Grammar.nominal) with
+  | Wrapper ty -> Wrapper (update_ty ty)
   | Record record -> Record (update_record record)
   | Variant variant -> Variant (update_variant variant)
+
+let update_decl decl : Grammar.decl =
+  match (decl : Grammar.decl) with
+  | Structural ty -> Structural (update_ty ty)
+  | Nominal nominal -> Nominal (update_nominal nominal)
 
 let update_kind kind : Grammar.kind =
   match (kind : Grammar.kind) with

--- a/metaquot/expander/ppx_metaquot_expander.ml
+++ b/metaquot/expander/ppx_metaquot_expander.ml
@@ -201,8 +201,7 @@ module Expr (Driver : Driver) = struct
       ~pexp_loc:loc
       ~pexp_attributes:(Attributes.create [])
       ~pexp_desc:(Expression_desc.pexp_ident
-                    (Longident_loc.create
-                       (Astlib.Loc.create ~loc ~txt:(Longident.lident "loc") ())))
+                    (Astlib.Loc.create ~loc ~txt:(Longident.lident "loc") ()))
   let attributes = None
   class std_lifters = Ppx_metaquot_lifters.expression_lifters
   let cast ext =

--- a/metaquot_lifters/ppx_metaquot_lifters.ml
+++ b/metaquot_lifters/ppx_metaquot_lifters.ml
@@ -9,8 +9,7 @@ open Ppx_ast.Builder.V4_07
 
 let ppx_type ~loc ~arity name =
   (ptyp_constr ~loc
-     (Longident_loc.create
-        (Astlib.Loc.create ~loc ~txt:(Longident.ldot (Longident.lident "Ppx") name) ()))
+     (Astlib.Loc.create ~loc ~txt:(Longident.ldot (Longident.lident "Ppx") name) ())
      (List.init arity ~f:(fun _ -> ptyp_any ~loc)))
 
 let econstraint ~loc typ expr =
@@ -29,13 +28,12 @@ class expression_lifters loc =
     method record typ flds =
       pexp_record ~loc
         (List.map flds ~f:(fun (lab, e) ->
-           (Longident_loc.create
-              (Astlib.Loc.create ~loc ~txt:(Longident.lident lab) ()), e)))
+           (Astlib.Loc.create ~loc ~txt:(Longident.lident lab) ()), e))
         None
       |> econstraint ~loc typ
     method constr typ id args =
       pexp_construct ~loc
-        (Longident_loc.create (Astlib.Loc.create ~loc ~txt:(Longident.lident id) ()))
+        (Astlib.Loc.create ~loc ~txt:(Longident.lident id) ())
         (match args with
          | [] -> None
          | l  -> Some (etuple ~loc l))
@@ -61,13 +59,12 @@ class pattern_lifters loc =
     method record typ flds =
       ppat_record ~loc
         (List.map flds ~f:(fun (lab, e) ->
-           (Longident_loc.create
-              (Astlib.Loc.create ~loc ~txt:(Longident.lident lab) ()), e)))
+           (Astlib.Loc.create ~loc ~txt:(Longident.lident lab) ()), e))
         Closed_flag.closed
       |> pconstraint ~loc typ
     method constr typ id args =
       ppat_construct ~loc
-        (Longident_loc.create (Astlib.Loc.create ~loc ~txt:(Longident.lident id) ()))
+        (Astlib.Loc.create ~loc ~txt:(Longident.lident id) ())
         (match args with
          | [] -> None
          | l  -> Some (ptuple ~loc l))

--- a/ppx_view/lib/deconstructor.ml
+++ b/ppx_view/lib/deconstructor.ml
@@ -16,12 +16,9 @@ let pattern ~loc pat =
     | None -> Error.conversion_failed ~loc "pattern_desc"
     | Some desc -> (ppat_loc, desc)
 
-let longident_loc ~loc longident_loc =
-  match Longident_loc.to_concrete longident_loc with
-  | None -> Error.conversion_failed ~loc "longident_loc"
-  | Some longident_loc ->
-    let loc = Astlib.Loc.loc longident_loc in
-    let longident = Astlib.Loc.txt longident_loc in
-    match Longident.to_concrete longident with
-    | None -> Error.conversion_failed ~loc "longident"
-    | Some longident -> (loc, longident)
+let longident_loc longident_loc =
+  let loc = Astlib.Loc.loc longident_loc in
+  let longident = Astlib.Loc.txt longident_loc in
+  match Longident.to_concrete longident with
+  | None -> Error.conversion_failed ~loc "longident"
+  | Some longident -> (loc, longident)

--- a/ppx_view/lib/deconstructor.mli
+++ b/ppx_view/lib/deconstructor.mli
@@ -16,6 +16,5 @@ val pattern :
   Astlib.Location.t * Pattern_desc.concrete
 
 val longident_loc :
-  loc: Astlib.Location.t ->
   Longident_loc.t ->
   Astlib.Location.t * Longident.concrete

--- a/ppx_view/lib/expand.ml
+++ b/ppx_view/lib/expand.ml
@@ -108,10 +108,10 @@ let rec translate_pattern ~err_loc pattern =
     let fields = View_attr.extract_fields ~err_loc ppat_attributes in
     match fields with
     | None -> translate_pattern_desc ~loc ppat_desc
-    | Some (fields_loc, fields) ->
+    | Some fields ->
       let expr, vars = translate_pattern_desc ~loc ppat_desc in
       let field_exprs_vars =
-        List.map fields ~f:(translate_record_field ~loc:fields_loc)
+        List.map fields ~f:translate_record_field
       in
       let field_exprs, field_vars = List.split field_exprs_vars in
       ( Builder.Exp.view_lib_sequence ~loc (field_exprs @ [expr])
@@ -144,12 +144,12 @@ and translate_pattern_desc ~loc desc =
   | Some (Ppat_tuple patts) ->
     translate_tuple ~loc patts
   | Some (Ppat_construct (ctor_ident, None)) ->
-    let ctor_loc, ctor_ident = Deconstructor.longident_loc ~loc ctor_ident in
+    let ctor_loc, ctor_ident = Deconstructor.longident_loc ctor_ident in
     let f = translate_ctor_ident ~loc:ctor_loc ctor_ident in
     ( pexp_ident ~loc f
     , [] )
   | Some (Ppat_construct (ctor_ident, Some patt)) ->
-    let ctor_loc, ctor_ident = Deconstructor.longident_loc ~loc ctor_ident in
+    let ctor_loc, ctor_ident = Deconstructor.longident_loc ctor_ident in
     let f = translate_ctor_ident ~loc:ctor_loc ctor_ident in
     let apply args = Builder.Exp.apply_lident ~loc f args in
     (match Deconstructor.pattern ~loc patt with
@@ -177,7 +177,7 @@ and translate_pattern_desc ~loc desc =
     else
       Error.or_pattern_variables_differ ~loc
   | Some (Ppat_record (fields, _closed)) ->
-    let exprs_vars = List.map ~f:(translate_record_field ~loc) fields in
+    let exprs_vars = List.map ~f:translate_record_field fields in
     let exprs, vars = List.split exprs_vars in
     ( Builder.Exp.view_lib_sequence ~loc exprs
     , List.flatten vars )
@@ -223,8 +223,8 @@ and translate_tuple ~loc patts =
     ( eapply ~loc f exprs
     , vars )
 
-and translate_record_field ~loc (label, patt) =
-  let (label_loc, label) = Deconstructor.longident_loc ~loc label in
+and translate_record_field (label, patt) =
+  let (label_loc, label) = Deconstructor.longident_loc label in
   match label with
   | Lident label ->
     let expr, vars = translate_pattern ~err_loc:label_loc patt in

--- a/ppx_view/lib/view_attr.ml
+++ b/ppx_view/lib/view_attr.ml
@@ -6,7 +6,7 @@ type field = Longident_loc.t * Pattern.t
 let fields_from_pattern ~loc pattern =
   let ppat_loc, ppat_desc = Deconstructor.pattern ~loc pattern in
   match ppat_desc with
-  | Ppat_record (fields, _closed) -> (ppat_loc, fields)
+  | Ppat_record (fields, _closed) -> fields
   | _ -> Error.invalid_attribute_payload ~loc:ppat_loc
 
 let fields_from_payload ~loc payload =

--- a/ppx_view/lib/view_attr.mli
+++ b/ppx_view/lib/view_attr.mli
@@ -11,4 +11,4 @@ type field = Longident_loc.t * Pattern.t
 val extract_fields :
   err_loc: Astlib.Location.t ->
   Attributes.t ->
-  (Astlib.Location.t * field list) option
+  (field list) option

--- a/ppx_view/test/test.ml
+++ b/ppx_view/test/test.ml
@@ -113,12 +113,8 @@ let%expect_test "match with alias" =
 
 let%expect_test "match with record" =
   let match_ident = function%view
-    | Pexp_ident longident_loc ->
-      (match%view Longident_loc.to_concrete longident_loc with
-       | Some { txt = Lident id; _} -> print_string id
-       | _ -> print_string "KO")
-    | _ ->
-      print_string "KO"
+    | Pexp_ident { txt = Lident id; _} -> print_string id
+    | _ -> print_string "KO"
   in
   begin
     match_ident (ident "x");

--- a/stdppx/list.ml
+++ b/stdppx/list.ml
@@ -177,3 +177,16 @@ let rec mem_sorted ~compare elm l =
      | Lt -> mem_sorted ~compare elm tl
      | Eq -> true
      | Gt -> false)
+
+let unzip t =
+  fold_right t ~init:([], []) ~f:(fun (fst, snd) (fsts, snds) ->
+    (fst :: fsts), (snd :: snds))
+
+let rec rev_zip_exn xs ys ~acc =
+  match xs, ys with
+  | [], [] -> rev acc
+  | x :: xs, y :: ys -> rev_zip_exn xs ys ~acc:((x, y) :: acc)
+  | [], _ :: _
+  | _ :: _, [] -> failwith "List.zip_exn: mismatch lengths"
+
+let zip_exn xs ys = rev_zip_exn xs ys ~acc:[]

--- a/stdppx/list.mli
+++ b/stdppx/list.mli
@@ -18,6 +18,9 @@ val concat_map : 'a t -> f:('a -> 'b t) -> 'b t
 val     partition_map : 'a t -> f:('a -> ('b, 'c) Either.t) -> 'b t * 'c t
 val rev_partition_map : 'a t -> f:('a -> ('b, 'c) Either.t) -> 'b t * 'c t
 
+val zip_exn : 'a t -> 'b t -> ('a * 'b) t
+val unzip : ('a * 'b) t -> 'a t * 'b t
+
 type ('a, 'b) skip_or_either =
   | Skip
   | Left  of 'a


### PR DESCRIPTION
This cleans up some of our types that had the most annoying node wrappers: Longident_loc and other "polymorphic instance" types.