### PR TITLE
Add a suffix to view functions for constructors

### DIFF
--- a/ast/cinaps/gen_viewer.ml
+++ b/ast/cinaps/gen_viewer.ml
@@ -2,6 +2,9 @@ open Stdppx
 
 let string_of_ty ty = Grammar.string_of_ty ~internal:false ty
 
+let variant_viewer_name cname =
+  Ml.id (cname ^ "'const")
+
 module type VIEWER_PRINTER = sig
   val print_field_viewer :
     targs: string list ->
@@ -46,7 +49,7 @@ module Structure : VIEWER_PRINTER = struct
     match (clause : Astlib.Grammar.clause) with
     | Empty ->
       Print.newline ();
-      Print.println "let %s value =" (Ml.id cname);
+      Print.println "let %s value =" (variant_viewer_name cname);
       Print.indented (fun () ->
         print_to_concrete ~shortcut name "value";
         Print.println "match concrete with";
@@ -54,7 +57,7 @@ module Structure : VIEWER_PRINTER = struct
         Print.println "| _ -> View.error")
     | Tuple tyl ->
       Print.newline ();
-      Print.println "let %s view value =" (Ml.id cname);
+      Print.println "let %s view value =" (variant_viewer_name cname);
       Print.indented (fun () ->
         let args = tuple tyl in
         print_to_concrete ~shortcut name "value";
@@ -115,7 +118,9 @@ module Signature : VIEWER_PRINTER = struct
     | Empty ->
       Print.newline ();
       let in_, out = "'a", "'a" in
-      Print.println "val %s : %s" (Ml.id cname) (view_t value_type ~in_ ~out)
+      Print.println "val %s : %s"
+        (variant_viewer_name cname)
+        (view_t value_type ~in_ ~out)
     | Tuple tyl ->
       let in_, out = "'i", "'o" in
       let arg_type : Astlib.Grammar.ty =
@@ -124,7 +129,7 @@ module Signature : VIEWER_PRINTER = struct
         | _ -> Tuple tyl
       in
       Print.println "val %s : %s -> %s"
-        (Ml.id cname)
+        (variant_viewer_name cname)
         (view_t (string_of_ty arg_type) ~in_ ~out)
         (view_t value_type ~in_ ~out)
     | Record _fields -> ()

--- a/ast/viewer.ml
+++ b/ast/viewer.ml
@@ -35,7 +35,7 @@ module Unstable_for_testing = struct
 
   let conversion_failed name = Raise.conversion_failed ~version:"Unstable_for_testing" name
 
-  let pdir_bool view value =
+  let pdir_bool'const view value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"
@@ -45,7 +45,7 @@ module Unstable_for_testing = struct
     | Directive_argument.Pdir_bool arg -> view arg
     | _ -> View.error
 
-  let pdir_ident view value =
+  let pdir_ident'const view value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"
@@ -55,7 +55,7 @@ module Unstable_for_testing = struct
     | Directive_argument.Pdir_ident arg -> view arg
     | _ -> View.error
 
-  let pdir_int view value =
+  let pdir_int'const view value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"
@@ -65,7 +65,7 @@ module Unstable_for_testing = struct
     | Directive_argument.Pdir_int (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pdir_string view value =
+  let pdir_string'const view value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"
@@ -75,7 +75,7 @@ module Unstable_for_testing = struct
     | Directive_argument.Pdir_string arg -> view arg
     | _ -> View.error
 
-  let pdir_none value =
+  let pdir_none'const value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"
@@ -85,7 +85,7 @@ module Unstable_for_testing = struct
     | Directive_argument.Pdir_none -> View.ok
     | _ -> View.error
 
-  let ptop_dir view value =
+  let ptop_dir'const view value =
     let concrete =
       match Toplevel_phrase.to_concrete value with
       | None -> conversion_failed "toplevel_phrase"
@@ -95,7 +95,7 @@ module Unstable_for_testing = struct
     | Toplevel_phrase.Ptop_dir (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptop_def view value =
+  let ptop_def'const view value =
     let concrete =
       match Toplevel_phrase.to_concrete value with
       | None -> conversion_failed "toplevel_phrase"
@@ -169,7 +169,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Value_binding.pvb_pat
 
-  let pstr_extension view value =
+  let pstr_extension'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -185,7 +185,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_extension (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pstr_attribute view value =
+  let pstr_attribute'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -201,7 +201,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_attribute arg -> view arg
     | _ -> View.error
 
-  let pstr_include view value =
+  let pstr_include'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -217,7 +217,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_include arg -> view arg
     | _ -> View.error
 
-  let pstr_class_type view value =
+  let pstr_class_type'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -233,7 +233,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_class_type arg -> view arg
     | _ -> View.error
 
-  let pstr_class view value =
+  let pstr_class'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -249,7 +249,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_class arg -> view arg
     | _ -> View.error
 
-  let pstr_open view value =
+  let pstr_open'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -265,7 +265,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_open arg -> view arg
     | _ -> View.error
 
-  let pstr_modtype view value =
+  let pstr_modtype'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -281,7 +281,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_modtype arg -> view arg
     | _ -> View.error
 
-  let pstr_recmodule view value =
+  let pstr_recmodule'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -297,7 +297,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_recmodule arg -> view arg
     | _ -> View.error
 
-  let pstr_module view value =
+  let pstr_module'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -313,7 +313,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_module arg -> view arg
     | _ -> View.error
 
-  let pstr_exception view value =
+  let pstr_exception'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -329,7 +329,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_exception arg -> view arg
     | _ -> View.error
 
-  let pstr_typext view value =
+  let pstr_typext'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -345,7 +345,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_typext arg -> view arg
     | _ -> View.error
 
-  let pstr_type view value =
+  let pstr_type'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -361,7 +361,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_type (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pstr_primitive view value =
+  let pstr_primitive'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -377,7 +377,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_primitive arg -> view arg
     | _ -> View.error
 
-  let pstr_value view value =
+  let pstr_value'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -393,7 +393,7 @@ module Unstable_for_testing = struct
     | Structure_item_desc.Pstr_value (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pstr_eval view value =
+  let pstr_eval'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -425,7 +425,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Structure_item.pstr_desc
 
-  let pmod_extension view value =
+  let pmod_extension'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -441,7 +441,7 @@ module Unstable_for_testing = struct
     | Module_expr_desc.Pmod_extension arg -> view arg
     | _ -> View.error
 
-  let pmod_unpack view value =
+  let pmod_unpack'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -457,7 +457,7 @@ module Unstable_for_testing = struct
     | Module_expr_desc.Pmod_unpack arg -> view arg
     | _ -> View.error
 
-  let pmod_constraint view value =
+  let pmod_constraint'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -473,7 +473,7 @@ module Unstable_for_testing = struct
     | Module_expr_desc.Pmod_constraint (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pmod_apply view value =
+  let pmod_apply'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -489,7 +489,7 @@ module Unstable_for_testing = struct
     | Module_expr_desc.Pmod_apply (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pmod_functor view value =
+  let pmod_functor'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -505,7 +505,7 @@ module Unstable_for_testing = struct
     | Module_expr_desc.Pmod_functor (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pmod_structure view value =
+  let pmod_structure'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -521,7 +521,7 @@ module Unstable_for_testing = struct
     | Module_expr_desc.Pmod_structure arg -> view arg
     | _ -> View.error
 
-  let pmod_ident view value =
+  let pmod_ident'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -561,7 +561,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Module_expr.pmod_desc
 
-  let pwith_modsubst view value =
+  let pwith_modsubst'const view value =
     let concrete =
       match With_constraint.to_concrete value with
       | None -> conversion_failed "with_constraint"
@@ -571,7 +571,7 @@ module Unstable_for_testing = struct
     | With_constraint.Pwith_modsubst (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pwith_typesubst view value =
+  let pwith_typesubst'const view value =
     let concrete =
       match With_constraint.to_concrete value with
       | None -> conversion_failed "with_constraint"
@@ -581,7 +581,7 @@ module Unstable_for_testing = struct
     | With_constraint.Pwith_typesubst (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pwith_module view value =
+  let pwith_module'const view value =
     let concrete =
       match With_constraint.to_concrete value with
       | None -> conversion_failed "with_constraint"
@@ -591,7 +591,7 @@ module Unstable_for_testing = struct
     | With_constraint.Pwith_module (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pwith_type view value =
+  let pwith_type'const view value =
     let concrete =
       match With_constraint.to_concrete value with
       | None -> conversion_failed "with_constraint"
@@ -721,7 +721,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Module_declaration.pmd_name
 
-  let psig_extension view value =
+  let psig_extension'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -737,7 +737,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_extension (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let psig_attribute view value =
+  let psig_attribute'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -753,7 +753,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_attribute arg -> view arg
     | _ -> View.error
 
-  let psig_class_type view value =
+  let psig_class_type'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -769,7 +769,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_class_type arg -> view arg
     | _ -> View.error
 
-  let psig_class view value =
+  let psig_class'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -785,7 +785,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_class arg -> view arg
     | _ -> View.error
 
-  let psig_include view value =
+  let psig_include'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -801,7 +801,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_include arg -> view arg
     | _ -> View.error
 
-  let psig_open view value =
+  let psig_open'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -817,7 +817,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_open arg -> view arg
     | _ -> View.error
 
-  let psig_modtype view value =
+  let psig_modtype'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -833,7 +833,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_modtype arg -> view arg
     | _ -> View.error
 
-  let psig_recmodule view value =
+  let psig_recmodule'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -849,7 +849,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_recmodule arg -> view arg
     | _ -> View.error
 
-  let psig_module view value =
+  let psig_module'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -865,7 +865,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_module arg -> view arg
     | _ -> View.error
 
-  let psig_exception view value =
+  let psig_exception'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -881,7 +881,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_exception arg -> view arg
     | _ -> View.error
 
-  let psig_typext view value =
+  let psig_typext'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -897,7 +897,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_typext arg -> view arg
     | _ -> View.error
 
-  let psig_type view value =
+  let psig_type'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -913,7 +913,7 @@ module Unstable_for_testing = struct
     | Signature_item_desc.Psig_type (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let psig_value view value =
+  let psig_value'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -945,7 +945,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Signature_item.psig_desc
 
-  let pmty_alias view value =
+  let pmty_alias'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -961,7 +961,7 @@ module Unstable_for_testing = struct
     | Module_type_desc.Pmty_alias arg -> view arg
     | _ -> View.error
 
-  let pmty_extension view value =
+  let pmty_extension'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -977,7 +977,7 @@ module Unstable_for_testing = struct
     | Module_type_desc.Pmty_extension arg -> view arg
     | _ -> View.error
 
-  let pmty_typeof view value =
+  let pmty_typeof'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -993,7 +993,7 @@ module Unstable_for_testing = struct
     | Module_type_desc.Pmty_typeof arg -> view arg
     | _ -> View.error
 
-  let pmty_with view value =
+  let pmty_with'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -1009,7 +1009,7 @@ module Unstable_for_testing = struct
     | Module_type_desc.Pmty_with (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pmty_functor view value =
+  let pmty_functor'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -1025,7 +1025,7 @@ module Unstable_for_testing = struct
     | Module_type_desc.Pmty_functor (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pmty_signature view value =
+  let pmty_signature'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -1041,7 +1041,7 @@ module Unstable_for_testing = struct
     | Module_type_desc.Pmty_signature arg -> view arg
     | _ -> View.error
 
-  let pmty_ident view value =
+  let pmty_ident'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -1081,7 +1081,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Module_type.pmty_desc
 
-  let cfk_concrete view value =
+  let cfk_concrete'const view value =
     let concrete =
       match Class_field_kind.to_concrete value with
       | None -> conversion_failed "class_field_kind"
@@ -1091,7 +1091,7 @@ module Unstable_for_testing = struct
     | Class_field_kind.Cfk_concrete (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let cfk_virtual view value =
+  let cfk_virtual'const view value =
     let concrete =
       match Class_field_kind.to_concrete value with
       | None -> conversion_failed "class_field_kind"
@@ -1101,7 +1101,7 @@ module Unstable_for_testing = struct
     | Class_field_kind.Cfk_virtual arg -> view arg
     | _ -> View.error
 
-  let pcf_extension view value =
+  let pcf_extension'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -1117,7 +1117,7 @@ module Unstable_for_testing = struct
     | Class_field_desc.Pcf_extension arg -> view arg
     | _ -> View.error
 
-  let pcf_attribute view value =
+  let pcf_attribute'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -1133,7 +1133,7 @@ module Unstable_for_testing = struct
     | Class_field_desc.Pcf_attribute arg -> view arg
     | _ -> View.error
 
-  let pcf_initializer view value =
+  let pcf_initializer'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -1149,7 +1149,7 @@ module Unstable_for_testing = struct
     | Class_field_desc.Pcf_initializer arg -> view arg
     | _ -> View.error
 
-  let pcf_constraint view value =
+  let pcf_constraint'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -1165,7 +1165,7 @@ module Unstable_for_testing = struct
     | Class_field_desc.Pcf_constraint arg -> view arg
     | _ -> View.error
 
-  let pcf_method view value =
+  let pcf_method'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -1181,7 +1181,7 @@ module Unstable_for_testing = struct
     | Class_field_desc.Pcf_method arg -> view arg
     | _ -> View.error
 
-  let pcf_val view value =
+  let pcf_val'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -1197,7 +1197,7 @@ module Unstable_for_testing = struct
     | Class_field_desc.Pcf_val arg -> view arg
     | _ -> View.error
 
-  let pcf_inherit view value =
+  let pcf_inherit'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -1253,7 +1253,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Class_structure.pcstr_self
 
-  let pcl_open view value =
+  let pcl_open'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -1269,7 +1269,7 @@ module Unstable_for_testing = struct
     | Class_expr_desc.Pcl_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pcl_extension view value =
+  let pcl_extension'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -1285,7 +1285,7 @@ module Unstable_for_testing = struct
     | Class_expr_desc.Pcl_extension arg -> view arg
     | _ -> View.error
 
-  let pcl_constraint view value =
+  let pcl_constraint'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -1301,7 +1301,7 @@ module Unstable_for_testing = struct
     | Class_expr_desc.Pcl_constraint (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pcl_let view value =
+  let pcl_let'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -1317,7 +1317,7 @@ module Unstable_for_testing = struct
     | Class_expr_desc.Pcl_let (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pcl_apply view value =
+  let pcl_apply'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -1333,7 +1333,7 @@ module Unstable_for_testing = struct
     | Class_expr_desc.Pcl_apply (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pcl_fun view value =
+  let pcl_fun'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -1349,7 +1349,7 @@ module Unstable_for_testing = struct
     | Class_expr_desc.Pcl_fun (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
     | _ -> View.error
 
-  let pcl_structure view value =
+  let pcl_structure'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -1365,7 +1365,7 @@ module Unstable_for_testing = struct
     | Class_expr_desc.Pcl_structure arg -> view arg
     | _ -> View.error
 
-  let pcl_constr view value =
+  let pcl_constr'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -1453,7 +1453,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Class_infos.pci_virt
 
-  let pctf_extension view value =
+  let pctf_extension'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -1469,7 +1469,7 @@ module Unstable_for_testing = struct
     | Class_type_field_desc.Pctf_extension arg -> view arg
     | _ -> View.error
 
-  let pctf_attribute view value =
+  let pctf_attribute'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -1485,7 +1485,7 @@ module Unstable_for_testing = struct
     | Class_type_field_desc.Pctf_attribute arg -> view arg
     | _ -> View.error
 
-  let pctf_constraint view value =
+  let pctf_constraint'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -1501,7 +1501,7 @@ module Unstable_for_testing = struct
     | Class_type_field_desc.Pctf_constraint arg -> view arg
     | _ -> View.error
 
-  let pctf_method view value =
+  let pctf_method'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -1517,7 +1517,7 @@ module Unstable_for_testing = struct
     | Class_type_field_desc.Pctf_method arg -> view arg
     | _ -> View.error
 
-  let pctf_val view value =
+  let pctf_val'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -1533,7 +1533,7 @@ module Unstable_for_testing = struct
     | Class_type_field_desc.Pctf_val arg -> view arg
     | _ -> View.error
 
-  let pctf_inherit view value =
+  let pctf_inherit'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -1589,7 +1589,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Class_signature.pcsig_self
 
-  let pcty_open view value =
+  let pcty_open'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -1605,7 +1605,7 @@ module Unstable_for_testing = struct
     | Class_type_desc.Pcty_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pcty_extension view value =
+  let pcty_extension'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -1621,7 +1621,7 @@ module Unstable_for_testing = struct
     | Class_type_desc.Pcty_extension arg -> view arg
     | _ -> View.error
 
-  let pcty_arrow view value =
+  let pcty_arrow'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -1637,7 +1637,7 @@ module Unstable_for_testing = struct
     | Class_type_desc.Pcty_arrow (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pcty_signature view value =
+  let pcty_signature'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -1653,7 +1653,7 @@ module Unstable_for_testing = struct
     | Class_type_desc.Pcty_signature arg -> view arg
     | _ -> View.error
 
-  let pcty_constr view value =
+  let pcty_constr'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -1693,7 +1693,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Class_type.pcty_desc
 
-  let pext_rebind view value =
+  let pext_rebind'const view value =
     let concrete =
       match Extension_constructor_kind.to_concrete value with
       | None -> conversion_failed "extension_constructor_kind"
@@ -1703,7 +1703,7 @@ module Unstable_for_testing = struct
     | Extension_constructor_kind.Pext_rebind arg -> view arg
     | _ -> View.error
 
-  let pext_decl view value =
+  let pext_decl'const view value =
     let concrete =
       match Extension_constructor_kind.to_concrete value with
       | None -> conversion_failed "extension_constructor_kind"
@@ -1785,7 +1785,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Type_extension.ptyext_path
 
-  let pcstr_record view value =
+  let pcstr_record'const view value =
     let concrete =
       match Constructor_arguments.to_concrete value with
       | None -> conversion_failed "constructor_arguments"
@@ -1795,7 +1795,7 @@ module Unstable_for_testing = struct
     | Constructor_arguments.Pcstr_record arg -> view arg
     | _ -> View.error
 
-  let pcstr_tuple view value =
+  let pcstr_tuple'const view value =
     let concrete =
       match Constructor_arguments.to_concrete value with
       | None -> conversion_failed "constructor_arguments"
@@ -1885,7 +1885,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Label_declaration.pld_name
 
-  let ptype_open value =
+  let ptype_open'const value =
     let concrete =
       match Type_kind.to_concrete value with
       | None -> conversion_failed "type_kind"
@@ -1895,7 +1895,7 @@ module Unstable_for_testing = struct
     | Type_kind.Ptype_open -> View.ok
     | _ -> View.error
 
-  let ptype_record view value =
+  let ptype_record'const view value =
     let concrete =
       match Type_kind.to_concrete value with
       | None -> conversion_failed "type_kind"
@@ -1905,7 +1905,7 @@ module Unstable_for_testing = struct
     | Type_kind.Ptype_record arg -> view arg
     | _ -> View.error
 
-  let ptype_variant view value =
+  let ptype_variant'const view value =
     let concrete =
       match Type_kind.to_concrete value with
       | None -> conversion_failed "type_kind"
@@ -1915,7 +1915,7 @@ module Unstable_for_testing = struct
     | Type_kind.Ptype_variant arg -> view arg
     | _ -> View.error
 
-  let ptype_abstract value =
+  let ptype_abstract'const value =
     let concrete =
       match Type_kind.to_concrete value with
       | None -> conversion_failed "type_kind"
@@ -2053,7 +2053,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Case.pc_lhs
 
-  let pexp_unreachable value =
+  let pexp_unreachable'const value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2069,7 +2069,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_unreachable -> View.ok
     | _ -> View.error
 
-  let pexp_extension view value =
+  let pexp_extension'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2085,7 +2085,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_extension arg -> view arg
     | _ -> View.error
 
-  let pexp_open view value =
+  let pexp_open'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2101,7 +2101,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_pack view value =
+  let pexp_pack'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2117,7 +2117,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_pack arg -> view arg
     | _ -> View.error
 
-  let pexp_newtype view value =
+  let pexp_newtype'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2133,7 +2133,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_newtype (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_object view value =
+  let pexp_object'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2149,7 +2149,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_object arg -> view arg
     | _ -> View.error
 
-  let pexp_poly view value =
+  let pexp_poly'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2165,7 +2165,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_poly (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_lazy view value =
+  let pexp_lazy'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2181,7 +2181,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_lazy arg -> view arg
     | _ -> View.error
 
-  let pexp_assert view value =
+  let pexp_assert'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2197,7 +2197,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_assert arg -> view arg
     | _ -> View.error
 
-  let pexp_letexception view value =
+  let pexp_letexception'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2213,7 +2213,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_letexception (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_letmodule view value =
+  let pexp_letmodule'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2229,7 +2229,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_letmodule (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_override view value =
+  let pexp_override'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2245,7 +2245,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_override arg -> view arg
     | _ -> View.error
 
-  let pexp_setinstvar view value =
+  let pexp_setinstvar'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2261,7 +2261,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_setinstvar (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_new view value =
+  let pexp_new'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2277,7 +2277,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_new arg -> view arg
     | _ -> View.error
 
-  let pexp_send view value =
+  let pexp_send'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2293,7 +2293,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_send (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_coerce view value =
+  let pexp_coerce'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2309,7 +2309,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_coerce (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_constraint view value =
+  let pexp_constraint'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2325,7 +2325,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_constraint (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_for view value =
+  let pexp_for'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2341,7 +2341,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_for (arg0, arg1, arg2, arg3, arg4) -> view (arg0, arg1, arg2, arg3, arg4)
     | _ -> View.error
 
-  let pexp_while view value =
+  let pexp_while'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2357,7 +2357,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_while (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_sequence view value =
+  let pexp_sequence'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2373,7 +2373,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_sequence (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_ifthenelse view value =
+  let pexp_ifthenelse'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2389,7 +2389,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_ifthenelse (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_array view value =
+  let pexp_array'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2405,7 +2405,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_array arg -> view arg
     | _ -> View.error
 
-  let pexp_setfield view value =
+  let pexp_setfield'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2421,7 +2421,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_setfield (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_field view value =
+  let pexp_field'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2437,7 +2437,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_field (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_record view value =
+  let pexp_record'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2453,7 +2453,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_record (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_variant view value =
+  let pexp_variant'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2469,7 +2469,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_variant (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_construct view value =
+  let pexp_construct'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2485,7 +2485,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_construct (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_tuple view value =
+  let pexp_tuple'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2501,7 +2501,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_tuple arg -> view arg
     | _ -> View.error
 
-  let pexp_try view value =
+  let pexp_try'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2517,7 +2517,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_try (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_match view value =
+  let pexp_match'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2533,7 +2533,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_match (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_apply view value =
+  let pexp_apply'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2549,7 +2549,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_apply (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_fun view value =
+  let pexp_fun'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2565,7 +2565,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_fun (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
     | _ -> View.error
 
-  let pexp_function view value =
+  let pexp_function'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2581,7 +2581,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_function arg -> view arg
     | _ -> View.error
 
-  let pexp_let view value =
+  let pexp_let'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2597,7 +2597,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_let (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_constant view value =
+  let pexp_constant'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2613,7 +2613,7 @@ module Unstable_for_testing = struct
     | Expression_desc.Pexp_constant arg -> view arg
     | _ -> View.error
 
-  let pexp_ident view value =
+  let pexp_ident'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -2653,7 +2653,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Expression.pexp_desc
 
-  let ppat_open view value =
+  let ppat_open'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2669,7 +2669,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_open (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_extension view value =
+  let ppat_extension'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2685,7 +2685,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_extension arg -> view arg
     | _ -> View.error
 
-  let ppat_exception view value =
+  let ppat_exception'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2701,7 +2701,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_exception arg -> view arg
     | _ -> View.error
 
-  let ppat_unpack view value =
+  let ppat_unpack'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2717,7 +2717,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_unpack arg -> view arg
     | _ -> View.error
 
-  let ppat_lazy view value =
+  let ppat_lazy'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2733,7 +2733,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_lazy arg -> view arg
     | _ -> View.error
 
-  let ppat_type view value =
+  let ppat_type'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2749,7 +2749,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_type arg -> view arg
     | _ -> View.error
 
-  let ppat_constraint view value =
+  let ppat_constraint'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2765,7 +2765,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_constraint (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_or view value =
+  let ppat_or'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2781,7 +2781,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_or (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_array view value =
+  let ppat_array'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2797,7 +2797,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_array arg -> view arg
     | _ -> View.error
 
-  let ppat_record view value =
+  let ppat_record'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2813,7 +2813,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_record (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_variant view value =
+  let ppat_variant'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2829,7 +2829,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_variant (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_construct view value =
+  let ppat_construct'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2845,7 +2845,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_construct (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_tuple view value =
+  let ppat_tuple'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2861,7 +2861,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_tuple arg -> view arg
     | _ -> View.error
 
-  let ppat_interval view value =
+  let ppat_interval'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2877,7 +2877,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_interval (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_constant view value =
+  let ppat_constant'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2893,7 +2893,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_constant arg -> view arg
     | _ -> View.error
 
-  let ppat_alias view value =
+  let ppat_alias'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2909,7 +2909,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_alias (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_var view value =
+  let ppat_var'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2925,7 +2925,7 @@ module Unstable_for_testing = struct
     | Pattern_desc.Ppat_var arg -> view arg
     | _ -> View.error
 
-  let ppat_any value =
+  let ppat_any'const value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -2965,7 +2965,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Pattern.ppat_desc
 
-  let oinherit view value =
+  let oinherit'const view value =
     let concrete =
       match Object_field.to_concrete value with
       | None -> conversion_failed "object_field"
@@ -2975,7 +2975,7 @@ module Unstable_for_testing = struct
     | Object_field.Oinherit arg -> view arg
     | _ -> View.error
 
-  let otag view value =
+  let otag'const view value =
     let concrete =
       match Object_field.to_concrete value with
       | None -> conversion_failed "object_field"
@@ -2985,7 +2985,7 @@ module Unstable_for_testing = struct
     | Object_field.Otag (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let rinherit view value =
+  let rinherit'const view value =
     let concrete =
       match Row_field.to_concrete value with
       | None -> conversion_failed "row_field"
@@ -2995,7 +2995,7 @@ module Unstable_for_testing = struct
     | Row_field.Rinherit arg -> view arg
     | _ -> View.error
 
-  let rtag view value =
+  let rtag'const view value =
     let concrete =
       match Row_field.to_concrete value with
       | None -> conversion_failed "row_field"
@@ -3005,7 +3005,7 @@ module Unstable_for_testing = struct
     | Row_field.Rtag (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
     | _ -> View.error
 
-  let ptyp_extension view value =
+  let ptyp_extension'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3021,7 +3021,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_extension arg -> view arg
     | _ -> View.error
 
-  let ptyp_package view value =
+  let ptyp_package'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3037,7 +3037,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_package arg -> view arg
     | _ -> View.error
 
-  let ptyp_poly view value =
+  let ptyp_poly'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3053,7 +3053,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_poly (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_variant view value =
+  let ptyp_variant'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3069,7 +3069,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_variant (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let ptyp_alias view value =
+  let ptyp_alias'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3085,7 +3085,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_alias (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_class view value =
+  let ptyp_class'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3101,7 +3101,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_class (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_object view value =
+  let ptyp_object'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3117,7 +3117,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_object (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_constr view value =
+  let ptyp_constr'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3133,7 +3133,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_constr (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_tuple view value =
+  let ptyp_tuple'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3149,7 +3149,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_tuple arg -> view arg
     | _ -> View.error
 
-  let ptyp_arrow view value =
+  let ptyp_arrow'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3165,7 +3165,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_arrow (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let ptyp_var view value =
+  let ptyp_var'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3181,7 +3181,7 @@ module Unstable_for_testing = struct
     | Core_type_desc.Ptyp_var arg -> view arg
     | _ -> View.error
 
-  let ptyp_any value =
+  let ptyp_any'const value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3221,7 +3221,7 @@ module Unstable_for_testing = struct
     in
     view concrete.Core_type.ptyp_desc
 
-  let ppat view value =
+  let ppat'const view value =
     let concrete =
       match Payload.to_concrete value with
       | None -> conversion_failed "payload"
@@ -3231,7 +3231,7 @@ module Unstable_for_testing = struct
     | Payload.PPat (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp view value =
+  let ptyp'const view value =
     let concrete =
       match Payload.to_concrete value with
       | None -> conversion_failed "payload"
@@ -3241,7 +3241,7 @@ module Unstable_for_testing = struct
     | Payload.PTyp arg -> view arg
     | _ -> View.error
 
-  let psig view value =
+  let psig'const view value =
     let concrete =
       match Payload.to_concrete value with
       | None -> conversion_failed "payload"
@@ -3251,7 +3251,7 @@ module Unstable_for_testing = struct
     | Payload.PSig arg -> view arg
     | _ -> View.error
 
-  let pstr view value =
+  let pstr'const view value =
     let concrete =
       match Payload.to_concrete value with
       | None -> conversion_failed "payload"
@@ -3261,7 +3261,7 @@ module Unstable_for_testing = struct
     | Payload.PStr arg -> view arg
     | _ -> View.error
 
-  let pconst_float view value =
+  let pconst_float'const view value =
     let concrete =
       match Constant.to_concrete value with
       | None -> conversion_failed "constant"
@@ -3271,7 +3271,7 @@ module Unstable_for_testing = struct
     | Constant.Pconst_float (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pconst_string view value =
+  let pconst_string'const view value =
     let concrete =
       match Constant.to_concrete value with
       | None -> conversion_failed "constant"
@@ -3281,7 +3281,7 @@ module Unstable_for_testing = struct
     | Constant.Pconst_string (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pconst_char view value =
+  let pconst_char'const view value =
     let concrete =
       match Constant.to_concrete value with
       | None -> conversion_failed "constant"
@@ -3291,7 +3291,7 @@ module Unstable_for_testing = struct
     | Constant.Pconst_char arg -> view arg
     | _ -> View.error
 
-  let pconst_integer view value =
+  let pconst_integer'const view value =
     let concrete =
       match Constant.to_concrete value with
       | None -> conversion_failed "constant"
@@ -3301,7 +3301,7 @@ module Unstable_for_testing = struct
     | Constant.Pconst_integer (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let invariant value =
+  let invariant'const value =
     let concrete =
       match Variance.to_concrete value with
       | None -> conversion_failed "variance"
@@ -3311,7 +3311,7 @@ module Unstable_for_testing = struct
     | Variance.Invariant -> View.ok
     | _ -> View.error
 
-  let contravariant value =
+  let contravariant'const value =
     let concrete =
       match Variance.to_concrete value with
       | None -> conversion_failed "variance"
@@ -3321,7 +3321,7 @@ module Unstable_for_testing = struct
     | Variance.Contravariant -> View.ok
     | _ -> View.error
 
-  let covariant value =
+  let covariant'const value =
     let concrete =
       match Variance.to_concrete value with
       | None -> conversion_failed "variance"
@@ -3331,7 +3331,7 @@ module Unstable_for_testing = struct
     | Variance.Covariant -> View.ok
     | _ -> View.error
 
-  let optional view value =
+  let optional'const view value =
     let concrete =
       match Arg_label.to_concrete value with
       | None -> conversion_failed "arg_label"
@@ -3341,7 +3341,7 @@ module Unstable_for_testing = struct
     | Arg_label.Optional arg -> view arg
     | _ -> View.error
 
-  let labelled view value =
+  let labelled'const view value =
     let concrete =
       match Arg_label.to_concrete value with
       | None -> conversion_failed "arg_label"
@@ -3351,7 +3351,7 @@ module Unstable_for_testing = struct
     | Arg_label.Labelled arg -> view arg
     | _ -> View.error
 
-  let nolabel value =
+  let nolabel'const value =
     let concrete =
       match Arg_label.to_concrete value with
       | None -> conversion_failed "arg_label"
@@ -3361,7 +3361,7 @@ module Unstable_for_testing = struct
     | Arg_label.Nolabel -> View.ok
     | _ -> View.error
 
-  let open_ value =
+  let open'const value =
     let concrete =
       match Closed_flag.to_concrete value with
       | None -> conversion_failed "closed_flag"
@@ -3371,7 +3371,7 @@ module Unstable_for_testing = struct
     | Closed_flag.Open -> View.ok
     | _ -> View.error
 
-  let closed value =
+  let closed'const value =
     let concrete =
       match Closed_flag.to_concrete value with
       | None -> conversion_failed "closed_flag"
@@ -3381,7 +3381,7 @@ module Unstable_for_testing = struct
     | Closed_flag.Closed -> View.ok
     | _ -> View.error
 
-  let fresh value =
+  let fresh'const value =
     let concrete =
       match Override_flag.to_concrete value with
       | None -> conversion_failed "override_flag"
@@ -3391,7 +3391,7 @@ module Unstable_for_testing = struct
     | Override_flag.Fresh -> View.ok
     | _ -> View.error
 
-  let override value =
+  let override'const value =
     let concrete =
       match Override_flag.to_concrete value with
       | None -> conversion_failed "override_flag"
@@ -3401,7 +3401,7 @@ module Unstable_for_testing = struct
     | Override_flag.Override -> View.ok
     | _ -> View.error
 
-  let concrete value =
+  let concrete'const value =
     let concrete =
       match Virtual_flag.to_concrete value with
       | None -> conversion_failed "virtual_flag"
@@ -3411,7 +3411,7 @@ module Unstable_for_testing = struct
     | Virtual_flag.Concrete -> View.ok
     | _ -> View.error
 
-  let virtual_ value =
+  let virtual'const value =
     let concrete =
       match Virtual_flag.to_concrete value with
       | None -> conversion_failed "virtual_flag"
@@ -3421,7 +3421,7 @@ module Unstable_for_testing = struct
     | Virtual_flag.Virtual -> View.ok
     | _ -> View.error
 
-  let mutable_ value =
+  let mutable'const value =
     let concrete =
       match Mutable_flag.to_concrete value with
       | None -> conversion_failed "mutable_flag"
@@ -3431,7 +3431,7 @@ module Unstable_for_testing = struct
     | Mutable_flag.Mutable -> View.ok
     | _ -> View.error
 
-  let immutable value =
+  let immutable'const value =
     let concrete =
       match Mutable_flag.to_concrete value with
       | None -> conversion_failed "mutable_flag"
@@ -3441,7 +3441,7 @@ module Unstable_for_testing = struct
     | Mutable_flag.Immutable -> View.ok
     | _ -> View.error
 
-  let public value =
+  let public'const value =
     let concrete =
       match Private_flag.to_concrete value with
       | None -> conversion_failed "private_flag"
@@ -3451,7 +3451,7 @@ module Unstable_for_testing = struct
     | Private_flag.Public -> View.ok
     | _ -> View.error
 
-  let private_ value =
+  let private'const value =
     let concrete =
       match Private_flag.to_concrete value with
       | None -> conversion_failed "private_flag"
@@ -3461,7 +3461,7 @@ module Unstable_for_testing = struct
     | Private_flag.Private -> View.ok
     | _ -> View.error
 
-  let downto_ value =
+  let downto'const value =
     let concrete =
       match Direction_flag.to_concrete value with
       | None -> conversion_failed "direction_flag"
@@ -3471,7 +3471,7 @@ module Unstable_for_testing = struct
     | Direction_flag.Downto -> View.ok
     | _ -> View.error
 
-  let upto value =
+  let upto'const value =
     let concrete =
       match Direction_flag.to_concrete value with
       | None -> conversion_failed "direction_flag"
@@ -3481,7 +3481,7 @@ module Unstable_for_testing = struct
     | Direction_flag.Upto -> View.ok
     | _ -> View.error
 
-  let recursive value =
+  let recursive'const value =
     let concrete =
       match Rec_flag.to_concrete value with
       | None -> conversion_failed "rec_flag"
@@ -3491,7 +3491,7 @@ module Unstable_for_testing = struct
     | Rec_flag.Recursive -> View.ok
     | _ -> View.error
 
-  let nonrecursive value =
+  let nonrecursive'const value =
     let concrete =
       match Rec_flag.to_concrete value with
       | None -> conversion_failed "rec_flag"
@@ -3501,7 +3501,7 @@ module Unstable_for_testing = struct
     | Rec_flag.Nonrecursive -> View.ok
     | _ -> View.error
 
-  let lapply view value =
+  let lapply'const view value =
     let concrete =
       match Longident.to_concrete value with
       | None -> conversion_failed "longident"
@@ -3511,7 +3511,7 @@ module Unstable_for_testing = struct
     | Longident.Lapply (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ldot view value =
+  let ldot'const view value =
     let concrete =
       match Longident.to_concrete value with
       | None -> conversion_failed "longident"
@@ -3521,7 +3521,7 @@ module Unstable_for_testing = struct
     | Longident.Ldot (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let lident view value =
+  let lident'const view value =
     let concrete =
       match Longident.to_concrete value with
       | None -> conversion_failed "longident"
@@ -3538,7 +3538,7 @@ module V4_07 = struct
 
   let conversion_failed name = Raise.conversion_failed ~version:"V4_07" name
 
-  let lident view value =
+  let lident'const view value =
     let concrete =
       match Longident.to_concrete value with
       | None -> conversion_failed "longident"
@@ -3548,7 +3548,7 @@ module V4_07 = struct
     | Longident.Lident arg -> view arg
     | _ -> View.error
 
-  let ldot view value =
+  let ldot'const view value =
     let concrete =
       match Longident.to_concrete value with
       | None -> conversion_failed "longident"
@@ -3558,7 +3558,7 @@ module V4_07 = struct
     | Longident.Ldot (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let lapply view value =
+  let lapply'const view value =
     let concrete =
       match Longident.to_concrete value with
       | None -> conversion_failed "longident"
@@ -3568,7 +3568,7 @@ module V4_07 = struct
     | Longident.Lapply (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let nonrecursive value =
+  let nonrecursive'const value =
     let concrete =
       match Rec_flag.to_concrete value with
       | None -> conversion_failed "rec_flag"
@@ -3578,7 +3578,7 @@ module V4_07 = struct
     | Rec_flag.Nonrecursive -> View.ok
     | _ -> View.error
 
-  let recursive value =
+  let recursive'const value =
     let concrete =
       match Rec_flag.to_concrete value with
       | None -> conversion_failed "rec_flag"
@@ -3588,7 +3588,7 @@ module V4_07 = struct
     | Rec_flag.Recursive -> View.ok
     | _ -> View.error
 
-  let upto value =
+  let upto'const value =
     let concrete =
       match Direction_flag.to_concrete value with
       | None -> conversion_failed "direction_flag"
@@ -3598,7 +3598,7 @@ module V4_07 = struct
     | Direction_flag.Upto -> View.ok
     | _ -> View.error
 
-  let downto_ value =
+  let downto'const value =
     let concrete =
       match Direction_flag.to_concrete value with
       | None -> conversion_failed "direction_flag"
@@ -3608,7 +3608,7 @@ module V4_07 = struct
     | Direction_flag.Downto -> View.ok
     | _ -> View.error
 
-  let private_ value =
+  let private'const value =
     let concrete =
       match Private_flag.to_concrete value with
       | None -> conversion_failed "private_flag"
@@ -3618,7 +3618,7 @@ module V4_07 = struct
     | Private_flag.Private -> View.ok
     | _ -> View.error
 
-  let public value =
+  let public'const value =
     let concrete =
       match Private_flag.to_concrete value with
       | None -> conversion_failed "private_flag"
@@ -3628,7 +3628,7 @@ module V4_07 = struct
     | Private_flag.Public -> View.ok
     | _ -> View.error
 
-  let immutable value =
+  let immutable'const value =
     let concrete =
       match Mutable_flag.to_concrete value with
       | None -> conversion_failed "mutable_flag"
@@ -3638,7 +3638,7 @@ module V4_07 = struct
     | Mutable_flag.Immutable -> View.ok
     | _ -> View.error
 
-  let mutable_ value =
+  let mutable'const value =
     let concrete =
       match Mutable_flag.to_concrete value with
       | None -> conversion_failed "mutable_flag"
@@ -3648,7 +3648,7 @@ module V4_07 = struct
     | Mutable_flag.Mutable -> View.ok
     | _ -> View.error
 
-  let virtual_ value =
+  let virtual'const value =
     let concrete =
       match Virtual_flag.to_concrete value with
       | None -> conversion_failed "virtual_flag"
@@ -3658,7 +3658,7 @@ module V4_07 = struct
     | Virtual_flag.Virtual -> View.ok
     | _ -> View.error
 
-  let concrete value =
+  let concrete'const value =
     let concrete =
       match Virtual_flag.to_concrete value with
       | None -> conversion_failed "virtual_flag"
@@ -3668,7 +3668,7 @@ module V4_07 = struct
     | Virtual_flag.Concrete -> View.ok
     | _ -> View.error
 
-  let override value =
+  let override'const value =
     let concrete =
       match Override_flag.to_concrete value with
       | None -> conversion_failed "override_flag"
@@ -3678,7 +3678,7 @@ module V4_07 = struct
     | Override_flag.Override -> View.ok
     | _ -> View.error
 
-  let fresh value =
+  let fresh'const value =
     let concrete =
       match Override_flag.to_concrete value with
       | None -> conversion_failed "override_flag"
@@ -3688,7 +3688,7 @@ module V4_07 = struct
     | Override_flag.Fresh -> View.ok
     | _ -> View.error
 
-  let closed value =
+  let closed'const value =
     let concrete =
       match Closed_flag.to_concrete value with
       | None -> conversion_failed "closed_flag"
@@ -3698,7 +3698,7 @@ module V4_07 = struct
     | Closed_flag.Closed -> View.ok
     | _ -> View.error
 
-  let open_ value =
+  let open'const value =
     let concrete =
       match Closed_flag.to_concrete value with
       | None -> conversion_failed "closed_flag"
@@ -3708,7 +3708,7 @@ module V4_07 = struct
     | Closed_flag.Open -> View.ok
     | _ -> View.error
 
-  let nolabel value =
+  let nolabel'const value =
     let concrete =
       match Arg_label.to_concrete value with
       | None -> conversion_failed "arg_label"
@@ -3718,7 +3718,7 @@ module V4_07 = struct
     | Arg_label.Nolabel -> View.ok
     | _ -> View.error
 
-  let labelled view value =
+  let labelled'const view value =
     let concrete =
       match Arg_label.to_concrete value with
       | None -> conversion_failed "arg_label"
@@ -3728,7 +3728,7 @@ module V4_07 = struct
     | Arg_label.Labelled arg -> view arg
     | _ -> View.error
 
-  let optional view value =
+  let optional'const view value =
     let concrete =
       match Arg_label.to_concrete value with
       | None -> conversion_failed "arg_label"
@@ -3738,7 +3738,7 @@ module V4_07 = struct
     | Arg_label.Optional arg -> view arg
     | _ -> View.error
 
-  let covariant value =
+  let covariant'const value =
     let concrete =
       match Variance.to_concrete value with
       | None -> conversion_failed "variance"
@@ -3748,7 +3748,7 @@ module V4_07 = struct
     | Variance.Covariant -> View.ok
     | _ -> View.error
 
-  let contravariant value =
+  let contravariant'const value =
     let concrete =
       match Variance.to_concrete value with
       | None -> conversion_failed "variance"
@@ -3758,7 +3758,7 @@ module V4_07 = struct
     | Variance.Contravariant -> View.ok
     | _ -> View.error
 
-  let invariant value =
+  let invariant'const value =
     let concrete =
       match Variance.to_concrete value with
       | None -> conversion_failed "variance"
@@ -3768,7 +3768,7 @@ module V4_07 = struct
     | Variance.Invariant -> View.ok
     | _ -> View.error
 
-  let pconst_integer view value =
+  let pconst_integer'const view value =
     let concrete =
       match Constant.to_concrete value with
       | None -> conversion_failed "constant"
@@ -3778,7 +3778,7 @@ module V4_07 = struct
     | Constant.Pconst_integer (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pconst_char view value =
+  let pconst_char'const view value =
     let concrete =
       match Constant.to_concrete value with
       | None -> conversion_failed "constant"
@@ -3788,7 +3788,7 @@ module V4_07 = struct
     | Constant.Pconst_char arg -> view arg
     | _ -> View.error
 
-  let pconst_string view value =
+  let pconst_string'const view value =
     let concrete =
       match Constant.to_concrete value with
       | None -> conversion_failed "constant"
@@ -3798,7 +3798,7 @@ module V4_07 = struct
     | Constant.Pconst_string (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pconst_float view value =
+  let pconst_float'const view value =
     let concrete =
       match Constant.to_concrete value with
       | None -> conversion_failed "constant"
@@ -3808,7 +3808,7 @@ module V4_07 = struct
     | Constant.Pconst_float (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pstr view value =
+  let pstr'const view value =
     let concrete =
       match Payload.to_concrete value with
       | None -> conversion_failed "payload"
@@ -3818,7 +3818,7 @@ module V4_07 = struct
     | Payload.PStr arg -> view arg
     | _ -> View.error
 
-  let psig view value =
+  let psig'const view value =
     let concrete =
       match Payload.to_concrete value with
       | None -> conversion_failed "payload"
@@ -3828,7 +3828,7 @@ module V4_07 = struct
     | Payload.PSig arg -> view arg
     | _ -> View.error
 
-  let ptyp view value =
+  let ptyp'const view value =
     let concrete =
       match Payload.to_concrete value with
       | None -> conversion_failed "payload"
@@ -3838,7 +3838,7 @@ module V4_07 = struct
     | Payload.PTyp arg -> view arg
     | _ -> View.error
 
-  let ppat view value =
+  let ppat'const view value =
     let concrete =
       match Payload.to_concrete value with
       | None -> conversion_failed "payload"
@@ -3872,7 +3872,7 @@ module V4_07 = struct
     in
     view concrete.Core_type.ptyp_attributes
 
-  let ptyp_any value =
+  let ptyp_any'const value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3888,7 +3888,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_any -> View.ok
     | _ -> View.error
 
-  let ptyp_var view value =
+  let ptyp_var'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3904,7 +3904,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_var arg -> view arg
     | _ -> View.error
 
-  let ptyp_arrow view value =
+  let ptyp_arrow'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3920,7 +3920,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_arrow (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let ptyp_tuple view value =
+  let ptyp_tuple'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3936,7 +3936,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_tuple arg -> view arg
     | _ -> View.error
 
-  let ptyp_constr view value =
+  let ptyp_constr'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3952,7 +3952,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_constr (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_object view value =
+  let ptyp_object'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3968,7 +3968,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_object (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_class view value =
+  let ptyp_class'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -3984,7 +3984,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_class (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_alias view value =
+  let ptyp_alias'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -4000,7 +4000,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_alias (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_variant view value =
+  let ptyp_variant'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -4016,7 +4016,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_variant (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let ptyp_poly view value =
+  let ptyp_poly'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -4032,7 +4032,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_poly (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ptyp_package view value =
+  let ptyp_package'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -4048,7 +4048,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_package arg -> view arg
     | _ -> View.error
 
-  let ptyp_extension view value =
+  let ptyp_extension'const view value =
     let parent_concrete =
       match Core_type.to_concrete value with
       | None -> conversion_failed "core_type"
@@ -4064,7 +4064,7 @@ module V4_07 = struct
     | Core_type_desc.Ptyp_extension arg -> view arg
     | _ -> View.error
 
-  let rtag view value =
+  let rtag'const view value =
     let concrete =
       match Row_field.to_concrete value with
       | None -> conversion_failed "row_field"
@@ -4074,7 +4074,7 @@ module V4_07 = struct
     | Row_field.Rtag (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
     | _ -> View.error
 
-  let rinherit view value =
+  let rinherit'const view value =
     let concrete =
       match Row_field.to_concrete value with
       | None -> conversion_failed "row_field"
@@ -4084,7 +4084,7 @@ module V4_07 = struct
     | Row_field.Rinherit arg -> view arg
     | _ -> View.error
 
-  let otag view value =
+  let otag'const view value =
     let concrete =
       match Object_field.to_concrete value with
       | None -> conversion_failed "object_field"
@@ -4094,7 +4094,7 @@ module V4_07 = struct
     | Object_field.Otag (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let oinherit view value =
+  let oinherit'const view value =
     let concrete =
       match Object_field.to_concrete value with
       | None -> conversion_failed "object_field"
@@ -4128,7 +4128,7 @@ module V4_07 = struct
     in
     view concrete.Pattern.ppat_attributes
 
-  let ppat_any value =
+  let ppat_any'const value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4144,7 +4144,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_any -> View.ok
     | _ -> View.error
 
-  let ppat_var view value =
+  let ppat_var'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4160,7 +4160,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_var arg -> view arg
     | _ -> View.error
 
-  let ppat_alias view value =
+  let ppat_alias'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4176,7 +4176,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_alias (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_constant view value =
+  let ppat_constant'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4192,7 +4192,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_constant arg -> view arg
     | _ -> View.error
 
-  let ppat_interval view value =
+  let ppat_interval'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4208,7 +4208,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_interval (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_tuple view value =
+  let ppat_tuple'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4224,7 +4224,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_tuple arg -> view arg
     | _ -> View.error
 
-  let ppat_construct view value =
+  let ppat_construct'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4240,7 +4240,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_construct (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_variant view value =
+  let ppat_variant'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4256,7 +4256,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_variant (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_record view value =
+  let ppat_record'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4272,7 +4272,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_record (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_array view value =
+  let ppat_array'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4288,7 +4288,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_array arg -> view arg
     | _ -> View.error
 
-  let ppat_or view value =
+  let ppat_or'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4304,7 +4304,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_or (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_constraint view value =
+  let ppat_constraint'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4320,7 +4320,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_constraint (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let ppat_type view value =
+  let ppat_type'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4336,7 +4336,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_type arg -> view arg
     | _ -> View.error
 
-  let ppat_lazy view value =
+  let ppat_lazy'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4352,7 +4352,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_lazy arg -> view arg
     | _ -> View.error
 
-  let ppat_unpack view value =
+  let ppat_unpack'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4368,7 +4368,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_unpack arg -> view arg
     | _ -> View.error
 
-  let ppat_exception view value =
+  let ppat_exception'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4384,7 +4384,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_exception arg -> view arg
     | _ -> View.error
 
-  let ppat_extension view value =
+  let ppat_extension'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4400,7 +4400,7 @@ module V4_07 = struct
     | Pattern_desc.Ppat_extension arg -> view arg
     | _ -> View.error
 
-  let ppat_open view value =
+  let ppat_open'const view value =
     let parent_concrete =
       match Pattern.to_concrete value with
       | None -> conversion_failed "pattern"
@@ -4440,7 +4440,7 @@ module V4_07 = struct
     in
     view concrete.Expression.pexp_attributes
 
-  let pexp_ident view value =
+  let pexp_ident'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4456,7 +4456,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_ident arg -> view arg
     | _ -> View.error
 
-  let pexp_constant view value =
+  let pexp_constant'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4472,7 +4472,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_constant arg -> view arg
     | _ -> View.error
 
-  let pexp_let view value =
+  let pexp_let'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4488,7 +4488,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_let (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_function view value =
+  let pexp_function'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4504,7 +4504,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_function arg -> view arg
     | _ -> View.error
 
-  let pexp_fun view value =
+  let pexp_fun'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4520,7 +4520,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_fun (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
     | _ -> View.error
 
-  let pexp_apply view value =
+  let pexp_apply'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4536,7 +4536,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_apply (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_match view value =
+  let pexp_match'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4552,7 +4552,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_match (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_try view value =
+  let pexp_try'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4568,7 +4568,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_try (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_tuple view value =
+  let pexp_tuple'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4584,7 +4584,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_tuple arg -> view arg
     | _ -> View.error
 
-  let pexp_construct view value =
+  let pexp_construct'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4600,7 +4600,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_construct (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_variant view value =
+  let pexp_variant'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4616,7 +4616,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_variant (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_record view value =
+  let pexp_record'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4632,7 +4632,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_record (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_field view value =
+  let pexp_field'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4648,7 +4648,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_field (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_setfield view value =
+  let pexp_setfield'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4664,7 +4664,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_setfield (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_array view value =
+  let pexp_array'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4680,7 +4680,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_array arg -> view arg
     | _ -> View.error
 
-  let pexp_ifthenelse view value =
+  let pexp_ifthenelse'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4696,7 +4696,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_ifthenelse (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_sequence view value =
+  let pexp_sequence'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4712,7 +4712,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_sequence (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_while view value =
+  let pexp_while'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4728,7 +4728,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_while (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_for view value =
+  let pexp_for'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4744,7 +4744,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_for (arg0, arg1, arg2, arg3, arg4) -> view (arg0, arg1, arg2, arg3, arg4)
     | _ -> View.error
 
-  let pexp_constraint view value =
+  let pexp_constraint'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4760,7 +4760,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_constraint (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_coerce view value =
+  let pexp_coerce'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4776,7 +4776,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_coerce (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_send view value =
+  let pexp_send'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4792,7 +4792,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_send (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_new view value =
+  let pexp_new'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4808,7 +4808,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_new arg -> view arg
     | _ -> View.error
 
-  let pexp_setinstvar view value =
+  let pexp_setinstvar'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4824,7 +4824,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_setinstvar (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_override view value =
+  let pexp_override'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4840,7 +4840,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_override arg -> view arg
     | _ -> View.error
 
-  let pexp_letmodule view value =
+  let pexp_letmodule'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4856,7 +4856,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_letmodule (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_letexception view value =
+  let pexp_letexception'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4872,7 +4872,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_letexception (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_assert view value =
+  let pexp_assert'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4888,7 +4888,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_assert arg -> view arg
     | _ -> View.error
 
-  let pexp_lazy view value =
+  let pexp_lazy'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4904,7 +4904,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_lazy arg -> view arg
     | _ -> View.error
 
-  let pexp_poly view value =
+  let pexp_poly'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4920,7 +4920,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_poly (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_object view value =
+  let pexp_object'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4936,7 +4936,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_object arg -> view arg
     | _ -> View.error
 
-  let pexp_newtype view value =
+  let pexp_newtype'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4952,7 +4952,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_newtype (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pexp_pack view value =
+  let pexp_pack'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4968,7 +4968,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_pack arg -> view arg
     | _ -> View.error
 
-  let pexp_open view value =
+  let pexp_open'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -4984,7 +4984,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pexp_extension view value =
+  let pexp_extension'const view value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -5000,7 +5000,7 @@ module V4_07 = struct
     | Expression_desc.Pexp_extension arg -> view arg
     | _ -> View.error
 
-  let pexp_unreachable value =
+  let pexp_unreachable'const value =
     let parent_concrete =
       match Expression.to_concrete value with
       | None -> conversion_failed "expression"
@@ -5144,7 +5144,7 @@ module V4_07 = struct
     in
     view concrete.Type_declaration.ptype_loc
 
-  let ptype_abstract value =
+  let ptype_abstract'const value =
     let concrete =
       match Type_kind.to_concrete value with
       | None -> conversion_failed "type_kind"
@@ -5154,7 +5154,7 @@ module V4_07 = struct
     | Type_kind.Ptype_abstract -> View.ok
     | _ -> View.error
 
-  let ptype_variant view value =
+  let ptype_variant'const view value =
     let concrete =
       match Type_kind.to_concrete value with
       | None -> conversion_failed "type_kind"
@@ -5164,7 +5164,7 @@ module V4_07 = struct
     | Type_kind.Ptype_variant arg -> view arg
     | _ -> View.error
 
-  let ptype_record view value =
+  let ptype_record'const view value =
     let concrete =
       match Type_kind.to_concrete value with
       | None -> conversion_failed "type_kind"
@@ -5174,7 +5174,7 @@ module V4_07 = struct
     | Type_kind.Ptype_record arg -> view arg
     | _ -> View.error
 
-  let ptype_open value =
+  let ptype_open'const value =
     let concrete =
       match Type_kind.to_concrete value with
       | None -> conversion_failed "type_kind"
@@ -5264,7 +5264,7 @@ module V4_07 = struct
     in
     view concrete.Constructor_declaration.pcd_attributes
 
-  let pcstr_tuple view value =
+  let pcstr_tuple'const view value =
     let concrete =
       match Constructor_arguments.to_concrete value with
       | None -> conversion_failed "constructor_arguments"
@@ -5274,7 +5274,7 @@ module V4_07 = struct
     | Constructor_arguments.Pcstr_tuple arg -> view arg
     | _ -> View.error
 
-  let pcstr_record view value =
+  let pcstr_record'const view value =
     let concrete =
       match Constructor_arguments.to_concrete value with
       | None -> conversion_failed "constructor_arguments"
@@ -5356,7 +5356,7 @@ module V4_07 = struct
     in
     view concrete.Extension_constructor.pext_attributes
 
-  let pext_decl view value =
+  let pext_decl'const view value =
     let concrete =
       match Extension_constructor_kind.to_concrete value with
       | None -> conversion_failed "extension_constructor_kind"
@@ -5366,7 +5366,7 @@ module V4_07 = struct
     | Extension_constructor_kind.Pext_decl (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pext_rebind view value =
+  let pext_rebind'const view value =
     let concrete =
       match Extension_constructor_kind.to_concrete value with
       | None -> conversion_failed "extension_constructor_kind"
@@ -5400,7 +5400,7 @@ module V4_07 = struct
     in
     view concrete.Class_type.pcty_attributes
 
-  let pcty_constr view value =
+  let pcty_constr'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -5416,7 +5416,7 @@ module V4_07 = struct
     | Class_type_desc.Pcty_constr (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pcty_signature view value =
+  let pcty_signature'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -5432,7 +5432,7 @@ module V4_07 = struct
     | Class_type_desc.Pcty_signature arg -> view arg
     | _ -> View.error
 
-  let pcty_arrow view value =
+  let pcty_arrow'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -5448,7 +5448,7 @@ module V4_07 = struct
     | Class_type_desc.Pcty_arrow (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pcty_extension view value =
+  let pcty_extension'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -5464,7 +5464,7 @@ module V4_07 = struct
     | Class_type_desc.Pcty_extension arg -> view arg
     | _ -> View.error
 
-  let pcty_open view value =
+  let pcty_open'const view value =
     let parent_concrete =
       match Class_type.to_concrete value with
       | None -> conversion_failed "class_type"
@@ -5520,7 +5520,7 @@ module V4_07 = struct
     in
     view concrete.Class_type_field.pctf_attributes
 
-  let pctf_inherit view value =
+  let pctf_inherit'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -5536,7 +5536,7 @@ module V4_07 = struct
     | Class_type_field_desc.Pctf_inherit arg -> view arg
     | _ -> View.error
 
-  let pctf_val view value =
+  let pctf_val'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -5552,7 +5552,7 @@ module V4_07 = struct
     | Class_type_field_desc.Pctf_val arg -> view arg
     | _ -> View.error
 
-  let pctf_method view value =
+  let pctf_method'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -5568,7 +5568,7 @@ module V4_07 = struct
     | Class_type_field_desc.Pctf_method arg -> view arg
     | _ -> View.error
 
-  let pctf_constraint view value =
+  let pctf_constraint'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -5584,7 +5584,7 @@ module V4_07 = struct
     | Class_type_field_desc.Pctf_constraint arg -> view arg
     | _ -> View.error
 
-  let pctf_attribute view value =
+  let pctf_attribute'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -5600,7 +5600,7 @@ module V4_07 = struct
     | Class_type_field_desc.Pctf_attribute arg -> view arg
     | _ -> View.error
 
-  let pctf_extension view value =
+  let pctf_extension'const view value =
     let parent_concrete =
       match Class_type_field.to_concrete value with
       | None -> conversion_failed "class_type_field"
@@ -5688,7 +5688,7 @@ module V4_07 = struct
     in
     view concrete.Class_expr.pcl_attributes
 
-  let pcl_constr view value =
+  let pcl_constr'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -5704,7 +5704,7 @@ module V4_07 = struct
     | Class_expr_desc.Pcl_constr (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pcl_structure view value =
+  let pcl_structure'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -5720,7 +5720,7 @@ module V4_07 = struct
     | Class_expr_desc.Pcl_structure arg -> view arg
     | _ -> View.error
 
-  let pcl_fun view value =
+  let pcl_fun'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -5736,7 +5736,7 @@ module V4_07 = struct
     | Class_expr_desc.Pcl_fun (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
     | _ -> View.error
 
-  let pcl_apply view value =
+  let pcl_apply'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -5752,7 +5752,7 @@ module V4_07 = struct
     | Class_expr_desc.Pcl_apply (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pcl_let view value =
+  let pcl_let'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -5768,7 +5768,7 @@ module V4_07 = struct
     | Class_expr_desc.Pcl_let (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pcl_constraint view value =
+  let pcl_constraint'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -5784,7 +5784,7 @@ module V4_07 = struct
     | Class_expr_desc.Pcl_constraint (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pcl_extension view value =
+  let pcl_extension'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -5800,7 +5800,7 @@ module V4_07 = struct
     | Class_expr_desc.Pcl_extension arg -> view arg
     | _ -> View.error
 
-  let pcl_open view value =
+  let pcl_open'const view value =
     let parent_concrete =
       match Class_expr.to_concrete value with
       | None -> conversion_failed "class_expr"
@@ -5856,7 +5856,7 @@ module V4_07 = struct
     in
     view concrete.Class_field.pcf_attributes
 
-  let pcf_inherit view value =
+  let pcf_inherit'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -5872,7 +5872,7 @@ module V4_07 = struct
     | Class_field_desc.Pcf_inherit (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pcf_val view value =
+  let pcf_val'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -5888,7 +5888,7 @@ module V4_07 = struct
     | Class_field_desc.Pcf_val arg -> view arg
     | _ -> View.error
 
-  let pcf_method view value =
+  let pcf_method'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -5904,7 +5904,7 @@ module V4_07 = struct
     | Class_field_desc.Pcf_method arg -> view arg
     | _ -> View.error
 
-  let pcf_constraint view value =
+  let pcf_constraint'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -5920,7 +5920,7 @@ module V4_07 = struct
     | Class_field_desc.Pcf_constraint arg -> view arg
     | _ -> View.error
 
-  let pcf_initializer view value =
+  let pcf_initializer'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -5936,7 +5936,7 @@ module V4_07 = struct
     | Class_field_desc.Pcf_initializer arg -> view arg
     | _ -> View.error
 
-  let pcf_attribute view value =
+  let pcf_attribute'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -5952,7 +5952,7 @@ module V4_07 = struct
     | Class_field_desc.Pcf_attribute arg -> view arg
     | _ -> View.error
 
-  let pcf_extension view value =
+  let pcf_extension'const view value =
     let parent_concrete =
       match Class_field.to_concrete value with
       | None -> conversion_failed "class_field"
@@ -5968,7 +5968,7 @@ module V4_07 = struct
     | Class_field_desc.Pcf_extension arg -> view arg
     | _ -> View.error
 
-  let cfk_virtual view value =
+  let cfk_virtual'const view value =
     let concrete =
       match Class_field_kind.to_concrete value with
       | None -> conversion_failed "class_field_kind"
@@ -5978,7 +5978,7 @@ module V4_07 = struct
     | Class_field_kind.Cfk_virtual arg -> view arg
     | _ -> View.error
 
-  let cfk_concrete view value =
+  let cfk_concrete'const view value =
     let concrete =
       match Class_field_kind.to_concrete value with
       | None -> conversion_failed "class_field_kind"
@@ -6012,7 +6012,7 @@ module V4_07 = struct
     in
     view concrete.Module_type.pmty_attributes
 
-  let pmty_ident view value =
+  let pmty_ident'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -6028,7 +6028,7 @@ module V4_07 = struct
     | Module_type_desc.Pmty_ident arg -> view arg
     | _ -> View.error
 
-  let pmty_signature view value =
+  let pmty_signature'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -6044,7 +6044,7 @@ module V4_07 = struct
     | Module_type_desc.Pmty_signature arg -> view arg
     | _ -> View.error
 
-  let pmty_functor view value =
+  let pmty_functor'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -6060,7 +6060,7 @@ module V4_07 = struct
     | Module_type_desc.Pmty_functor (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pmty_with view value =
+  let pmty_with'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -6076,7 +6076,7 @@ module V4_07 = struct
     | Module_type_desc.Pmty_with (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pmty_typeof view value =
+  let pmty_typeof'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -6092,7 +6092,7 @@ module V4_07 = struct
     | Module_type_desc.Pmty_typeof arg -> view arg
     | _ -> View.error
 
-  let pmty_extension view value =
+  let pmty_extension'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -6108,7 +6108,7 @@ module V4_07 = struct
     | Module_type_desc.Pmty_extension arg -> view arg
     | _ -> View.error
 
-  let pmty_alias view value =
+  let pmty_alias'const view value =
     let parent_concrete =
       match Module_type.to_concrete value with
       | None -> conversion_failed "module_type"
@@ -6140,7 +6140,7 @@ module V4_07 = struct
     in
     view concrete.Signature_item.psig_loc
 
-  let psig_value view value =
+  let psig_value'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6156,7 +6156,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_value arg -> view arg
     | _ -> View.error
 
-  let psig_type view value =
+  let psig_type'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6172,7 +6172,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_type (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let psig_typext view value =
+  let psig_typext'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6188,7 +6188,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_typext arg -> view arg
     | _ -> View.error
 
-  let psig_exception view value =
+  let psig_exception'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6204,7 +6204,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_exception arg -> view arg
     | _ -> View.error
 
-  let psig_module view value =
+  let psig_module'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6220,7 +6220,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_module arg -> view arg
     | _ -> View.error
 
-  let psig_recmodule view value =
+  let psig_recmodule'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6236,7 +6236,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_recmodule arg -> view arg
     | _ -> View.error
 
-  let psig_modtype view value =
+  let psig_modtype'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6252,7 +6252,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_modtype arg -> view arg
     | _ -> View.error
 
-  let psig_open view value =
+  let psig_open'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6268,7 +6268,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_open arg -> view arg
     | _ -> View.error
 
-  let psig_include view value =
+  let psig_include'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6284,7 +6284,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_include arg -> view arg
     | _ -> View.error
 
-  let psig_class view value =
+  let psig_class'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6300,7 +6300,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_class arg -> view arg
     | _ -> View.error
 
-  let psig_class_type view value =
+  let psig_class_type'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6316,7 +6316,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_class_type arg -> view arg
     | _ -> View.error
 
-  let psig_attribute view value =
+  let psig_attribute'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6332,7 +6332,7 @@ module V4_07 = struct
     | Signature_item_desc.Psig_attribute arg -> view arg
     | _ -> View.error
 
-  let psig_extension view value =
+  let psig_extension'const view value =
     let parent_concrete =
       match Signature_item.to_concrete value with
       | None -> conversion_failed "signature_item"
@@ -6468,7 +6468,7 @@ module V4_07 = struct
     in
     view concrete.Include_infos.pincl_attributes
 
-  let pwith_type view value =
+  let pwith_type'const view value =
     let concrete =
       match With_constraint.to_concrete value with
       | None -> conversion_failed "with_constraint"
@@ -6478,7 +6478,7 @@ module V4_07 = struct
     | With_constraint.Pwith_type (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pwith_module view value =
+  let pwith_module'const view value =
     let concrete =
       match With_constraint.to_concrete value with
       | None -> conversion_failed "with_constraint"
@@ -6488,7 +6488,7 @@ module V4_07 = struct
     | With_constraint.Pwith_module (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pwith_typesubst view value =
+  let pwith_typesubst'const view value =
     let concrete =
       match With_constraint.to_concrete value with
       | None -> conversion_failed "with_constraint"
@@ -6498,7 +6498,7 @@ module V4_07 = struct
     | With_constraint.Pwith_typesubst (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pwith_modsubst view value =
+  let pwith_modsubst'const view value =
     let concrete =
       match With_constraint.to_concrete value with
       | None -> conversion_failed "with_constraint"
@@ -6532,7 +6532,7 @@ module V4_07 = struct
     in
     view concrete.Module_expr.pmod_attributes
 
-  let pmod_ident view value =
+  let pmod_ident'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -6548,7 +6548,7 @@ module V4_07 = struct
     | Module_expr_desc.Pmod_ident arg -> view arg
     | _ -> View.error
 
-  let pmod_structure view value =
+  let pmod_structure'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -6564,7 +6564,7 @@ module V4_07 = struct
     | Module_expr_desc.Pmod_structure arg -> view arg
     | _ -> View.error
 
-  let pmod_functor view value =
+  let pmod_functor'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -6580,7 +6580,7 @@ module V4_07 = struct
     | Module_expr_desc.Pmod_functor (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
     | _ -> View.error
 
-  let pmod_apply view value =
+  let pmod_apply'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -6596,7 +6596,7 @@ module V4_07 = struct
     | Module_expr_desc.Pmod_apply (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pmod_constraint view value =
+  let pmod_constraint'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -6612,7 +6612,7 @@ module V4_07 = struct
     | Module_expr_desc.Pmod_constraint (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pmod_unpack view value =
+  let pmod_unpack'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -6628,7 +6628,7 @@ module V4_07 = struct
     | Module_expr_desc.Pmod_unpack arg -> view arg
     | _ -> View.error
 
-  let pmod_extension view value =
+  let pmod_extension'const view value =
     let parent_concrete =
       match Module_expr.to_concrete value with
       | None -> conversion_failed "module_expr"
@@ -6660,7 +6660,7 @@ module V4_07 = struct
     in
     view concrete.Structure_item.pstr_loc
 
-  let pstr_eval view value =
+  let pstr_eval'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6676,7 +6676,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_eval (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pstr_value view value =
+  let pstr_value'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6692,7 +6692,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_value (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pstr_primitive view value =
+  let pstr_primitive'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6708,7 +6708,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_primitive arg -> view arg
     | _ -> View.error
 
-  let pstr_type view value =
+  let pstr_type'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6724,7 +6724,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_type (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pstr_typext view value =
+  let pstr_typext'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6740,7 +6740,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_typext arg -> view arg
     | _ -> View.error
 
-  let pstr_exception view value =
+  let pstr_exception'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6756,7 +6756,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_exception arg -> view arg
     | _ -> View.error
 
-  let pstr_module view value =
+  let pstr_module'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6772,7 +6772,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_module arg -> view arg
     | _ -> View.error
 
-  let pstr_recmodule view value =
+  let pstr_recmodule'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6788,7 +6788,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_recmodule arg -> view arg
     | _ -> View.error
 
-  let pstr_modtype view value =
+  let pstr_modtype'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6804,7 +6804,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_modtype arg -> view arg
     | _ -> View.error
 
-  let pstr_open view value =
+  let pstr_open'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6820,7 +6820,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_open arg -> view arg
     | _ -> View.error
 
-  let pstr_class view value =
+  let pstr_class'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6836,7 +6836,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_class arg -> view arg
     | _ -> View.error
 
-  let pstr_class_type view value =
+  let pstr_class_type'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6852,7 +6852,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_class_type arg -> view arg
     | _ -> View.error
 
-  let pstr_include view value =
+  let pstr_include'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6868,7 +6868,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_include arg -> view arg
     | _ -> View.error
 
-  let pstr_attribute view value =
+  let pstr_attribute'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6884,7 +6884,7 @@ module V4_07 = struct
     | Structure_item_desc.Pstr_attribute arg -> view arg
     | _ -> View.error
 
-  let pstr_extension view value =
+  let pstr_extension'const view value =
     let parent_concrete =
       match Structure_item.to_concrete value with
       | None -> conversion_failed "structure_item"
@@ -6964,7 +6964,7 @@ module V4_07 = struct
     in
     view concrete.Module_binding.pmb_loc
 
-  let ptop_def view value =
+  let ptop_def'const view value =
     let concrete =
       match Toplevel_phrase.to_concrete value with
       | None -> conversion_failed "toplevel_phrase"
@@ -6974,7 +6974,7 @@ module V4_07 = struct
     | Toplevel_phrase.Ptop_def arg -> view arg
     | _ -> View.error
 
-  let ptop_dir view value =
+  let ptop_dir'const view value =
     let concrete =
       match Toplevel_phrase.to_concrete value with
       | None -> conversion_failed "toplevel_phrase"
@@ -6984,7 +6984,7 @@ module V4_07 = struct
     | Toplevel_phrase.Ptop_dir (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pdir_none value =
+  let pdir_none'const value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"
@@ -6994,7 +6994,7 @@ module V4_07 = struct
     | Directive_argument.Pdir_none -> View.ok
     | _ -> View.error
 
-  let pdir_string view value =
+  let pdir_string'const view value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"
@@ -7004,7 +7004,7 @@ module V4_07 = struct
     | Directive_argument.Pdir_string arg -> view arg
     | _ -> View.error
 
-  let pdir_int view value =
+  let pdir_int'const view value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"
@@ -7014,7 +7014,7 @@ module V4_07 = struct
     | Directive_argument.Pdir_int (arg0, arg1) -> view (arg0, arg1)
     | _ -> View.error
 
-  let pdir_ident view value =
+  let pdir_ident'const view value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"
@@ -7024,7 +7024,7 @@ module V4_07 = struct
     | Directive_argument.Pdir_ident arg -> view arg
     | _ -> View.error
 
-  let pdir_bool view value =
+  let pdir_bool'const view value =
     let concrete =
       match Directive_argument.to_concrete value with
       | None -> conversion_failed "directive_argument"

--- a/ast/viewer.mli
+++ b/ast/viewer.mli
@@ -19,14 +19,14 @@ module Unstable_for_testing : sig
   open Versions
   open Unstable_for_testing
   include LOC_TYPES
-  val pdir_bool : (bool, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
-  val pdir_ident : (Longident.t, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
-  val pdir_int : ((char option * string), 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
-  val pdir_string : (string, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+  val pdir_bool'const : (bool, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+  val pdir_ident'const : (Longident.t, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+  val pdir_int'const : ((char option * string), 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+  val pdir_string'const : (string, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
 
-  val pdir_none : (Directive_argument.t, 'a, 'a) View.t
-  val ptop_dir : ((Directive_argument.t * string), 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
-  val ptop_def : (Structure.t, 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+  val pdir_none'const : (Directive_argument.t, 'a, 'a) View.t
+  val ptop_dir'const : ((Directive_argument.t * string), 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+  val ptop_def'const : (Structure.t, 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
 
   val pmb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
 
@@ -43,42 +43,42 @@ module Unstable_for_testing : sig
   val pvb_expr'match : (Expression.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
 
   val pvb_pat'match : (Pattern.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
-  val pstr_extension : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_attribute : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_include : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_class_type : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_class : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_open : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_modtype : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_recmodule : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_module : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_exception : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_typext : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_type : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_primitive : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_value : ((Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_eval : ((Attributes.t * Expression.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_extension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_include'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_class'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_open'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_recmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_module'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_type'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_primitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_value'const : ((Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_eval'const : ((Attributes.t * Expression.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 
   val pstr_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 
   val pstr_desc'match : (Structure_item_desc.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pmod_extension : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_unpack : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_constraint : ((Module_type.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_apply : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_functor : ((Module_expr.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_structure : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_ident : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_constraint'const : ((Module_type.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_apply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_functor'const : ((Module_expr.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_structure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
   val pmod_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
   val pmod_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
   val pmod_desc'match : (Module_expr_desc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pwith_modsubst : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
-  val pwith_typesubst : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
-  val pwith_module : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
-  val pwith_type : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+  val pwith_modsubst'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+  val pwith_typesubst'const : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+  val pwith_module'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+  val pwith_type'const : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
 
   val pincl_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
 
@@ -109,45 +109,45 @@ module Unstable_for_testing : sig
   val pmd_type'match : (Module_type.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
 
   val pmd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
-  val psig_extension : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_attribute : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_class_type : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_class : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_include : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_open : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_modtype : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_recmodule : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_module : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_exception : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_typext : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_type : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_value : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_extension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_class'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_include'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_open'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_recmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_module'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_type'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_value'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
   val psig_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
   val psig_desc'match : (Signature_item_desc.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val pmty_alias : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_extension : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_typeof : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_with : ((With_constraint.t list * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_functor : ((Module_type.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_signature : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_ident : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_with'const : ((With_constraint.t list * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_functor'const : ((Module_type.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_signature'const : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
   val pmty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
   val pmty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
   val pmty_desc'match : (Module_type_desc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val cfk_concrete : ((Expression.t * Override_flag.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
-  val cfk_virtual : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
-  val pcf_extension : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_attribute : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_initializer : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_constraint : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_method : ((Class_field_kind.t * Private_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_val : ((Class_field_kind.t * Mutable_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_inherit : ((string Astlib.Loc.t option * Class_expr.t * Override_flag.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val cfk_concrete'const : ((Expression.t * Override_flag.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+  val cfk_virtual'const : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+  val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_method'const : ((Class_field_kind.t * Private_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_val'const : ((Class_field_kind.t * Mutable_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_inherit'const : ((string Astlib.Loc.t option * Class_expr.t * Override_flag.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 
   val pcf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 
@@ -158,14 +158,14 @@ module Unstable_for_testing : sig
   val pcstr_fields'match : (Class_field.t list, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
 
   val pcstr_self'match : (Pattern.t, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
-  val pcl_open : ((Class_expr.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_extension : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_constraint : ((Class_type.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_let : ((Class_expr.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_apply : (((Expression.t * Arg_label.t) list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_fun : ((Class_expr.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_structure : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_constr : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_open'const : ((Class_expr.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_constraint'const : ((Class_type.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_let'const : ((Class_expr.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_apply'const : (((Expression.t * Arg_label.t) list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_fun'const : ((Class_expr.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_structure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
   val pcl_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
@@ -184,12 +184,12 @@ module Unstable_for_testing : sig
   val pci_params'match : ((Variance.t * Core_type.t) list, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
 
   val pci_virt'match : (Virtual_flag.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
-  val pctf_extension : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_attribute : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_constraint : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_method : ((Core_type.t * Virtual_flag.t * Private_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_val : ((Core_type.t * Virtual_flag.t * Mutable_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_inherit : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_method'const : ((Core_type.t * Virtual_flag.t * Private_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_val'const : ((Core_type.t * Virtual_flag.t * Mutable_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 
   val pctf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 
@@ -200,19 +200,19 @@ module Unstable_for_testing : sig
   val pcsig_fields'match : (Class_type_field.t list, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
 
   val pcsig_self'match : (Core_type.t, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
-  val pcty_open : ((Class_type.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pcty_extension : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pcty_arrow : ((Class_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pcty_signature : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pcty_constr : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_open'const : ((Class_type.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_arrow'const : ((Class_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_signature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
   val pcty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
   val pcty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
   val pcty_desc'match : (Class_type_desc.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pext_rebind : (Longident_loc.t, 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
-  val pext_decl : ((Core_type.t option * Constructor_arguments.t), 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+  val pext_rebind'const : (Longident_loc.t, 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+  val pext_decl'const : ((Core_type.t option * Constructor_arguments.t), 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
 
   val pext_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
 
@@ -231,8 +231,8 @@ module Unstable_for_testing : sig
   val ptyext_params'match : ((Variance.t * Core_type.t) list, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
 
   val ptyext_path'match : (Longident_loc.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
-  val pcstr_record : (Label_declaration.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
-  val pcstr_tuple : (Core_type.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+  val pcstr_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+  val pcstr_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
 
   val pcd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
 
@@ -254,11 +254,11 @@ module Unstable_for_testing : sig
 
   val pld_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
 
-  val ptype_open : (Type_kind.t, 'a, 'a) View.t
-  val ptype_record : (Label_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
-  val ptype_variant : (Constructor_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+  val ptype_open'const : (Type_kind.t, 'a, 'a) View.t
+  val ptype_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+  val ptype_variant'const : (Constructor_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
 
-  val ptype_abstract : (Type_kind.t, 'a, 'a) View.t
+  val ptype_abstract'const : (Type_kind.t, 'a, 'a) View.t
 
   val ptype_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
 
@@ -292,200 +292,200 @@ module Unstable_for_testing : sig
 
   val pc_lhs'match : (Pattern.t, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
 
-  val pexp_unreachable : (Expression.t, 'a, 'a) View.t
-  val pexp_extension : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_open : ((Expression.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_pack : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_newtype : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_object : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_poly : ((Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_lazy : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_assert : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_letexception : ((Expression.t * Extension_constructor.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_letmodule : ((Expression.t * Module_expr.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_override : ((Expression.t * Label.t Astlib.Loc.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_setinstvar : ((Expression.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_new : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_send : ((Label.t Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_coerce : ((Core_type.t * Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_constraint : ((Core_type.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_for : ((Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_while : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_sequence : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_ifthenelse : ((Expression.t option * Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_array : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_setfield : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_field : ((Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_record : ((Expression.t option * (Expression.t * Longident_loc.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_variant : ((Expression.t option * Label.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_construct : ((Expression.t option * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_tuple : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_try : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_match : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_apply : (((Expression.t * Arg_label.t) list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_fun : ((Expression.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_function : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_let : ((Expression.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_constant : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_ident : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_unreachable'const : (Expression.t, 'a, 'a) View.t
+  val pexp_extension'const : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_open'const : ((Expression.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_pack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_newtype'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_object'const : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_poly'const : ((Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_lazy'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_letexception'const : ((Expression.t * Extension_constructor.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_letmodule'const : ((Expression.t * Module_expr.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_override'const : ((Expression.t * Label.t Astlib.Loc.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_setinstvar'const : ((Expression.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_send'const : ((Label.t Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_coerce'const : ((Core_type.t * Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_constraint'const : ((Core_type.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_for'const : ((Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_while'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_sequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_ifthenelse'const : ((Expression.t option * Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_array'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_field'const : ((Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_record'const : ((Expression.t option * (Expression.t * Longident_loc.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_variant'const : ((Expression.t option * Label.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_construct'const : ((Expression.t option * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_try'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_match'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_apply'const : (((Expression.t * Arg_label.t) list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_fun'const : ((Expression.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_function'const : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_let'const : ((Expression.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_constant'const : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
   val pexp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
   val pexp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
   val pexp_desc'match : (Expression_desc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val ppat_open : ((Pattern.t * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_extension : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_exception : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_unpack : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_lazy : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_type : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_constraint : ((Core_type.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_or : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_array : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_record : ((Closed_flag.t * (Pattern.t * Longident_loc.t) list), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_variant : ((Pattern.t option * Label.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_construct : ((Pattern.t option * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_tuple : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_interval : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_constant : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_alias : ((string Astlib.Loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_var : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_open'const : ((Pattern.t * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_extension'const : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_exception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_lazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_type'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_constraint'const : ((Core_type.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_record'const : ((Closed_flag.t * (Pattern.t * Longident_loc.t) list), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_variant'const : ((Pattern.t option * Label.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_construct'const : ((Pattern.t option * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_constant'const : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_alias'const : ((string Astlib.Loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
-  val ppat_any : (Pattern.t, 'a, 'a) View.t
+  val ppat_any'const : (Pattern.t, 'a, 'a) View.t
 
   val ppat_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
   val ppat_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
   val ppat_desc'match : (Pattern_desc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val oinherit : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
-  val otag : ((Core_type.t * Attributes.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
-  val rinherit : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
-  val rtag : ((Core_type.t list * bool * Attributes.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
-  val ptyp_extension : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_package : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_poly : ((Core_type.t * string Astlib.Loc.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_variant : ((Label.t list option * Closed_flag.t * Row_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_alias : ((string * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_class : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_object : ((Closed_flag.t * Object_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_constr : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_tuple : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_arrow : ((Core_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_var : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val oinherit'const : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+  val otag'const : ((Core_type.t * Attributes.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+  val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+  val rtag'const : ((Core_type.t list * bool * Attributes.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+  val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_poly'const : ((Core_type.t * string Astlib.Loc.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_variant'const : ((Label.t list option * Closed_flag.t * Row_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_alias'const : ((string * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_class'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_object'const : ((Closed_flag.t * Object_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_arrow'const : ((Core_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_var'const : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 
-  val ptyp_any : (Core_type.t, 'a, 'a) View.t
+  val ptyp_any'const : (Core_type.t, 'a, 'a) View.t
 
   val ptyp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 
   val ptyp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 
   val ptyp_desc'match : (Core_type_desc.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ppat : ((Expression.t option * Pattern.t), 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
-  val ptyp : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
-  val psig : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
-  val pstr : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
-  val pconst_float : ((char option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
-  val pconst_string : ((string option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
-  val pconst_char : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
-  val pconst_integer : ((char option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+  val ppat'const : ((Expression.t option * Pattern.t), 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+  val ptyp'const : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+  val psig'const : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+  val pstr'const : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+  val pconst_float'const : ((char option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+  val pconst_string'const : ((string option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+  val pconst_char'const : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+  val pconst_integer'const : ((char option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
 
-  val invariant : (Variance.t, 'a, 'a) View.t
+  val invariant'const : (Variance.t, 'a, 'a) View.t
 
-  val contravariant : (Variance.t, 'a, 'a) View.t
+  val contravariant'const : (Variance.t, 'a, 'a) View.t
 
-  val covariant : (Variance.t, 'a, 'a) View.t
-  val optional : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
-  val labelled : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+  val covariant'const : (Variance.t, 'a, 'a) View.t
+  val optional'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+  val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
 
-  val nolabel : (Arg_label.t, 'a, 'a) View.t
+  val nolabel'const : (Arg_label.t, 'a, 'a) View.t
 
-  val open_ : (Closed_flag.t, 'a, 'a) View.t
+  val open'const : (Closed_flag.t, 'a, 'a) View.t
 
-  val closed : (Closed_flag.t, 'a, 'a) View.t
+  val closed'const : (Closed_flag.t, 'a, 'a) View.t
 
-  val fresh : (Override_flag.t, 'a, 'a) View.t
+  val fresh'const : (Override_flag.t, 'a, 'a) View.t
 
-  val override : (Override_flag.t, 'a, 'a) View.t
+  val override'const : (Override_flag.t, 'a, 'a) View.t
 
-  val concrete : (Virtual_flag.t, 'a, 'a) View.t
+  val concrete'const : (Virtual_flag.t, 'a, 'a) View.t
 
-  val virtual_ : (Virtual_flag.t, 'a, 'a) View.t
+  val virtual'const : (Virtual_flag.t, 'a, 'a) View.t
 
-  val mutable_ : (Mutable_flag.t, 'a, 'a) View.t
+  val mutable'const : (Mutable_flag.t, 'a, 'a) View.t
 
-  val immutable : (Mutable_flag.t, 'a, 'a) View.t
+  val immutable'const : (Mutable_flag.t, 'a, 'a) View.t
 
-  val public : (Private_flag.t, 'a, 'a) View.t
+  val public'const : (Private_flag.t, 'a, 'a) View.t
 
-  val private_ : (Private_flag.t, 'a, 'a) View.t
+  val private'const : (Private_flag.t, 'a, 'a) View.t
 
-  val downto_ : (Direction_flag.t, 'a, 'a) View.t
+  val downto'const : (Direction_flag.t, 'a, 'a) View.t
 
-  val upto : (Direction_flag.t, 'a, 'a) View.t
+  val upto'const : (Direction_flag.t, 'a, 'a) View.t
 
-  val recursive : (Rec_flag.t, 'a, 'a) View.t
+  val recursive'const : (Rec_flag.t, 'a, 'a) View.t
 
-  val nonrecursive : (Rec_flag.t, 'a, 'a) View.t
-  val lapply : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
-  val ldot : ((string * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
-  val lident : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+  val nonrecursive'const : (Rec_flag.t, 'a, 'a) View.t
+  val lapply'const : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+  val ldot'const : ((string * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+  val lident'const : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
 end
 
 module V4_07 : sig
   open Versions
   open V4_07
   include LOC_TYPES
-  val lident : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
-  val ldot : ((Longident.t * string), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
-  val lapply : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+  val lident'const : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+  val ldot'const : ((Longident.t * string), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+  val lapply'const : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
 
-  val nonrecursive : (Rec_flag.t, 'a, 'a) View.t
+  val nonrecursive'const : (Rec_flag.t, 'a, 'a) View.t
 
-  val recursive : (Rec_flag.t, 'a, 'a) View.t
+  val recursive'const : (Rec_flag.t, 'a, 'a) View.t
 
-  val upto : (Direction_flag.t, 'a, 'a) View.t
+  val upto'const : (Direction_flag.t, 'a, 'a) View.t
 
-  val downto_ : (Direction_flag.t, 'a, 'a) View.t
+  val downto'const : (Direction_flag.t, 'a, 'a) View.t
 
-  val private_ : (Private_flag.t, 'a, 'a) View.t
+  val private'const : (Private_flag.t, 'a, 'a) View.t
 
-  val public : (Private_flag.t, 'a, 'a) View.t
+  val public'const : (Private_flag.t, 'a, 'a) View.t
 
-  val immutable : (Mutable_flag.t, 'a, 'a) View.t
+  val immutable'const : (Mutable_flag.t, 'a, 'a) View.t
 
-  val mutable_ : (Mutable_flag.t, 'a, 'a) View.t
+  val mutable'const : (Mutable_flag.t, 'a, 'a) View.t
 
-  val virtual_ : (Virtual_flag.t, 'a, 'a) View.t
+  val virtual'const : (Virtual_flag.t, 'a, 'a) View.t
 
-  val concrete : (Virtual_flag.t, 'a, 'a) View.t
+  val concrete'const : (Virtual_flag.t, 'a, 'a) View.t
 
-  val override : (Override_flag.t, 'a, 'a) View.t
+  val override'const : (Override_flag.t, 'a, 'a) View.t
 
-  val fresh : (Override_flag.t, 'a, 'a) View.t
+  val fresh'const : (Override_flag.t, 'a, 'a) View.t
 
-  val closed : (Closed_flag.t, 'a, 'a) View.t
+  val closed'const : (Closed_flag.t, 'a, 'a) View.t
 
-  val open_ : (Closed_flag.t, 'a, 'a) View.t
+  val open'const : (Closed_flag.t, 'a, 'a) View.t
 
-  val nolabel : (Arg_label.t, 'a, 'a) View.t
-  val labelled : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
-  val optional : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+  val nolabel'const : (Arg_label.t, 'a, 'a) View.t
+  val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+  val optional'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
 
-  val covariant : (Variance.t, 'a, 'a) View.t
+  val covariant'const : (Variance.t, 'a, 'a) View.t
 
-  val contravariant : (Variance.t, 'a, 'a) View.t
+  val contravariant'const : (Variance.t, 'a, 'a) View.t
 
-  val invariant : (Variance.t, 'a, 'a) View.t
-  val pconst_integer : ((string * char option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
-  val pconst_char : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
-  val pconst_string : ((string * string option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
-  val pconst_float : ((string * char option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
-  val pstr : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
-  val psig : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
-  val ptyp : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
-  val ppat : ((Pattern.t * Expression.t option), 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+  val invariant'const : (Variance.t, 'a, 'a) View.t
+  val pconst_integer'const : ((string * char option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+  val pconst_char'const : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+  val pconst_string'const : ((string * string option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+  val pconst_float'const : ((string * char option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+  val pstr'const : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+  val psig'const : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+  val ptyp'const : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+  val ppat'const : ((Pattern.t * Expression.t option), 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
 
   val ptyp_desc'match : (Core_type_desc.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 
@@ -493,22 +493,22 @@ module V4_07 : sig
 
   val ptyp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 
-  val ptyp_any : (Core_type.t, 'a, 'a) View.t
-  val ptyp_var : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_arrow : ((Arg_label.t * Core_type.t * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_tuple : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_constr : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_object : ((Object_field.t list * Closed_flag.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_class : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_alias : ((Core_type.t * string), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_variant : ((Row_field.t list * Closed_flag.t * Label.t list option), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_poly : ((string Astlib.Loc.t list * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_package : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val ptyp_extension : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-  val rtag : ((Label.t Astlib.Loc.t * Attributes.t * bool * Core_type.t list), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
-  val rinherit : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
-  val otag : ((Label.t Astlib.Loc.t * Attributes.t * Core_type.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
-  val oinherit : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+  val ptyp_any'const : (Core_type.t, 'a, 'a) View.t
+  val ptyp_var'const : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_arrow'const : ((Arg_label.t * Core_type.t * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_object'const : ((Object_field.t list * Closed_flag.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_class'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_alias'const : ((Core_type.t * string), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_variant'const : ((Row_field.t list * Closed_flag.t * Label.t list option), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_poly'const : ((string Astlib.Loc.t list * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+  val rtag'const : ((Label.t Astlib.Loc.t * Attributes.t * bool * Core_type.t list), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+  val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+  val otag'const : ((Label.t Astlib.Loc.t * Attributes.t * Core_type.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+  val oinherit'const : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
 
   val ppat_desc'match : (Pattern_desc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
@@ -516,67 +516,67 @@ module V4_07 : sig
 
   val ppat_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
-  val ppat_any : (Pattern.t, 'a, 'a) View.t
-  val ppat_var : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_alias : ((Pattern.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_constant : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_interval : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_tuple : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_construct : ((Longident_loc.t * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_variant : ((Label.t * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_record : (((Longident_loc.t * Pattern.t) list * Closed_flag.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_array : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_or : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_constraint : ((Pattern.t * Core_type.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_type : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_lazy : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_unpack : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_exception : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_extension : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-  val ppat_open : ((Longident_loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_any'const : (Pattern.t, 'a, 'a) View.t
+  val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_alias'const : ((Pattern.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_constant'const : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_construct'const : ((Longident_loc.t * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_variant'const : ((Label.t * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_record'const : (((Longident_loc.t * Pattern.t) list * Closed_flag.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_constraint'const : ((Pattern.t * Core_type.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_type'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_lazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_exception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_extension'const : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+  val ppat_open'const : ((Longident_loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
   val pexp_desc'match : (Expression_desc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
   val pexp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
   val pexp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_ident : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_constant : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_let : ((Rec_flag.t * Value_binding.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_function : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_fun : ((Arg_label.t * Expression.t option * Pattern.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_apply : ((Expression.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_match : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_try : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_tuple : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_construct : ((Longident_loc.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_variant : ((Label.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_record : (((Longident_loc.t * Expression.t) list * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_field : ((Expression.t * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_setfield : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_array : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_ifthenelse : ((Expression.t * Expression.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_sequence : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_while : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_for : ((Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_constraint : ((Expression.t * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_coerce : ((Expression.t * Core_type.t option * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_send : ((Expression.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_new : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_setinstvar : ((Label.t Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_override : ((Label.t Astlib.Loc.t * Expression.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_letmodule : ((string Astlib.Loc.t * Module_expr.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_letexception : ((Extension_constructor.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_assert : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_lazy : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_poly : ((Expression.t * Core_type.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_object : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_newtype : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_pack : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_open : ((Override_flag.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-  val pexp_extension : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_constant'const : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_let'const : ((Rec_flag.t * Value_binding.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_function'const : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_fun'const : ((Arg_label.t * Expression.t option * Pattern.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_apply'const : ((Expression.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_match'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_try'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_construct'const : ((Longident_loc.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_variant'const : ((Label.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_record'const : (((Longident_loc.t * Expression.t) list * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_field'const : ((Expression.t * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_array'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_ifthenelse'const : ((Expression.t * Expression.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_sequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_while'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_for'const : ((Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_constraint'const : ((Expression.t * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_coerce'const : ((Expression.t * Core_type.t option * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_send'const : ((Expression.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_setinstvar'const : ((Label.t Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_override'const : ((Label.t Astlib.Loc.t * Expression.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_letmodule'const : ((string Astlib.Loc.t * Module_expr.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_letexception'const : ((Extension_constructor.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_lazy'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_poly'const : ((Expression.t * Core_type.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_object'const : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_newtype'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_pack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_open'const : ((Override_flag.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+  val pexp_extension'const : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
-  val pexp_unreachable : (Expression.t, 'a, 'a) View.t
+  val pexp_unreachable'const : (Expression.t, 'a, 'a) View.t
 
   val pc_lhs'match : (Pattern.t, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
 
@@ -610,11 +610,11 @@ module V4_07 : sig
 
   val ptype_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
 
-  val ptype_abstract : (Type_kind.t, 'a, 'a) View.t
-  val ptype_variant : (Constructor_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
-  val ptype_record : (Label_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+  val ptype_abstract'const : (Type_kind.t, 'a, 'a) View.t
+  val ptype_variant'const : (Constructor_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+  val ptype_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
 
-  val ptype_open : (Type_kind.t, 'a, 'a) View.t
+  val ptype_open'const : (Type_kind.t, 'a, 'a) View.t
 
   val pld_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
 
@@ -635,8 +635,8 @@ module V4_07 : sig
   val pcd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
 
   val pcd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
-  val pcstr_tuple : (Core_type.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
-  val pcstr_record : (Label_declaration.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+  val pcstr_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+  val pcstr_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
 
   val ptyext_path'match : (Longident_loc.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
 
@@ -655,19 +655,19 @@ module V4_07 : sig
   val pext_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
 
   val pext_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
-  val pext_decl : ((Constructor_arguments.t * Core_type.t option), 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
-  val pext_rebind : (Longident_loc.t, 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+  val pext_decl'const : ((Constructor_arguments.t * Core_type.t option), 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+  val pext_rebind'const : (Longident_loc.t, 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
 
   val pcty_desc'match : (Class_type_desc.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
   val pcty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
   val pcty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pcty_constr : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pcty_signature : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pcty_arrow : ((Arg_label.t * Core_type.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pcty_extension : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-  val pcty_open : ((Override_flag.t * Longident_loc.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_signature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_arrow'const : ((Arg_label.t * Core_type.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+  val pcty_open'const : ((Override_flag.t * Longident_loc.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
   val pcsig_self'match : (Core_type.t, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
 
@@ -678,12 +678,12 @@ module V4_07 : sig
   val pctf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 
   val pctf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_inherit : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_val : ((Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_method : ((Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_constraint : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_attribute : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-  val pctf_extension : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_val'const : ((Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_method'const : ((Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+  val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 
   val pci_virt'match : (Virtual_flag.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
 
@@ -702,14 +702,14 @@ module V4_07 : sig
   val pcl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
   val pcl_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_constr : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_structure : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_fun : ((Arg_label.t * Expression.t option * Pattern.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_apply : ((Class_expr.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_let : ((Rec_flag.t * Value_binding.t list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_constraint : ((Class_expr.t * Class_type.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_extension : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-  val pcl_open : ((Override_flag.t * Longident_loc.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_structure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_fun'const : ((Arg_label.t * Expression.t option * Pattern.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_apply'const : ((Class_expr.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_let'const : ((Rec_flag.t * Value_binding.t list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_constraint'const : ((Class_expr.t * Class_type.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+  val pcl_open'const : ((Override_flag.t * Longident_loc.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
   val pcstr_self'match : (Pattern.t, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
 
@@ -720,45 +720,45 @@ module V4_07 : sig
   val pcf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 
   val pcf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_inherit : ((Override_flag.t * Class_expr.t * string Astlib.Loc.t option), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_val : ((Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_method : ((Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_constraint : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_initializer : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_attribute : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val pcf_extension : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-  val cfk_virtual : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
-  val cfk_concrete : ((Override_flag.t * Expression.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+  val pcf_inherit'const : ((Override_flag.t * Class_expr.t * string Astlib.Loc.t option), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_val'const : ((Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_method'const : ((Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+  val cfk_virtual'const : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+  val cfk_concrete'const : ((Override_flag.t * Expression.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
 
   val pmty_desc'match : (Module_type_desc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
   val pmty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
   val pmty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_ident : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_signature : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_functor : ((string Astlib.Loc.t * Module_type.t option * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_with : ((Module_type.t * With_constraint.t list), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_typeof : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_extension : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-  val pmty_alias : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_signature'const : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_functor'const : ((string Astlib.Loc.t * Module_type.t option * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_with'const : ((Module_type.t * With_constraint.t list), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+  val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
   val psig_desc'match : (Signature_item_desc.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
   val psig_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_value : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_type : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_typext : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_exception : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_module : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_recmodule : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_modtype : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_open : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_include : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_class : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_class_type : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_attribute : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-  val psig_extension : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_value'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_type'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_module'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_recmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_open'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_include'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_class'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+  val psig_extension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
   val pmd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
 
@@ -789,42 +789,42 @@ module V4_07 : sig
   val pincl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
 
   val pincl_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
-  val pwith_type : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
-  val pwith_module : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
-  val pwith_typesubst : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
-  val pwith_modsubst : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+  val pwith_type'const : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+  val pwith_module'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+  val pwith_typesubst'const : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+  val pwith_modsubst'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
 
   val pmod_desc'match : (Module_expr_desc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
   val pmod_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
   val pmod_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_ident : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_structure : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_functor : ((string Astlib.Loc.t * Module_type.t option * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_apply : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_constraint : ((Module_expr.t * Module_type.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_unpack : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-  val pmod_extension : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_structure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_functor'const : ((string Astlib.Loc.t * Module_type.t option * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_apply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_constraint'const : ((Module_expr.t * Module_type.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+  val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
   val pstr_desc'match : (Structure_item_desc.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 
   val pstr_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_eval : ((Expression.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_value : ((Rec_flag.t * Value_binding.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_primitive : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_type : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_typext : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_exception : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_module : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_recmodule : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_modtype : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_open : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_class : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_class_type : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_include : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_attribute : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-  val pstr_extension : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_eval'const : ((Expression.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_value'const : ((Rec_flag.t * Value_binding.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_primitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_type'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_module'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_recmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_open'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_class'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_include'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+  val pstr_extension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 
   val pvb_pat'match : (Pattern.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
 
@@ -841,13 +841,13 @@ module V4_07 : sig
   val pmb_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
 
   val pmb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
-  val ptop_def : (Structure.t, 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
-  val ptop_dir : ((string * Directive_argument.t), 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+  val ptop_def'const : (Structure.t, 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+  val ptop_dir'const : ((string * Directive_argument.t), 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
 
-  val pdir_none : (Directive_argument.t, 'a, 'a) View.t
-  val pdir_string : (string, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
-  val pdir_int : ((string * char option), 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
-  val pdir_ident : (Longident.t, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
-  val pdir_bool : (bool, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+  val pdir_none'const : (Directive_argument.t, 'a, 'a) View.t
+  val pdir_string'const : (string, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+  val pdir_int'const : ((string * char option), 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+  val pdir_ident'const : (Longident.t, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+  val pdir_bool'const : (bool, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
 end
 (*$*)

--- a/ppx_view/lib/expand.ml
+++ b/ppx_view/lib/expand.ml
@@ -49,15 +49,9 @@ let predefined_ident ~loc = function
   | "Not" -> Some (Builder.view_lib_ident ~loc "not")
   | _ -> None
 
-let is_keyword s =
-  List.mem_sorted ~compare:String.compare s Astlib.Syntax.keywords
-
 let ctor_viewer s =
   let lowercase = String.uncapitalize_ascii s in
-  if is_keyword lowercase then
-    lowercase ^ "_"
-  else
-    lowercase
+  lowercase ^ "'const"
 
 let translate_ctor_ident ~loc (ident : Longident.concrete) =
   match ident with

--- a/ppx_view/test/test.ml
+++ b/ppx_view/test/test.ml
@@ -136,28 +136,28 @@ type custom = Int of int | Unit of unit | Nothing
 
 let%expect_test "match with custom constructor" =
   let open Viewlib in
-  let int : (int, 'i, 'o) View.t -> (custom, 'i, 'o) View.t =
+  let int'const : (int, 'i, 'o) View.t -> (custom, 'i, 'o) View.t =
     fun view value ->
       match value with
       | Int   i -> view i
       | Unit  _ -> View.error
       | Nothing -> View.error
   in
-  let unit : (unit, 'i, 'i) View.t -> (custom, 'i, 'i) View.t =
+  let unit'const : (unit, 'i, 'i) View.t -> (custom, 'i, 'i) View.t =
     fun view value ->
       match value with
       | Int   _ -> View.error
       | Unit () -> view ()
       | Nothing -> View.error
   in
-  let nothing : (custom, 'i, 'i) View.t =
+  let nothing'const : (custom, 'i, 'i) View.t =
     fun value ->
       match value with
       | Int   _ -> View.error
       | Unit () -> View.error
       | Nothing -> View.unit ()
   in
-  let useless : (custom, 'i, 'i) View.t =
+  let useless'const : (custom, 'i, 'i) View.t =
     fun value ->
       match value with
       | Int _            -> View.error
@@ -192,25 +192,25 @@ let%expect_test "match with custom constructor" =
 
 let%expect_test "match with polymorphic variant" =
   let open Viewlib in
-  let int : (int, 'i, 'o) View.t -> ([> `Int of int], 'i, 'o) View.t =
+  let int'const : (int, 'i, 'o) View.t -> ([> `Int of int], 'i, 'o) View.t =
     fun view value ->
       match value with
       | `Int i -> view i
       | _      -> View.error
   in
-  let unit : (unit, 'i, 'i) View.t -> ([> `Unit of unit], 'i, 'i) View.t =
+  let unit'const : (unit, 'i, 'i) View.t -> ([> `Unit of unit], 'i, 'i) View.t =
     fun view value ->
       match value with
       | `Unit () -> view ()
       | _        -> View.error
   in
-  let nothing : ([> `Nothing], 'i, 'i) View.t =
+  let nothing'const : ([> `Nothing], 'i, 'i) View.t =
     fun value ->
       match value with
       | `Nothing -> View.unit ()
       | _        -> View.error
   in
-  let useless : ([`Int of int | `Unit of unit | `Nothing], 'i, 'i) View.t =
+  let useless'const : ([`Int of int | `Unit of unit | `Nothing], 'i, 'i) View.t =
     fun value ->
       match value with
       | `Int _             -> View.error
@@ -245,11 +245,11 @@ let%expect_test "match with polymorphic variant" =
 
 let%expect_test "match with object" =
   let open Viewlib in
-  let int : (int, 'i, 'o) View.t -> (< int: int; .. >, 'i, 'o) View.t =
+  let int'const : (int, 'i, 'o) View.t -> (< int: int; .. >, 'i, 'o) View.t =
     fun view value ->
       view value#int
   in
-  let unit : (unit, 'i, 'i) View.t -> (< unit: unit; .. >, 'i, 'i) View.t =
+  let unit'const : (unit, 'i, 'i) View.t -> (< unit: unit; .. >, 'i, 'i) View.t =
     fun view value ->
       view value#unit
   in
@@ -272,12 +272,12 @@ module M = struct
     | Pair of int * int
     | Record of {fst : int; snd : int}
 
-  let pair view value =
+  let pair'const view value =
     match value with
     | Pair (x, y) -> view (x, y)
     | Record _ -> Viewlib.View.error
 
-  let record view value =
+  let record'const view value =
     match value with
     | Pair _ -> Viewlib.View.error
     | Record {fst; snd} -> view (fst, snd)
@@ -315,12 +315,12 @@ module Shortcut = struct
     ; c : int
     }
 
-  let an_int view value =
+  let an_int'const view value =
     match value.a with
     | An_int i -> view i
     | _ -> Viewlib.View.error
 
-  let a_float view value =
+  let a_float'const view value =
     match value.a with
     | A_float f -> view f
     | _ -> Viewlib.View.error
@@ -354,7 +354,7 @@ let%expect_test "shortcut fields pattern" =
 
 let%expect_test "constructor translated to keyword" =
   let open Viewlib in
-  let virtual_ _ = View.ok in
+  let virtual'const _ = View.ok in
   (match%view 1 with
    | Virtual -> print_string "OK"
    | _ -> print_string "KO");


### PR DESCRIPTION
In our case these names collide between `Ppx_ast.Viewer` and `Ppx_ast.Builder` making it tedious to write code that matches over and produces AST types values at the same time.

This PR modifies ppx_view so it turns a `Some_const _` pattern into a call to `some_const'const` instead of a call to `some_const`.

This will probably apply to different use cases for ppx_view as well. I think it's okay to add a suffix as those functions aren't meant to be called "by hand" anyway.

For consistency we could maybe rename the `'match` functions into `'field` ones but that's not as urgent!