### PR TITLE
Backport location check

### DIFF
--- a/metaquot/expander/ppx_metaquot_expander.ml
+++ b/metaquot/expander/ppx_metaquot_expander.ml
@@ -194,9 +194,12 @@ let ppat_any ~loc =
     ~ppat_attributes:(Attributes.create [])
     ~ppat_desc:Pattern_desc.ppat_any
 
+let ghost loc = Astlib.Location.update ~ghost:true loc
+
 module Expr (Driver : Driver) = struct
   type t = Expression.t
   let location loc =
+    let loc = ghost loc in
     Expression.create
       ~pexp_loc:loc
       ~pexp_attributes:(Attributes.create [])
@@ -217,8 +220,8 @@ end
 
 module Patt = struct
   type t = Pattern.t
-  let location loc = ppat_any ~loc
-  let attributes = Some (fun loc -> ppat_any ~loc)
+  let location loc = ppat_any ~loc:(ghost loc)
+  let attributes = Some (fun loc -> ppat_any ~loc:(ghost loc))
   class std_lifters = Ppx_metaquot_lifters.pattern_lifters
   let cast ext =
     match pattern_payload_of ext with

--- a/metaquot_lifters/ppx_metaquot_lifters.ml
+++ b/metaquot_lifters/ppx_metaquot_lifters.ml
@@ -23,6 +23,7 @@ let pconstraint ~loc typ pat =
   | Some (name, arity) -> ppat_constraint ~loc pat (ppx_type ~loc ~arity name)
 
 class expression_lifters loc =
+  let loc = Astlib.Location.update ~ghost:true loc in
   object
     inherit [Expression.t] Traverse_builtins.lift
     method record typ flds =
@@ -54,6 +55,7 @@ class expression_lifters loc =
   end
 
 class pattern_lifters loc =
+  let loc = Astlib.Location.update ~ghost:true loc in
   object
     inherit [Pattern.t] Traverse_builtins.lift
     method record typ flds =

--- a/src/ast_builder.ml
+++ b/src/ast_builder.ml
@@ -128,6 +128,7 @@ let unapplied_type_constr_conv_without_apply ~loc (ident : Longident.t) ~f =
   | Lapply _ -> Location.raise_errorf ~loc "unexpected applicative functor type"
 
 let type_constr_conv ~loc:apply_loc { Loc.loc; txt = longident } ~f args =
+  let loc = { loc with loc_ghost = true } in
   match (longident : Longident.t) with
   | Lident _
     | Ldot ((Lident _ | Ldot _), _)

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -340,7 +340,10 @@ let handle_attr_group_inline attrs rf items ~loc ~base_ctxt =
       match get_group group.attribute items with
       | None -> acc
       | Some values ->
-        let ctxt = Expansion_context.Deriver.make ~derived_item_loc:loc ~base:base_ctxt () in
+        let ctxt =
+          Expansion_context.Deriver.make ~derived_item_loc:loc
+            ~inline:group.expect ~base:base_ctxt ()
+        in
         let expect_items = group.expand ~ctxt rf items values in
         expect_items :: acc)
 
@@ -350,7 +353,10 @@ let handle_attr_inline attrs item ~loc ~base_ctxt =
       match Attribute.get a.attribute item with
       | None -> acc
       | Some value ->
-        let ctxt = Expansion_context.Deriver.make ~derived_item_loc:loc ~base:base_ctxt () in
+        let ctxt =
+          Expansion_context.Deriver.make ~derived_item_loc:loc
+            ~inline:a.expect ~base:base_ctxt ()
+        in
         let expect_items = a.expand ~ctxt item value in
         expect_items :: acc)
 

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -517,47 +517,71 @@ let mk_deriving_attr context ~prefix ~suffix =
 ;;
 
 (* +-----------------------------------------------------------------+
-   | Unused warning stuff                                            |
+   | Unused warning stuff + locations check silencing                |
    +-----------------------------------------------------------------+ *)
 
-let disable_unused_warning_attribute ~loc =
+let disable_unused_warning_attribute =
+  let loc = Location.none in
   ({ txt = "ocaml.warning"; loc },
    PStr [pstr_eval ~loc (estring ~loc "-32") []])
 ;;
 
-let inline_doc_attr ~loc =
+let inline_doc_attr =
+  let loc = Location.none in
   ({ txt = "ocaml.doc"; loc },
    PStr [pstr_eval ~loc (estring ~loc "@inline") []])
 ;;
 
-let disable_unused_warning_str ~loc st =
-  if keep_w32_impl () then
-    st
-  else if not !do_insert_unused_warning_attribute then
-    Ignore_unused_warning.add_dummy_user_for_values#structure st
+let wrap_str ~loc ~hide st =
+  let include_infos = include_infos ~loc (pmod_structure ~loc st) in
+  let pincl_attributes =
+    if hide then
+      [ inline_doc_attr; Merlin_helpers.hide_attribute ]
+    else
+      [ inline_doc_attr ]
+  in
+  [pstr_include ~loc {include_infos with pincl_attributes}]
+
+let wrap_str ~loc ~hide st =
+  let loc = { loc with loc_ghost = true } in
+  let wrap, st =
+    if keep_w32_impl () then
+      hide, st
+    else if not !do_insert_unused_warning_attribute then
+      hide, Ignore_unused_warning.add_dummy_user_for_values#structure st
+    else
+      (* note: a structure is created because it is not currently possible to
+         attach an [@@ocaml.warning] attribute to a single structure item. *)
+      true, (pstr_attribute ~loc disable_unused_warning_attribute :: st)
+  in
+  if wrap then
+    wrap_str ~loc ~hide st
   else
-    (* note: a structure is created because it is not currently possible to
-       attach an [@@ocaml.warning] attribute to a single structure item. *)
-    let include_infos =
-      include_infos ~loc
-        (pmod_structure ~loc
-           (pstr_attribute ~loc (disable_unused_warning_attribute ~loc) :: st))
-    in
-    [pstr_include ~loc
-       {include_infos with pincl_attributes = [inline_doc_attr ~loc]}]
+    st
 ;;
 
-let disable_unused_warning_sig ~loc sg =
-  if keep_w32_intf () then
-    sg
+let wrap_sig ~loc ~hide st =
+  let include_infos = include_infos ~loc (pmty_signature ~loc st) in
+  let pincl_attributes =
+    if hide then
+      [ inline_doc_attr; Merlin_helpers.hide_attribute ]
+    else
+      [ inline_doc_attr ]
+  in
+  [psig_include ~loc {include_infos with pincl_attributes}]
+
+let wrap_sig ~loc ~hide sg =
+  let loc = { loc with loc_ghost = true } in
+  let wrap, sg =
+    if keep_w32_intf () then
+      hide, sg
+    else
+      true, (psig_attribute ~loc disable_unused_warning_attribute :: sg)
+  in
+  if wrap then
+    wrap_sig ~loc ~hide sg
   else
-    let include_infos =
-      include_infos ~loc
-        (pmty_signature ~loc
-           (psig_attribute ~loc (disable_unused_warning_attribute ~loc) :: sg))
-    in
-    [psig_include ~loc
-       { include_infos with pincl_attributes = [inline_doc_attr ~loc]}]
+    sg
 ;;
 
 (* +-----------------------------------------------------------------+
@@ -622,42 +646,50 @@ let expand_str_type_decls ~ctxt rec_flag tds values =
     types_used_by_deriving tds
     @ Generator.apply_all ~ctxt (rec_flag, tds) generators;
   in
-  disable_unused_warning_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
+  wrap_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~hide:(not @@ Expansion_context.Deriver.inline ctxt) generated
 
 let expand_sig_type_decls ~ctxt rec_flag tds values =
   let generators = merge_generators Deriver.Field.sig_type_decl values in
   let generated = Generator.apply_all ~ctxt (rec_flag, tds) generators in
-  disable_unused_warning_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
+  wrap_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~hide:(not @@ Expansion_context.Deriver.inline ctxt) generated
 
 let expand_str_module_type_decl ~ctxt mtd generators =
   let generators = Deriver.resolve_all Deriver.Field.str_module_type_decl generators in
   let generated = Generator.apply_all ~ctxt mtd generators in
-  disable_unused_warning_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
+  wrap_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~hide:(not @@ Expansion_context.Deriver.inline ctxt) generated
 
 let expand_sig_module_type_decl ~ctxt mtd generators =
   let generators = Deriver.resolve_all Deriver.Field.sig_module_type_decl generators in
   let generated = Generator.apply_all ~ctxt mtd generators in
-  disable_unused_warning_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
+  wrap_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~hide:(not @@ Expansion_context.Deriver.inline ctxt) generated
 
 let expand_str_exception ~ctxt ec generators =
   let generators = Deriver.resolve_all Deriver.Field.str_exception generators in
   let generated = Generator.apply_all ~ctxt ec generators in
-  disable_unused_warning_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
+  wrap_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~hide:(not @@ Expansion_context.Deriver.inline ctxt) generated
 
 let expand_sig_exception ~ctxt ec generators =
   let generators = Deriver.resolve_all Deriver.Field.sig_exception generators in
   let generated = Generator.apply_all ~ctxt ec generators in
-  disable_unused_warning_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
+  wrap_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~hide:(not @@ Expansion_context.Deriver.inline ctxt) generated
 
 let expand_str_type_ext ~ctxt te generators =
   let generators = Deriver.resolve_all Deriver.Field.str_type_ext generators in
   let generated = Generator.apply_all ~ctxt te generators in
-  disable_unused_warning_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
+  wrap_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~hide:(not @@ Expansion_context.Deriver.inline ctxt) generated
 
 let expand_sig_type_ext ~ctxt te generators =
   let generators = Deriver.resolve_all Deriver.Field.sig_type_ext generators in
   let generated = Generator.apply_all ~ctxt te generators in
-  disable_unused_warning_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
+  wrap_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~hide:(not @@ Expansion_context.Deriver.inline ctxt) generated
 
 let rules ~typ ~expand_sig ~expand_str ~rule_str ~rule_sig ~rule_str_expect
       ~rule_sig_expect =

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -10,8 +10,10 @@ let args = ref []
 
 let add_arg key spec ~doc = args := (key, spec, doc) :: !args
 
+let loc_fname = ref None
 let perform_checks = ref Options.perform_checks
 let perform_checks_on_extensions = ref Options.perform_checks_on_extensions
+let perform_locations_check = ref Options.perform_locations_check
 let debug_attribute_drop = ref false
 let apply_list = ref None
 let preprocessor = ref None
@@ -498,6 +500,11 @@ let real_map_structure config cookies st =
     Attribute.check_unused#structure st;
     if !perform_checks_on_extensions then Extension.check_unused#structure st;
     Attribute.check_all_seen ();
+    if !perform_locations_check then
+      let open Location_check in
+      ignore (
+        (enforce_invariants !loc_fname)#structure
+          st Non_intersecting_ranges.empty : Non_intersecting_ranges.t)
   end;
   st
 ;;
@@ -541,6 +548,11 @@ let real_map_signature config cookies sg =
     Attribute.check_unused#signature sg;
     if !perform_checks_on_extensions then Extension.check_unused#signature sg;
     Attribute.check_all_seen ();
+    if !perform_locations_check then
+      let open Location_check in
+      ignore (
+        (enforce_invariants !loc_fname)#signature
+          sg Non_intersecting_ranges.empty : Non_intersecting_ranges.t)
   end;
   sg
 ;;
@@ -966,7 +978,6 @@ let process_file (kind : Kind.t) fn ~input_name ~relocate ~output_mode ~embed_er
     end
 ;;
 
-let loc_fname = ref None
 let output_mode = ref Pretty_print
 let output = ref None
 let kind = ref None
@@ -1077,6 +1088,10 @@ let shared_args =
     " Disable checks on extension point only"
   ; "-check-on-extensions", Arg.Set perform_checks_on_extensions,
     " Enable checks on extension point only"
+  ; "-no-locations-check", Arg.Clear perform_locations_check,
+    " Disable locations check only"
+  ; "-locations-check", Arg.Set perform_locations_check,
+    " Enable locations check only"
   ; "-apply", Arg.String handle_apply,
     "<names> Apply these transformations in order (comma-separated list)"
   ; "-dont-apply", Arg.String handle_dont_apply,
@@ -1299,5 +1314,7 @@ let () =
        { A.default_mapper with structure; signature })
 
 let enable_checks () =
+  (* We do not enable the locations check here, we currently require that one
+     to be specifically enabled. *)
   perform_checks := true;
   perform_checks_on_extensions := true

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -33,14 +33,16 @@ end
 module Deriver = struct
   type t =
     { derived_item_loc : Location.t
+    ; inline : bool
     ; base : Base.t
     }
 
-  let make ~derived_item_loc ~base () = {derived_item_loc; base}
+  let make ~derived_item_loc ~inline ~base () = {derived_item_loc; base; inline}
 
   let derived_item_loc t = t.derived_item_loc
   let code_path t = t.base.code_path
   let omp_config t = t.base.omp_config
+  let inline t = t.inline
 
   let with_loc_and_path f =
     fun ~ctxt -> f ~loc:ctxt.derived_item_loc ~path:(Code_path.to_string_path ctxt.base.code_path)

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -58,9 +58,12 @@ module Deriver : sig
   (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
   val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
 
+  (** Whether the derived code is going to be inlined in the source *)
+  val inline : t -> bool
+
   (**/**)
   (** Undocumented section *)
 
   (** Build a new expansion context with the given item location and code path *)
-  val make : derived_item_loc:Location.t -> base:Base.t -> unit -> t
+  val make : derived_item_loc:Location.t -> inline:bool -> base:Base.t -> unit -> t
 end

--- a/src/location.ml
+++ b/src/location.ml
@@ -44,6 +44,30 @@ type nonrec 'a loc = 'a loc =
   ; loc : t
   }
 
+let compare_pos p1 p2 =
+  let open Lexing in
+  let column p =
+    (* Manual extract:
+       The difference between pos_cnum and pos_bol is the character offset
+       within the line (i.e. the column number, assuming each character is
+       one column wide). *)
+    p.pos_cnum - p.pos_bol
+  in
+  match Int.compare p1.pos_lnum p2.pos_lnum with
+  | 0 -> Int.compare (column p1) (column p2)
+  | n -> n
+
+let min_pos p1 p2 =
+  if compare_pos p1 p2 <= 0 then p1 else p2
+
+let max_pos p1 p2 =
+  if compare_pos p1 p2 >= 0 then p1 else p2
+
+let compare loc1 loc2 =
+  match compare_pos loc1.loc_start loc2.loc_start with
+  | 0 -> compare_pos loc1.loc_end loc2.loc_end
+  | n -> n
+
 module Error = struct
   type t = L.error
 

--- a/src/location.mli
+++ b/src/location.mli
@@ -35,6 +35,12 @@ type nonrec 'a loc = 'a loc =
   ; loc : t
   }
 
+val compare_pos : Lexing.position -> Lexing.position -> int
+val min_pos : Lexing.position -> Lexing.position -> Lexing.position
+val max_pos : Lexing.position -> Lexing.position -> Lexing.position
+
+val compare : t -> t -> int
+
 module Error : sig
   type location = t
   type t = Ocaml_common.Location.error

--- a/src/location.mli
+++ b/src/location.mli
@@ -35,11 +35,20 @@ type nonrec 'a loc = 'a loc =
   ; loc : t
   }
 
-val compare_pos : Lexing.position -> Lexing.position -> int
-val min_pos : Lexing.position -> Lexing.position -> Lexing.position
-val max_pos : Lexing.position -> Lexing.position -> Lexing.position
+module Pos : sig
+  val compare : Lexing.position -> Lexing.position -> Ordering.t
+  val min : Lexing.position -> Lexing.position -> Lexing.position
+  val max : Lexing.position -> Lexing.position -> Lexing.position
 
-val compare : t -> t -> int
+  module O : sig
+    val (>) : Lexing.position -> Lexing.position -> bool
+    val (>=) : Lexing.position -> Lexing.position -> bool
+    val (<=) : Lexing.position -> Lexing.position -> bool
+    val (<) : Lexing.position -> Lexing.position -> bool
+  end
+end
+
+val compare : t -> t -> Ordering.t
 
 module Error : sig
   type location = t

--- a/src/location_check.ml
+++ b/src/location_check.ml
@@ -1,0 +1,693 @@
+open! Import
+
+module Non_intersecting_ranges : sig
+  type t
+
+  val empty : t
+
+  val insert : node_name:string -> Location.t -> t -> t
+
+  val union : t -> t -> t
+
+  val covered_by : t -> loc:Location.t -> bool
+  (** [covered_by t ~loc = true] iff [t] is covered by [loc] *)
+
+  val find_outside : Location.t -> t -> string * Location.t
+end = struct
+  type t =
+    { min_pos: Lexing.position option
+    ; max_pos: Lexing.position option
+    ; ranges : (string * Location.t) list
+    }
+
+  let empty = { min_pos = None; max_pos = None; ranges = [] }
+
+  let rec insert ranges (node_name, node_loc as node) =
+    match ranges with
+    | [] -> [ node ]
+    | (x_name, x_loc) as x :: xs ->
+      let open Location in
+      if compare_pos node_loc.loc_start x_loc.loc_end >= 0 then
+        node :: x :: xs
+      else if compare_pos x_loc.loc_start node_loc.loc_end >= 0 then
+        x :: insert xs node
+      else
+        raise_errorf ~loc:node_loc
+          "invalid output from ppx, %s overlaps with %s at location:@.%a"
+          node_name x_name Location.print x_loc
+
+  let min_pos p1 p2 =
+    match p1, p2 with
+    | None, None -> None
+    | (Some _ as p), None
+    | None, (Some _ as p) -> p
+    | Some p1, Some p2 -> Some (Location.min_pos p1 p2)
+
+  let max_pos p1 p2 =
+    match p1, p2 with
+    | None, None -> None
+    | (Some _ as p), None
+    | None, (Some _ as p) -> p
+    | Some p1, Some p2 -> Some (Location.max_pos p1 p2)
+
+  let longest_first l1 l2 ~stop_after =
+    let rec loop xs ys n =
+      match xs, ys, n with
+      | [], _, _
+      | _, _, 0 -> l2, l1
+      | _, [], _ -> l1, l2
+      | _ :: xs, _ :: ys, n -> loop xs ys (n - 1)
+    in
+    loop l1 l2 stop_after
+
+  let union t1 t2 =
+    let init, l = longest_first t1.ranges t2.ranges ~stop_after:42 in
+    let ranges = List.fold l ~init ~f:insert in
+    { min_pos = min_pos t1.min_pos t2.min_pos
+    ; max_pos = max_pos t1.max_pos t2.max_pos
+    ; ranges }
+
+  let insert ~node_name loc t =
+    { min_pos = min_pos (Some loc.loc_start) t.min_pos
+    ; max_pos = max_pos (Some loc.loc_end) t.max_pos
+    ; ranges = insert t.ranges (node_name, loc)
+    }
+
+  let covered_by t ~loc =
+    match t.min_pos, t.max_pos with
+    | None, None -> true
+    | Some min_pos, Some max_pos ->
+      Location.compare_pos min_pos loc.loc_start >= 0 &&
+      Location.compare_pos max_pos loc.loc_end <= 0
+    | _, _ -> (* there are no open ranges *)
+      assert false
+
+  let find_outside loc t =
+    List.find_exn t.ranges ~f:(fun (_, l) ->
+      Location.compare_pos loc.loc_start l.loc_start > 0 ||
+      Location.compare_pos loc.loc_end l.loc_end < 0
+    )
+end
+
+let reloc_pmty_functors x =
+  let outmost_loc = x.pmty_loc in
+  let rec aux x =
+    match x.pmty_desc with
+    | Pmty_functor (id, mty_opt, initial_res) ->
+      let res = aux initial_res in
+      if Location.compare outmost_loc res.pmty_loc = 0 then
+        let loc_start =
+          (match mty_opt with
+          | None -> id.loc
+          | Some mty -> mty.pmty_loc).loc_end
+        in
+        let res = { res with pmty_loc = { res.pmty_loc with loc_start } } in
+        { x with pmty_desc = Pmty_functor (id, mty_opt, res) }
+      else if phys_equal res initial_res then
+        x
+      else
+        { x with pmty_desc = Pmty_functor (id, mty_opt, res) }
+    | _ -> x
+  in
+  aux x
+
+let reloc_pmod_functors x =
+  let outmost_loc = x.pmod_loc in
+  let rec aux x =
+    match x.pmod_desc with
+    | Pmod_functor (id, mty_opt, initial_res) ->
+      let res = aux initial_res in
+      if Location.compare outmost_loc res.pmod_loc = 0 then
+        let loc_start =
+          (match mty_opt with
+          | None -> id.loc
+          | Some mty -> mty.pmty_loc).loc_end
+        in
+        let res = { res with pmod_loc = { res.pmod_loc with loc_start } } in
+        { x with pmod_desc = Pmod_functor (id, mty_opt, res) }
+      else if phys_equal res initial_res then
+        x
+      else
+        { x with pmod_desc = Pmod_functor (id, mty_opt, res) }
+    | _ -> x
+  in
+  aux x
+
+let all_payloads_inside_parent ~loc =
+  List.for_all
+    ~f:(fun attr -> Location.compare_pos loc.loc_end attr.attr_loc.loc_end >= 0)
+
+let file : string option ref = ref None
+let same_file_so_far = ref true
+
+let stayed_in_the_same_file =
+  fun fname ->
+    (* CR-soon trefis: remove uses of Location.none from the ppxes. *)
+    if String.equal fname "_none_" then
+      true (* do nothing for now. *)
+    else
+      match !file with
+      | None -> file := Some fname; true
+      | Some orig_fname ->
+        String.equal orig_fname fname || (same_file_so_far := false; false)
+
+let should_ignore loc attrs =
+  (* If the filename changed, then there were line directives, and the locations
+     are all messed up. *)
+  not (stayed_in_the_same_file loc.loc_start.pos_fname) ||
+  (* Ignore things explicitely marked. *)
+  List.exists ~f:(fun attr ->
+    String.equal attr.attr_name.txt Merlin_helpers.hide_attribute.attr_name.txt
+  ) attrs
+
+let rec extract_constraint e =
+  match e.pexp_desc with
+  | Pexp_constraint (e, ct) -> Some (e, ct)
+  | Pexp_newtype (name, exp) ->
+    Option.map (extract_constraint exp) ~f:(fun (exp, ct) ->
+      { e with
+        pexp_desc = Pexp_newtype (name, exp);
+        pexp_loc = { e.pexp_loc with loc_ghost = true }
+      }, ct
+    )
+  | _ -> None
+
+let do_check ~node_name node_loc childrens_locs siblings_locs =
+  if not !same_file_so_far then
+    Non_intersecting_ranges.empty
+  else if node_loc.loc_ghost then
+    Non_intersecting_ranges.union childrens_locs siblings_locs
+  else if Non_intersecting_ranges.covered_by childrens_locs ~loc:node_loc then
+    Non_intersecting_ranges.insert ~node_name node_loc siblings_locs
+  else
+    let child_name, child_loc =
+      Non_intersecting_ranges.find_outside node_loc childrens_locs
+    in
+    Location.raise_errorf ~loc:node_loc
+      "invalid output from ppx:@ this %s is built from a%s whose location is outside \
+       of this node's.@.Child %s found at:@ %a"
+      node_name
+      ((match String.unsafe_get child_name 0 with
+         | 'a' | 'e' | 'i' | 'o' | 'u' -> "n "
+         | _ -> " ") ^ child_name)
+      child_name Location.print child_loc
+
+let enforce_invariants fname =
+  let () = file := fname in
+  object(self)
+    inherit [Non_intersecting_ranges.t] Ast_traverse.fold as super
+
+    (* CR-someday trefis: we should generate a class which enforces the location
+       invariant.
+       And then we should only override the methods where we need an escape
+       hatch because the parser isn't doing the right thing.
+
+       That would ensure that we stay up to date as the AST changes. *)
+
+    method! longident_loc x siblings =
+      if x.loc.loc_ghost then
+        siblings
+      else
+        Non_intersecting_ranges.insert ~node_name:"ident" x.loc siblings
+
+    method! row_field x siblings_locs =
+      if should_ignore x.prf_loc x.prf_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#row_field x Non_intersecting_ranges.empty in
+        do_check ~node_name:"row field" x.prf_loc childrens_locs siblings_locs
+
+    method! object_field x siblings_locs =
+      if should_ignore x.pof_loc x.pof_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#object_field x Non_intersecting_ranges.empty in
+        do_check ~node_name:"object field" x.pof_loc childrens_locs siblings_locs
+
+    method! pattern x siblings_locs =
+      if should_ignore x.ppat_loc x.ppat_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#pattern x Non_intersecting_ranges.empty in
+        do_check ~node_name:"pattern" x.ppat_loc childrens_locs siblings_locs
+
+    method! binding_op x siblings_locs =
+      let childrens_locs = super#binding_op x Non_intersecting_ranges.empty in
+      do_check ~node_name:"binding operator" x.pbop_loc childrens_locs siblings_locs
+
+    method! value_description x siblings_locs =
+      if should_ignore x.pval_loc x.pval_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#value_description x Non_intersecting_ranges.empty in
+        do_check ~node_name:"value description" x.pval_loc childrens_locs siblings_locs
+
+    method! type_declaration x siblings_locs =
+      if should_ignore x.ptype_loc x.ptype_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#type_declaration x Non_intersecting_ranges.empty in
+        do_check ~node_name:"type declaration" x.ptype_loc childrens_locs siblings_locs
+
+    method! label_declaration x siblings_locs =
+      if should_ignore x.pld_loc x.pld_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#label_declaration x Non_intersecting_ranges.empty in
+        do_check ~node_name:"label declaration" x.pld_loc childrens_locs siblings_locs
+
+    method! constructor_declaration x siblings_locs =
+      if should_ignore x.pcd_loc x.pcd_attributes then
+        siblings_locs
+      else
+        let childrens_locs =
+          super#constructor_declaration x Non_intersecting_ranges.empty
+        in
+        do_check ~node_name:"constructor declaration" x.pcd_loc childrens_locs
+          siblings_locs
+
+    method! type_extension x siblings_locs =
+      if should_ignore x.ptyext_loc x.ptyext_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#type_extension x Non_intersecting_ranges.empty in
+        do_check ~node_name:"type extension" x.ptyext_loc childrens_locs siblings_locs
+
+    method! extension_constructor x siblings_locs =
+      if should_ignore x.pext_loc x.pext_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#extension_constructor x Non_intersecting_ranges.empty in
+        do_check ~node_name:"extension constructor" x.pext_loc childrens_locs siblings_locs
+
+    method! class_type x siblings_locs =
+      if should_ignore x.pcty_loc x.pcty_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#class_type x Non_intersecting_ranges.empty in
+        do_check ~node_name:"class type" x.pcty_loc childrens_locs siblings_locs
+
+    method! class_type_field x siblings_locs =
+      if should_ignore x.pctf_loc x.pctf_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#class_type_field x Non_intersecting_ranges.empty in
+        do_check ~node_name:"class type field" x.pctf_loc childrens_locs siblings_locs
+
+    method! class_infos f x siblings_locs =
+      if should_ignore x.pci_loc x.pci_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#class_infos f x Non_intersecting_ranges.empty in
+        do_check ~node_name:"class" x.pci_loc childrens_locs siblings_locs
+
+    method! class_expr x siblings_locs =
+      if should_ignore x.pcl_loc x.pcl_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#class_expr x Non_intersecting_ranges.empty in
+        do_check ~node_name:"class expression" x.pcl_loc childrens_locs siblings_locs
+
+    method! class_field x siblings_locs =
+      if should_ignore x.pcf_loc x.pcf_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#class_field x Non_intersecting_ranges.empty in
+        do_check ~node_name:"class field" x.pcf_loc childrens_locs siblings_locs
+
+    method! signature_item x siblings_locs =
+      if should_ignore x.psig_loc [] then
+        siblings_locs
+      else
+        let childrens_locs = super#signature_item x Non_intersecting_ranges.empty in
+        do_check ~node_name:"signature item" x.psig_loc childrens_locs siblings_locs
+
+    method! module_declaration x siblings_locs =
+      if should_ignore x.pmd_loc x.pmd_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#module_declaration x Non_intersecting_ranges.empty in
+        do_check ~node_name:"module declaration" x.pmd_loc childrens_locs siblings_locs
+
+    method! module_substitution x siblings_locs =
+      if should_ignore x.pms_loc x.pms_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#module_substitution x Non_intersecting_ranges.empty in
+        do_check ~node_name:"module substitution" x.pms_loc childrens_locs siblings_locs
+
+    method! module_type_declaration x siblings_locs =
+      if should_ignore x.pmtd_loc x.pmtd_attributes then
+        siblings_locs
+      else
+        let childrens_locs =
+          super#module_type_declaration x Non_intersecting_ranges.empty
+        in
+        do_check ~node_name:"module type declaration" x.pmtd_loc childrens_locs siblings_locs
+
+    method! open_infos f x siblings_locs =
+      if should_ignore x.popen_loc x.popen_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#open_infos f x Non_intersecting_ranges.empty in
+        do_check ~node_name:"open" x.popen_loc childrens_locs siblings_locs
+
+    method! include_infos f x siblings_locs =
+      if should_ignore x.pincl_loc x.pincl_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#include_infos f x Non_intersecting_ranges.empty in
+        do_check ~node_name:"include" x.pincl_loc childrens_locs siblings_locs
+
+    method! structure_item x siblings_locs =
+      if should_ignore x.pstr_loc [] then
+        siblings_locs
+      else
+        let childrens_locs = super#structure_item x Non_intersecting_ranges.empty in
+        do_check ~node_name:"structure item" x.pstr_loc childrens_locs siblings_locs
+
+    method! module_binding x siblings_locs =
+      if should_ignore x.pmb_loc x.pmb_attributes then
+        siblings_locs
+      else
+        let childrens_locs = super#module_binding x Non_intersecting_ranges.empty in
+        do_check ~node_name:"module binding" x.pmb_loc childrens_locs siblings_locs
+
+    (******************************************)
+    (* The following is special cased because *)
+    (* the type constraint is duplicated.     *)
+    (******************************************)
+
+    method! value_binding x siblings_locs =
+      if should_ignore x.pvb_loc x.pvb_attributes then
+        siblings_locs
+      else
+        let childrens_locs =
+          match x.pvb_pat.ppat_desc, extract_constraint x.pvb_expr with
+          | (* let x : type a b c. ct = e *)
+            Ppat_constraint (pvb_pat, { ptyp_desc = Ptyp_poly (_ :: _, ctp); _ }),
+            Some (pvb_expr, cte)
+          | (* let x : ct = e *)
+            Ppat_constraint (pvb_pat, { ptyp_desc = Ptyp_poly ([], ctp); _ }),
+            Some (pvb_expr, cte)
+            when Location.compare ctp.ptyp_loc cte.ptyp_loc = 0 ->
+            let acc = Non_intersecting_ranges.empty in
+            let acc = self#pattern pvb_pat acc in
+            let _acc = self#core_type ctp acc in
+            let acc = self#expression pvb_expr acc in
+            let acc = self#attributes x.pvb_attributes acc in
+            acc
+          | _ ->
+            super#value_binding x Non_intersecting_ranges.empty
+        in
+        do_check ~node_name:"value binding" x.pvb_loc childrens_locs siblings_locs
+
+    (**********************************************)
+    (* The following is special cased because of: *)
+    (*     MT [@attr payload]                     *)
+    (* where the loc of payload is outside the    *)
+    (* loc of the module type....                 *)
+    (* and                                        *)
+    (*     functor (A : S) (B : S) ...            *)
+    (* where the loc of [(B : S) ...] is the same *)
+    (* as the loc of the outermost module type.   *)
+    (**********************************************)
+
+    method! module_type x siblings_locs =
+      if should_ignore x.pmty_loc x.pmty_attributes then
+        siblings_locs
+      else
+        let x = reloc_pmty_functors x in
+        let childrens_locs =
+          if all_payloads_inside_parent ~loc:x.pmty_loc x.pmty_attributes then
+            super#module_type x Non_intersecting_ranges.empty
+          else
+            let acc = self#module_type_desc x.pmty_desc Non_intersecting_ranges.empty in
+            let _ = self#attributes x.pmty_attributes acc in
+            acc
+        in
+        do_check ~node_name:"module type" x.pmty_loc childrens_locs siblings_locs
+
+    (**********************************************)
+    (* The following is special cased because of: *)
+    (*     ME [@attr payload]                     *)
+    (* where the loc of payload is outside the    *)
+    (* loc of the module expr....                 *)
+    (* and                                        *)
+    (*     functor (A : S) (B : S) ...            *)
+    (* where the loc of [(B : S) ...] is the same *)
+    (* as the loc of the outermost module expr.   *)
+    (**********************************************)
+
+    method! module_expr x siblings_locs =
+      if should_ignore x.pmod_loc x.pmod_attributes then
+        siblings_locs
+      else
+        let x = reloc_pmod_functors x in
+        let childrens_locs =
+          if all_payloads_inside_parent ~loc:x.pmod_loc x.pmod_attributes then
+            super#module_expr x Non_intersecting_ranges.empty
+          else
+            let acc = self#module_expr_desc x.pmod_desc Non_intersecting_ranges.empty in
+            let _ = self#attributes x.pmod_attributes acc in
+            acc
+        in
+        do_check ~node_name:"module expression" x.pmod_loc childrens_locs siblings_locs
+
+    (*********************)
+    (* Same as above ... *)
+    (*********************)
+
+    method! core_type x siblings_locs =
+      if should_ignore x.ptyp_loc x.ptyp_attributes then
+        siblings_locs
+      else
+        let childrens_locs =
+          if all_payloads_inside_parent ~loc:x.ptyp_loc x.ptyp_attributes then
+            super#core_type x Non_intersecting_ranges.empty
+          else
+            let acc = self#core_type_desc x.ptyp_desc Non_intersecting_ranges.empty in
+            let _ = self#attributes x.ptyp_attributes acc in
+            acc
+        in
+        do_check ~node_name:"core type" x.ptyp_loc childrens_locs siblings_locs
+
+    (*****************)
+    (* And again ... *)
+    (*****************)
+
+    method! expression x siblings_locs =
+      if should_ignore x.pexp_loc x.pexp_attributes then
+        siblings_locs
+      else
+        let childrens_locs =
+          if all_payloads_inside_parent ~loc:x.pexp_loc x.pexp_attributes then
+            super#expression x Non_intersecting_ranges.empty
+          else
+            let acc = self#expression_desc x.pexp_desc Non_intersecting_ranges.empty in
+            let _ = self#attributes x.pexp_attributes acc in
+            acc
+        in
+        do_check ~node_name:"expression" x.pexp_loc childrens_locs siblings_locs
+
+
+    (***********************************************************)
+    (* The following is special cased because the location of  *)
+    (* the construct equals the location of the type_exception *)
+    (* (and so covers the location of the attributes).         *)
+    (***********************************************************)
+
+    method! type_exception x siblings_locs =
+      if should_ignore x.ptyexn_loc x.ptyexn_attributes then
+        siblings_locs
+      else
+        let init = Non_intersecting_ranges.empty in
+        let childs_locs = self#extension_constructor x.ptyexn_constructor init in
+        let attrs_locs = self#attributes x.ptyexn_attributes init in
+        ignore (do_check ~node_name:"exception" x.ptyexn_loc attrs_locs siblings_locs);
+        do_check ~node_name:"exception" x.ptyexn_loc childs_locs siblings_locs
+
+    (******************************************)
+    (* The following is overriden because the *)
+    (* lhs is sometimes included in the rhs.  *)
+    (******************************************)
+
+    method! with_constraint x siblings_loc =
+      match x with
+      | Pwith_type (_, tdecl)
+      | Pwith_typesubst (_, tdecl) ->
+        self#type_declaration tdecl siblings_loc
+      | _ ->
+        super#with_constraint x siblings_loc
+
+
+    (******************************************)
+    (* The following is overriden because of: *)
+    (* - Foo.{ bar; ... }                     *)
+    (* - Foo.[ bar; ... ]                     *)
+    (* - Foo.( bar; ... )                     *)
+    (* - method x : type a. ... = ...         *)
+    (* - foo.@(bar)                           *)
+    (* - foo.@(bar) <- baz                    *)
+    (* - foo.%.{bar}                          *)
+    (* - foo.%.{bar} <- baz                   *)
+    (* - foo.%.[bar]                          *)
+    (* - foo.%.[bar] <- baz                   *)
+    (******************************************)
+
+    method! expression_desc x acc =
+      match x with
+      | Pexp_record (labels, expr_o) ->
+        let acc =
+          self#list
+            (fun (lid, e) acc->
+               if Location.compare_pos lid.loc.loc_start e.pexp_loc.loc_start = 0 then
+                 if Location.compare lid.loc e.pexp_loc = 0 then
+                   (* punning. *)
+                   self#longident_loc lid acc
+                 else
+                   match e.pexp_desc with
+                   | Pexp_constraint (e, c) ->
+                     (* { foo : int } and { foo : int = x } ... *)
+                     let _ = self#core_type c acc in
+                     self#expression e acc
+                   | _ ->
+                     (* No idea what's going on there. *)
+                     self#expression e acc
+               else
+                 let acc = self#longident_loc lid acc in
+                 let acc = self#expression e acc in acc) labels acc
+        in
+        self#option self#expression expr_o acc
+      | Pexp_open ({ popen_expr = { pmod_desc = Pmod_ident lid; _ }; _ } as opn, e)
+        when Location.compare_pos lid.loc.loc_start e.pexp_loc.loc_start = 0
+          && Location.compare_pos lid.loc.loc_end e.pexp_loc.loc_end <> 0 ->
+        (* let's relocate ... *)
+        let e_loc = { e.pexp_loc with loc_start = lid.loc.loc_end } in
+        super#expression_desc (Pexp_open (opn, { e with pexp_loc = e_loc })) acc
+      | Pexp_poly (e, Some { ptyp_desc = Ptyp_poly (_, ct); _ }) ->
+        begin match extract_constraint e with
+        | Some (e, cte) when Location.compare cte.ptyp_loc ct.ptyp_loc = 0 ->
+          let acc = self#expression e acc in
+          let acc = self#core_type ct acc in
+          acc
+        | _ ->
+          super#expression_desc x acc
+        end
+      | Pexp_apply ({ pexp_desc = Pexp_ident { txt = lid; _ }; _ }, args) ->
+        begin match Longident.last_exn lid with
+        | id when String.is_prefix id ~prefix:"."
+               && (String.is_suffix id ~suffix:"()" ||
+                   String.is_suffix id ~suffix:"()<-" ||
+                   String.is_suffix id ~suffix:"[]" ||
+                   String.is_suffix id ~suffix:"[]<-" ||
+                   String.is_suffix id ~suffix:"{}" ||
+                   String.is_suffix id ~suffix:"{}<-") ->
+          self#list (fun (_, e) -> self#expression e) args acc
+        | exception _ -> super#expression_desc x acc
+        | _ -> super#expression_desc x acc
+        end
+      | _ ->
+        super#expression_desc x acc
+
+    (*******************************************************)
+    (* The following is overriden because of:              *)
+    (* - punning.                                          *)
+    (* - record field with type constraint.                *)
+    (* - unpack locations being incorrect when constrained *)
+    (*******************************************************)
+
+    method! pattern_desc x acc =
+      match x with
+      | Ppat_record (labels, _) ->
+        self#list
+          (fun (lid, pat) acc ->
+             if Location.compare_pos lid.loc.loc_start pat.ppat_loc.loc_start = 0 then
+               if Location.compare lid.loc pat.ppat_loc = 0 then
+                 (* simple punning! *)
+                 self#longident_loc lid acc
+               else
+                 match pat.ppat_desc with
+                 | Ppat_constraint (p, c) ->
+                   (* { foo : int } and { foo : int = x } ... *)
+                   let _ = self#core_type c acc in
+                   self#pattern p acc
+                 | _ ->
+                   (* No idea what's going on there. *)
+                   self#pattern pat acc
+             else
+               let acc = self#longident_loc lid acc in
+               let acc = self#pattern pat acc in acc) labels acc
+      | Ppat_constraint ({ ppat_desc = Ppat_unpack a; _ }, b) ->
+        let acc = self#loc self#string a acc in
+        self#core_type b acc
+      | _ ->
+        super#pattern_desc x acc
+
+    (**********************************************************)
+    (* The following is overriden because the location of the *)
+    (* fake structure for a generative argument covers the    *)
+    (* location of the functor.                               *)
+    (**********************************************************)
+
+    method! module_expr_desc x acc =
+      match x with
+      | Pmod_apply (m, { pmod_desc = Pmod_structure []; pmod_loc; _ })
+        when Location.compare_pos m.pmod_loc.loc_start pmod_loc.loc_start = 0 ->
+        super#module_expr m acc
+      | _ ->
+        super#module_expr_desc x acc
+
+    (**********************************************************)
+    (* The following is overriden because the location of the *)
+    (* open_infos for Pcl_open only covers the "open" keyword *)
+    (* and not the module opened.                             *)
+    (**********************************************************)
+
+    method! class_expr_desc x acc =
+      match x with
+      | Pcl_open (od, ce) ->
+        (* inline of open_description (which effectively makes that node
+           disappear) *)
+        let acc = self#longident_loc od.popen_expr acc in
+        let acc = self#override_flag od.popen_override acc in
+        let acc = self#location od.popen_loc acc in
+        let acc = self#attributes od.popen_attributes acc in
+        (* continue *)
+        let acc = self#class_expr ce acc in
+        acc
+      | _ ->
+        super#class_expr_desc x acc
+
+    (*********************)
+    (* Same as above ... *)
+    (*********************)
+
+    method! class_type_desc x acc =
+      match x with
+      | Pcty_open (od, ct) ->
+        (* inline of open_description (which effectively makes that node
+           disappear) *)
+        let acc = self#longident_loc od.popen_expr acc in
+        let acc = self#override_flag od.popen_override acc in
+        let acc = self#location od.popen_loc acc in
+        let acc = self#attributes od.popen_attributes acc in
+        (* continue *)
+        let acc = self#class_type ct acc in
+        acc
+      | _ ->
+        super#class_type_desc x acc
+
+    (**********************************************************)
+    (* The following is overriden because docstrings have the *)
+    (* same location as the item they get attached to.        *)
+    (**********************************************************)
+
+    method! attribute x acc =
+      match x.attr_name.txt with
+      | "ocaml.doc"
+      | "ocaml.text" ->
+        acc
+      | _ -> super#attribute x acc
+
+  end

--- a/src/location_check.ml
+++ b/src/location_check.ml
@@ -27,9 +27,9 @@ end = struct
     | [] -> [ node ]
     | (x_name, x_loc) as x :: xs ->
       let open Location in
-      if compare_pos node_loc.loc_start x_loc.loc_end >= 0 then
+      if Pos.O.(node_loc.loc_start >= x_loc.loc_end) then
         node :: x :: xs
-      else if compare_pos x_loc.loc_start node_loc.loc_end >= 0 then
+      else if Pos.O.(x_loc.loc_start >= node_loc.loc_end) then
         x :: insert xs node
       else
         raise_errorf ~loc:node_loc
@@ -41,14 +41,14 @@ end = struct
     | None, None -> None
     | (Some _ as p), None
     | None, (Some _ as p) -> p
-    | Some p1, Some p2 -> Some (Location.min_pos p1 p2)
+    | Some p1, Some p2 -> Some (Location.Pos.min p1 p2)
 
   let max_pos p1 p2 =
     match p1, p2 with
     | None, None -> None
     | (Some _ as p), None
     | None, (Some _ as p) -> p
-    | Some p1, Some p2 -> Some (Location.max_pos p1 p2)
+    | Some p1, Some p2 -> Some (Location.Pos.max p1 p2)
 
   let longest_first l1 l2 ~stop_after =
     let rec loop xs ys n =
@@ -62,7 +62,7 @@ end = struct
 
   let union t1 t2 =
     let init, l = longest_first t1.ranges t2.ranges ~stop_after:42 in
-    let ranges = List.fold l ~init ~f:insert in
+    let ranges = List.fold_left l ~init ~f:insert in
     { min_pos = min_pos t1.min_pos t2.min_pos
     ; max_pos = max_pos t1.max_pos t2.max_pos
     ; ranges }
@@ -77,15 +77,13 @@ end = struct
     match t.min_pos, t.max_pos with
     | None, None -> true
     | Some min_pos, Some max_pos ->
-      Location.compare_pos min_pos loc.loc_start >= 0 &&
-      Location.compare_pos max_pos loc.loc_end <= 0
+      Location.Pos.O.(min_pos >= loc.loc_start && max_pos <= loc.loc_end)
     | _, _ -> (* there are no open ranges *)
       assert false
 
   let find_outside loc t =
     List.find_exn t.ranges ~f:(fun (_, l) ->
-      Location.compare_pos loc.loc_start l.loc_start > 0 ||
-      Location.compare_pos loc.loc_end l.loc_end < 0
+      Location.Pos.O.(loc.loc_start > l.loc_start || loc.loc_end < l.loc_end)
     )
 end
 
@@ -95,7 +93,7 @@ let reloc_pmty_functors x =
     match x.pmty_desc with
     | Pmty_functor (id, mty_opt, initial_res) ->
       let res = aux initial_res in
-      if Location.compare outmost_loc res.pmty_loc = 0 then
+      if Location.compare outmost_loc res.pmty_loc = Eq then
         let loc_start =
           (match mty_opt with
           | None -> id.loc
@@ -103,7 +101,7 @@ let reloc_pmty_functors x =
         in
         let res = { res with pmty_loc = { res.pmty_loc with loc_start } } in
         { x with pmty_desc = Pmty_functor (id, mty_opt, res) }
-      else if phys_equal res initial_res then
+      else if res == initial_res then
         x
       else
         { x with pmty_desc = Pmty_functor (id, mty_opt, res) }
@@ -117,7 +115,7 @@ let reloc_pmod_functors x =
     match x.pmod_desc with
     | Pmod_functor (id, mty_opt, initial_res) ->
       let res = aux initial_res in
-      if Location.compare outmost_loc res.pmod_loc = 0 then
+      if Location.compare outmost_loc res.pmod_loc = Eq then
         let loc_start =
           (match mty_opt with
           | None -> id.loc
@@ -125,7 +123,7 @@ let reloc_pmod_functors x =
         in
         let res = { res with pmod_loc = { res.pmod_loc with loc_start } } in
         { x with pmod_desc = Pmod_functor (id, mty_opt, res) }
-      else if phys_equal res initial_res then
+      else if res == initial_res then
         x
       else
         { x with pmod_desc = Pmod_functor (id, mty_opt, res) }
@@ -135,7 +133,11 @@ let reloc_pmod_functors x =
 
 let all_payloads_inside_parent ~loc =
   List.for_all
-    ~f:(fun attr -> Location.compare_pos loc.loc_end attr.attr_loc.loc_end >= 0)
+    ~f:(fun (attr, _) ->
+      (* When upgrading the AST to 4.08 or higher, this check should use
+         the [attr_loc] field of the attribute instead of the location
+         of the attribute name *)
+      Location.Pos.O.(loc.loc_end >= attr.loc.loc_end))
 
 let file : string option ref = ref None
 let same_file_so_far = ref true
@@ -156,8 +158,9 @@ let should_ignore loc attrs =
      are all messed up. *)
   not (stayed_in_the_same_file loc.loc_start.pos_fname) ||
   (* Ignore things explicitely marked. *)
-  List.exists ~f:(fun attr ->
-    String.equal attr.attr_name.txt Merlin_helpers.hide_attribute.attr_name.txt
+  List.exists ~f:(fun (attr, _) ->
+    let (merlin_hide_attr_name, _) = Merlin_helpers.hide_attribute in
+    String.equal attr.txt merlin_hide_attr_name.txt
   ) attrs
 
 let rec extract_constraint e =
@@ -210,30 +213,12 @@ let enforce_invariants fname =
       else
         Non_intersecting_ranges.insert ~node_name:"ident" x.loc siblings
 
-    method! row_field x siblings_locs =
-      if should_ignore x.prf_loc x.prf_attributes then
-        siblings_locs
-      else
-        let childrens_locs = super#row_field x Non_intersecting_ranges.empty in
-        do_check ~node_name:"row field" x.prf_loc childrens_locs siblings_locs
-
-    method! object_field x siblings_locs =
-      if should_ignore x.pof_loc x.pof_attributes then
-        siblings_locs
-      else
-        let childrens_locs = super#object_field x Non_intersecting_ranges.empty in
-        do_check ~node_name:"object field" x.pof_loc childrens_locs siblings_locs
-
     method! pattern x siblings_locs =
       if should_ignore x.ppat_loc x.ppat_attributes then
         siblings_locs
       else
         let childrens_locs = super#pattern x Non_intersecting_ranges.empty in
         do_check ~node_name:"pattern" x.ppat_loc childrens_locs siblings_locs
-
-    method! binding_op x siblings_locs =
-      let childrens_locs = super#binding_op x Non_intersecting_ranges.empty in
-      do_check ~node_name:"binding operator" x.pbop_loc childrens_locs siblings_locs
 
     method! value_description x siblings_locs =
       if should_ignore x.pval_loc x.pval_attributes then
@@ -265,13 +250,6 @@ let enforce_invariants fname =
         in
         do_check ~node_name:"constructor declaration" x.pcd_loc childrens_locs
           siblings_locs
-
-    method! type_extension x siblings_locs =
-      if should_ignore x.ptyext_loc x.ptyext_attributes then
-        siblings_locs
-      else
-        let childrens_locs = super#type_extension x Non_intersecting_ranges.empty in
-        do_check ~node_name:"type extension" x.ptyext_loc childrens_locs siblings_locs
 
     method! extension_constructor x siblings_locs =
       if should_ignore x.pext_loc x.pext_attributes then
@@ -329,13 +307,6 @@ let enforce_invariants fname =
         let childrens_locs = super#module_declaration x Non_intersecting_ranges.empty in
         do_check ~node_name:"module declaration" x.pmd_loc childrens_locs siblings_locs
 
-    method! module_substitution x siblings_locs =
-      if should_ignore x.pms_loc x.pms_attributes then
-        siblings_locs
-      else
-        let childrens_locs = super#module_substitution x Non_intersecting_ranges.empty in
-        do_check ~node_name:"module substitution" x.pms_loc childrens_locs siblings_locs
-
     method! module_type_declaration x siblings_locs =
       if should_ignore x.pmtd_loc x.pmtd_attributes then
         siblings_locs
@@ -344,13 +315,6 @@ let enforce_invariants fname =
           super#module_type_declaration x Non_intersecting_ranges.empty
         in
         do_check ~node_name:"module type declaration" x.pmtd_loc childrens_locs siblings_locs
-
-    method! open_infos f x siblings_locs =
-      if should_ignore x.popen_loc x.popen_attributes then
-        siblings_locs
-      else
-        let childrens_locs = super#open_infos f x Non_intersecting_ranges.empty in
-        do_check ~node_name:"open" x.popen_loc childrens_locs siblings_locs
 
     method! include_infos f x siblings_locs =
       if should_ignore x.pincl_loc x.pincl_attributes then
@@ -390,7 +354,7 @@ let enforce_invariants fname =
           | (* let x : ct = e *)
             Ppat_constraint (pvb_pat, { ptyp_desc = Ptyp_poly ([], ctp); _ }),
             Some (pvb_expr, cte)
-            when Location.compare ctp.ptyp_loc cte.ptyp_loc = 0 ->
+            when Location.compare ctp.ptyp_loc cte.ptyp_loc = Eq ->
             let acc = Non_intersecting_ranges.empty in
             let acc = self#pattern pvb_pat acc in
             let _acc = self#core_type ctp acc in
@@ -491,22 +455,6 @@ let enforce_invariants fname =
         do_check ~node_name:"expression" x.pexp_loc childrens_locs siblings_locs
 
 
-    (***********************************************************)
-    (* The following is special cased because the location of  *)
-    (* the construct equals the location of the type_exception *)
-    (* (and so covers the location of the attributes).         *)
-    (***********************************************************)
-
-    method! type_exception x siblings_locs =
-      if should_ignore x.ptyexn_loc x.ptyexn_attributes then
-        siblings_locs
-      else
-        let init = Non_intersecting_ranges.empty in
-        let childs_locs = self#extension_constructor x.ptyexn_constructor init in
-        let attrs_locs = self#attributes x.ptyexn_attributes init in
-        ignore (do_check ~node_name:"exception" x.ptyexn_loc attrs_locs siblings_locs);
-        do_check ~node_name:"exception" x.ptyexn_loc childs_locs siblings_locs
-
     (******************************************)
     (* The following is overriden because the *)
     (* lhs is sometimes included in the rhs.  *)
@@ -541,8 +489,8 @@ let enforce_invariants fname =
         let acc =
           self#list
             (fun (lid, e) acc->
-               if Location.compare_pos lid.loc.loc_start e.pexp_loc.loc_start = 0 then
-                 if Location.compare lid.loc e.pexp_loc = 0 then
+               if Location.Pos.compare lid.loc.loc_start e.pexp_loc.loc_start = Eq then
+                 if Location.compare lid.loc e.pexp_loc = Eq then
                    (* punning. *)
                    self#longident_loc lid acc
                  else
@@ -559,15 +507,15 @@ let enforce_invariants fname =
                  let acc = self#expression e acc in acc) labels acc
         in
         self#option self#expression expr_o acc
-      | Pexp_open ({ popen_expr = { pmod_desc = Pmod_ident lid; _ }; _ } as opn, e)
-        when Location.compare_pos lid.loc.loc_start e.pexp_loc.loc_start = 0
-          && Location.compare_pos lid.loc.loc_end e.pexp_loc.loc_end <> 0 ->
+      | Pexp_open (override_flag, lid, e)
+        when Location.Pos.compare lid.loc.loc_start e.pexp_loc.loc_start = Eq
+          && Location.Pos.compare lid.loc.loc_end e.pexp_loc.loc_end <> Eq ->
         (* let's relocate ... *)
         let e_loc = { e.pexp_loc with loc_start = lid.loc.loc_end } in
-        super#expression_desc (Pexp_open (opn, { e with pexp_loc = e_loc })) acc
+        super#expression_desc (Pexp_open (override_flag, lid, { e with pexp_loc = e_loc })) acc
       | Pexp_poly (e, Some { ptyp_desc = Ptyp_poly (_, ct); _ }) ->
         begin match extract_constraint e with
-        | Some (e, cte) when Location.compare cte.ptyp_loc ct.ptyp_loc = 0 ->
+        | Some (e, cte) when Location.compare cte.ptyp_loc ct.ptyp_loc = Eq ->
           let acc = self#expression e acc in
           let acc = self#core_type ct acc in
           acc
@@ -602,8 +550,8 @@ let enforce_invariants fname =
       | Ppat_record (labels, _) ->
         self#list
           (fun (lid, pat) acc ->
-             if Location.compare_pos lid.loc.loc_start pat.ppat_loc.loc_start = 0 then
-               if Location.compare lid.loc pat.ppat_loc = 0 then
+             if Location.Pos.compare lid.loc.loc_start pat.ppat_loc.loc_start = Eq then
+               if Location.compare lid.loc pat.ppat_loc = Eq then
                  (* simple punning! *)
                  self#longident_loc lid acc
                else
@@ -633,7 +581,7 @@ let enforce_invariants fname =
     method! module_expr_desc x acc =
       match x with
       | Pmod_apply (m, { pmod_desc = Pmod_structure []; pmod_loc; _ })
-        when Location.compare_pos m.pmod_loc.loc_start pmod_loc.loc_start = 0 ->
+        when Location.Pos.compare m.pmod_loc.loc_start pmod_loc.loc_start = Eq ->
         super#module_expr m acc
       | _ ->
         super#module_expr_desc x acc
@@ -646,13 +594,11 @@ let enforce_invariants fname =
 
     method! class_expr_desc x acc =
       match x with
-      | Pcl_open (od, ce) ->
+      | Pcl_open (override_flag, lid, ce) ->
         (* inline of open_description (which effectively makes that node
            disappear) *)
-        let acc = self#longident_loc od.popen_expr acc in
-        let acc = self#override_flag od.popen_override acc in
-        let acc = self#location od.popen_loc acc in
-        let acc = self#attributes od.popen_attributes acc in
+        let acc = self#longident_loc lid acc in
+        let acc = self#override_flag override_flag acc in
         (* continue *)
         let acc = self#class_expr ce acc in
         acc
@@ -665,13 +611,11 @@ let enforce_invariants fname =
 
     method! class_type_desc x acc =
       match x with
-      | Pcty_open (od, ct) ->
+      | Pcty_open (override_flag, lid, ct) ->
         (* inline of open_description (which effectively makes that node
            disappear) *)
-        let acc = self#longident_loc od.popen_expr acc in
-        let acc = self#override_flag od.popen_override acc in
-        let acc = self#location od.popen_loc acc in
-        let acc = self#attributes od.popen_attributes acc in
+        let acc = self#longident_loc lid acc in
+        let acc = self#override_flag override_flag acc in
         (* continue *)
         let acc = self#class_type ct acc in
         acc
@@ -684,7 +628,8 @@ let enforce_invariants fname =
     (**********************************************************)
 
     method! attribute x acc =
-      match x.attr_name.txt with
+      let (name, _) = x in
+      match name.txt with
       | "ocaml.doc"
       | "ocaml.text" ->
         acc

--- a/src/location_check.mli
+++ b/src/location_check.mli
@@ -1,0 +1,9 @@
+open! Import
+
+module Non_intersecting_ranges : sig
+  type t
+
+  val empty : t
+end
+
+val enforce_invariants : string option -> Non_intersecting_ranges.t Ast_traverse.fold

--- a/src/options.ml
+++ b/src/options.ml
@@ -4,5 +4,6 @@ let perform_checks = false
    them externally to make it easier to use non ppx based
    rewriters with ppx *)
 let perform_checks_on_extensions = false
+let perform_locations_check = false
 let fail_on_duplicate_derivers = false
 let diff_command = None

--- a/stdppx/ordering.ml
+++ b/stdppx/ordering.ml
@@ -25,6 +25,14 @@ let neq = function
   | Eq -> false
   | Lt | Gt -> true
 
+let leq = function
+  | Lt | Eq -> true
+  | Gt -> false
+
+let geq = function
+  | Gt | Eq -> true
+  | Lt -> false
+
 let is_eq = function
   | Eq -> true
   | Lt | Gt -> false

--- a/stdppx/ordering.mli
+++ b/stdppx/ordering.mli
@@ -13,6 +13,10 @@ val to_string : t -> string
 
 val neq : t -> bool
 
+val leq : t -> bool
+
+val geq : t -> bool
+
 val is_eq : t -> bool
 
 val rev : t -> t


### PR DESCRIPTION
This PR backports https://github.com/ocaml-ppx/ppxlib/pull/107.

The first commit only contains the cherry-pick and a few straightforward changes but doesn't build. The second one contains changes I made to get it to work. This should allow for an easier review.

The main differences are that we don't use `Base` whereas ppxlib does and that we're based on the `4.07` AST when ppxlib is based on a more recent versions with more locations.

Some of those changes will have to be reverted when we bump the AST we use internally. I'm happy to split this into smaller commits to ease that process.

CC @trefis if you can take a look at this that'd be great. I'd feel a lot better if you can confirm I haven't messed things up!