### PR TITLE
Generate both shortcut and regular views for AST desc types

### DIFF
--- a/ast/viewer_unstable_for_testing.ml
+++ b/ast/viewer_unstable_for_testing.ml
@@ -141,6 +141,16 @@ let pvb_pat'match view value =
   view concrete.Value_binding.pvb_pat
 
 let pstr_extension'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_extension (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let strextension'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -157,6 +167,16 @@ let pstr_extension'const view value =
   | _ -> View.error
 
 let pstr_attribute'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_attribute arg -> view arg
+  | _ -> View.error
+
+let strattribute'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -173,6 +193,16 @@ let pstr_attribute'const view value =
   | _ -> View.error
 
 let pstr_include'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_include arg -> view arg
+  | _ -> View.error
+
+let strinclude'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -189,6 +219,16 @@ let pstr_include'const view value =
   | _ -> View.error
 
 let pstr_class_type'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_class_type arg -> view arg
+  | _ -> View.error
+
+let strclass_type'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -205,6 +245,16 @@ let pstr_class_type'const view value =
   | _ -> View.error
 
 let pstr_class'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_class arg -> view arg
+  | _ -> View.error
+
+let strclass'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -221,6 +271,16 @@ let pstr_class'const view value =
   | _ -> View.error
 
 let pstr_open'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_open arg -> view arg
+  | _ -> View.error
+
+let stropen'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -237,6 +297,16 @@ let pstr_open'const view value =
   | _ -> View.error
 
 let pstr_modtype'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_modtype arg -> view arg
+  | _ -> View.error
+
+let strmodtype'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -253,6 +323,16 @@ let pstr_modtype'const view value =
   | _ -> View.error
 
 let pstr_recmodule'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_recmodule arg -> view arg
+  | _ -> View.error
+
+let strrecmodule'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -269,6 +349,16 @@ let pstr_recmodule'const view value =
   | _ -> View.error
 
 let pstr_module'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_module arg -> view arg
+  | _ -> View.error
+
+let strmodule'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -285,6 +375,16 @@ let pstr_module'const view value =
   | _ -> View.error
 
 let pstr_exception'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_exception arg -> view arg
+  | _ -> View.error
+
+let strexception'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -301,6 +401,16 @@ let pstr_exception'const view value =
   | _ -> View.error
 
 let pstr_typext'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_typext arg -> view arg
+  | _ -> View.error
+
+let strtypext'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -317,6 +427,16 @@ let pstr_typext'const view value =
   | _ -> View.error
 
 let pstr_type'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_type (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let strtype'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -333,6 +453,16 @@ let pstr_type'const view value =
   | _ -> View.error
 
 let pstr_primitive'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_primitive arg -> view arg
+  | _ -> View.error
+
+let strprimitive'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -349,6 +479,16 @@ let pstr_primitive'const view value =
   | _ -> View.error
 
 let pstr_value'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_value (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let strvalue'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -365,6 +505,16 @@ let pstr_value'const view value =
   | _ -> View.error
 
 let pstr_eval'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_eval (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let streval'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -405,6 +555,16 @@ let structure'const view value =
   view concrete0
 
 let pmod_extension'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_extension arg -> view arg
+  | _ -> View.error
+
+let meextension'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -421,6 +581,16 @@ let pmod_extension'const view value =
   | _ -> View.error
 
 let pmod_unpack'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_unpack arg -> view arg
+  | _ -> View.error
+
+let meunpack'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -437,6 +607,16 @@ let pmod_unpack'const view value =
   | _ -> View.error
 
 let pmod_constraint'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_constraint (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let meconstraint'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -453,6 +633,16 @@ let pmod_constraint'const view value =
   | _ -> View.error
 
 let pmod_apply'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_apply (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let meapply'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -469,6 +659,16 @@ let pmod_apply'const view value =
   | _ -> View.error
 
 let pmod_functor'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_functor (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let mefunctor'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -485,6 +685,16 @@ let pmod_functor'const view value =
   | _ -> View.error
 
 let pmod_structure'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_structure arg -> view arg
+  | _ -> View.error
+
+let mestructure'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -501,6 +711,16 @@ let pmod_structure'const view value =
   | _ -> View.error
 
 let pmod_ident'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_ident arg -> view arg
+  | _ -> View.error
+
+let meident'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -717,6 +937,16 @@ let pmd_name'match view value =
   view concrete.Module_declaration.pmd_name
 
 let psig_extension'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_extension (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let sigextension'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -733,6 +963,16 @@ let psig_extension'const view value =
   | _ -> View.error
 
 let psig_attribute'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_attribute arg -> view arg
+  | _ -> View.error
+
+let sigattribute'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -749,6 +989,16 @@ let psig_attribute'const view value =
   | _ -> View.error
 
 let psig_class_type'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_class_type arg -> view arg
+  | _ -> View.error
+
+let sigclass_type'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -765,6 +1015,16 @@ let psig_class_type'const view value =
   | _ -> View.error
 
 let psig_class'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_class arg -> view arg
+  | _ -> View.error
+
+let sigclass'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -781,6 +1041,16 @@ let psig_class'const view value =
   | _ -> View.error
 
 let psig_include'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_include arg -> view arg
+  | _ -> View.error
+
+let siginclude'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -797,6 +1067,16 @@ let psig_include'const view value =
   | _ -> View.error
 
 let psig_open'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_open arg -> view arg
+  | _ -> View.error
+
+let sigopen'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -813,6 +1093,16 @@ let psig_open'const view value =
   | _ -> View.error
 
 let psig_modtype'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_modtype arg -> view arg
+  | _ -> View.error
+
+let sigmodtype'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -829,6 +1119,16 @@ let psig_modtype'const view value =
   | _ -> View.error
 
 let psig_recmodule'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_recmodule arg -> view arg
+  | _ -> View.error
+
+let sigrecmodule'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -845,6 +1145,16 @@ let psig_recmodule'const view value =
   | _ -> View.error
 
 let psig_module'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_module arg -> view arg
+  | _ -> View.error
+
+let sigmodule'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -861,6 +1171,16 @@ let psig_module'const view value =
   | _ -> View.error
 
 let psig_exception'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_exception arg -> view arg
+  | _ -> View.error
+
+let sigexception'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -877,6 +1197,16 @@ let psig_exception'const view value =
   | _ -> View.error
 
 let psig_typext'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_typext arg -> view arg
+  | _ -> View.error
+
+let sigtypext'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -893,6 +1223,16 @@ let psig_typext'const view value =
   | _ -> View.error
 
 let psig_type'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_type (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let sigtype'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -909,6 +1249,16 @@ let psig_type'const view value =
   | _ -> View.error
 
 let psig_value'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_value arg -> view arg
+  | _ -> View.error
+
+let sigvalue'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -949,6 +1299,16 @@ let signature'const view value =
   view concrete0
 
 let pmty_alias'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_alias arg -> view arg
+  | _ -> View.error
+
+let mtalias'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -965,6 +1325,16 @@ let pmty_alias'const view value =
   | _ -> View.error
 
 let pmty_extension'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_extension arg -> view arg
+  | _ -> View.error
+
+let mtextension'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -981,6 +1351,16 @@ let pmty_extension'const view value =
   | _ -> View.error
 
 let pmty_typeof'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_typeof arg -> view arg
+  | _ -> View.error
+
+let mttypeof'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -997,6 +1377,16 @@ let pmty_typeof'const view value =
   | _ -> View.error
 
 let pmty_with'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_with (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let mtwith'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -1013,6 +1403,16 @@ let pmty_with'const view value =
   | _ -> View.error
 
 let pmty_functor'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_functor (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let mtfunctor'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -1029,6 +1429,16 @@ let pmty_functor'const view value =
   | _ -> View.error
 
 let pmty_signature'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_signature arg -> view arg
+  | _ -> View.error
+
+let mtsignature'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -1045,6 +1455,16 @@ let pmty_signature'const view value =
   | _ -> View.error
 
 let pmty_ident'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_ident arg -> view arg
+  | _ -> View.error
+
+let mtident'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -1113,6 +1533,16 @@ let cfk_virtual'const view value =
   | _ -> View.error
 
 let pcf_extension'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_extension arg -> view arg
+  | _ -> View.error
+
+let cfextension'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -1129,6 +1559,16 @@ let pcf_extension'const view value =
   | _ -> View.error
 
 let pcf_attribute'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_attribute arg -> view arg
+  | _ -> View.error
+
+let cfattribute'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -1145,6 +1585,16 @@ let pcf_attribute'const view value =
   | _ -> View.error
 
 let pcf_initializer'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_initializer arg -> view arg
+  | _ -> View.error
+
+let cfinitializer'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -1161,6 +1611,16 @@ let pcf_initializer'const view value =
   | _ -> View.error
 
 let pcf_constraint'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_constraint arg -> view arg
+  | _ -> View.error
+
+let cfconstraint'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -1177,6 +1637,16 @@ let pcf_constraint'const view value =
   | _ -> View.error
 
 let pcf_method'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_method arg -> view arg
+  | _ -> View.error
+
+let cfmethod'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -1193,6 +1663,16 @@ let pcf_method'const view value =
   | _ -> View.error
 
 let pcf_val'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_val arg -> view arg
+  | _ -> View.error
+
+let cfval'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -1209,6 +1689,16 @@ let pcf_val'const view value =
   | _ -> View.error
 
 let pcf_inherit'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_inherit (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let cfinherit'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -1265,6 +1755,16 @@ let pcstr_self'match view value =
   view concrete.Class_structure.pcstr_self
 
 let pcl_open'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let ceopen'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -1281,6 +1781,16 @@ let pcl_open'const view value =
   | _ -> View.error
 
 let pcl_extension'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_extension arg -> view arg
+  | _ -> View.error
+
+let ceextension'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -1297,6 +1807,16 @@ let pcl_extension'const view value =
   | _ -> View.error
 
 let pcl_constraint'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_constraint (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ceconstraint'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -1313,6 +1833,16 @@ let pcl_constraint'const view value =
   | _ -> View.error
 
 let pcl_let'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_let (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let celet'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -1329,6 +1859,16 @@ let pcl_let'const view value =
   | _ -> View.error
 
 let pcl_apply'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_apply (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ceapply'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -1345,6 +1885,16 @@ let pcl_apply'const view value =
   | _ -> View.error
 
 let pcl_fun'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_fun (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
+  | _ -> View.error
+
+let cefun'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -1361,6 +1911,16 @@ let pcl_fun'const view value =
   | _ -> View.error
 
 let pcl_structure'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_structure arg -> view arg
+  | _ -> View.error
+
+let cestructure'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -1377,6 +1937,16 @@ let pcl_structure'const view value =
   | _ -> View.error
 
 let pcl_constr'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_constr (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ceconstr'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -1481,6 +2051,16 @@ let pci_virt'match view value =
   view concrete.Class_infos.pci_virt
 
 let pctf_extension'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_extension arg -> view arg
+  | _ -> View.error
+
+let ctfextension'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -1497,6 +2077,16 @@ let pctf_extension'const view value =
   | _ -> View.error
 
 let pctf_attribute'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_attribute arg -> view arg
+  | _ -> View.error
+
+let ctfattribute'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -1513,6 +2103,16 @@ let pctf_attribute'const view value =
   | _ -> View.error
 
 let pctf_constraint'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_constraint arg -> view arg
+  | _ -> View.error
+
+let ctfconstraint'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -1529,6 +2129,16 @@ let pctf_constraint'const view value =
   | _ -> View.error
 
 let pctf_method'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_method arg -> view arg
+  | _ -> View.error
+
+let ctfmethod'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -1545,6 +2155,16 @@ let pctf_method'const view value =
   | _ -> View.error
 
 let pctf_val'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_val arg -> view arg
+  | _ -> View.error
+
+let ctfval'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -1561,6 +2181,16 @@ let pctf_val'const view value =
   | _ -> View.error
 
 let pctf_inherit'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_inherit arg -> view arg
+  | _ -> View.error
+
+let ctfinherit'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -1617,6 +2247,16 @@ let pcsig_self'match view value =
   view concrete.Class_signature.pcsig_self
 
 let pcty_open'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let ctopen'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -1633,6 +2273,16 @@ let pcty_open'const view value =
   | _ -> View.error
 
 let pcty_extension'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_extension arg -> view arg
+  | _ -> View.error
+
+let ctextension'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -1649,6 +2299,16 @@ let pcty_extension'const view value =
   | _ -> View.error
 
 let pcty_arrow'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_arrow (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let ctarrow'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -1665,6 +2325,16 @@ let pcty_arrow'const view value =
   | _ -> View.error
 
 let pcty_signature'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_signature arg -> view arg
+  | _ -> View.error
+
+let ctsignature'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -1681,6 +2351,16 @@ let pcty_signature'const view value =
   | _ -> View.error
 
 let pcty_constr'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_constr (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ctconstr'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -2081,6 +2761,16 @@ let pc_lhs'match view value =
   view concrete.Case.pc_lhs
 
 let pexp_unreachable'const value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_unreachable -> View.ok
+  | _ -> View.error
+
+let eunreachable'const value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2097,6 +2787,16 @@ let pexp_unreachable'const value =
   | _ -> View.error
 
 let pexp_extension'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_extension arg -> view arg
+  | _ -> View.error
+
+let eextension'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2113,6 +2813,16 @@ let pexp_extension'const view value =
   | _ -> View.error
 
 let pexp_open'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let eopen'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2129,6 +2839,16 @@ let pexp_open'const view value =
   | _ -> View.error
 
 let pexp_pack'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_pack arg -> view arg
+  | _ -> View.error
+
+let epack'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2145,6 +2865,16 @@ let pexp_pack'const view value =
   | _ -> View.error
 
 let pexp_newtype'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_newtype (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let enewtype'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2161,6 +2891,16 @@ let pexp_newtype'const view value =
   | _ -> View.error
 
 let pexp_object'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_object arg -> view arg
+  | _ -> View.error
+
+let eobject'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2177,6 +2917,16 @@ let pexp_object'const view value =
   | _ -> View.error
 
 let pexp_poly'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_poly (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let epoly'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2193,6 +2943,16 @@ let pexp_poly'const view value =
   | _ -> View.error
 
 let pexp_lazy'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_lazy arg -> view arg
+  | _ -> View.error
+
+let elazy'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2209,6 +2969,16 @@ let pexp_lazy'const view value =
   | _ -> View.error
 
 let pexp_assert'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_assert arg -> view arg
+  | _ -> View.error
+
+let eassert'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2225,6 +2995,16 @@ let pexp_assert'const view value =
   | _ -> View.error
 
 let pexp_letexception'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_letexception (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let eletexception'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2241,6 +3021,16 @@ let pexp_letexception'const view value =
   | _ -> View.error
 
 let pexp_letmodule'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_letmodule (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let eletmodule'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2257,6 +3047,16 @@ let pexp_letmodule'const view value =
   | _ -> View.error
 
 let pexp_override'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_override arg -> view arg
+  | _ -> View.error
+
+let eoverride'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2273,6 +3073,16 @@ let pexp_override'const view value =
   | _ -> View.error
 
 let pexp_setinstvar'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_setinstvar (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let esetinstvar'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2289,6 +3099,16 @@ let pexp_setinstvar'const view value =
   | _ -> View.error
 
 let pexp_new'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_new arg -> view arg
+  | _ -> View.error
+
+let enew'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2305,6 +3125,16 @@ let pexp_new'const view value =
   | _ -> View.error
 
 let pexp_send'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_send (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let esend'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2321,6 +3151,16 @@ let pexp_send'const view value =
   | _ -> View.error
 
 let pexp_coerce'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_coerce (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let ecoerce'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2337,6 +3177,16 @@ let pexp_coerce'const view value =
   | _ -> View.error
 
 let pexp_constraint'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_constraint (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let econstraint'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2353,6 +3203,16 @@ let pexp_constraint'const view value =
   | _ -> View.error
 
 let pexp_for'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_for (arg0, arg1, arg2, arg3, arg4) -> view (arg0, arg1, arg2, arg3, arg4)
+  | _ -> View.error
+
+let efor'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2369,6 +3229,16 @@ let pexp_for'const view value =
   | _ -> View.error
 
 let pexp_while'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_while (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ewhile'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2385,6 +3255,16 @@ let pexp_while'const view value =
   | _ -> View.error
 
 let pexp_sequence'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_sequence (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let esequence'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2401,6 +3281,16 @@ let pexp_sequence'const view value =
   | _ -> View.error
 
 let pexp_ifthenelse'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_ifthenelse (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let eifthenelse'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2417,6 +3307,16 @@ let pexp_ifthenelse'const view value =
   | _ -> View.error
 
 let pexp_array'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_array arg -> view arg
+  | _ -> View.error
+
+let earray'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2433,6 +3333,16 @@ let pexp_array'const view value =
   | _ -> View.error
 
 let pexp_setfield'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_setfield (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let esetfield'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2449,6 +3359,16 @@ let pexp_setfield'const view value =
   | _ -> View.error
 
 let pexp_field'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_field (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let efield'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2465,6 +3385,16 @@ let pexp_field'const view value =
   | _ -> View.error
 
 let pexp_record'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_record (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let erecord'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2481,6 +3411,16 @@ let pexp_record'const view value =
   | _ -> View.error
 
 let pexp_variant'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_variant (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let evariant'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2497,6 +3437,16 @@ let pexp_variant'const view value =
   | _ -> View.error
 
 let pexp_construct'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_construct (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let econstruct'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2513,6 +3463,16 @@ let pexp_construct'const view value =
   | _ -> View.error
 
 let pexp_tuple'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_tuple arg -> view arg
+  | _ -> View.error
+
+let etuple'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2529,6 +3489,16 @@ let pexp_tuple'const view value =
   | _ -> View.error
 
 let pexp_try'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_try (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let etry'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2545,6 +3515,16 @@ let pexp_try'const view value =
   | _ -> View.error
 
 let pexp_match'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_match (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ematch'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2561,6 +3541,16 @@ let pexp_match'const view value =
   | _ -> View.error
 
 let pexp_apply'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_apply (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let eapply'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2577,6 +3567,16 @@ let pexp_apply'const view value =
   | _ -> View.error
 
 let pexp_fun'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_fun (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
+  | _ -> View.error
+
+let efun'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2593,6 +3593,16 @@ let pexp_fun'const view value =
   | _ -> View.error
 
 let pexp_function'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_function arg -> view arg
+  | _ -> View.error
+
+let efunction'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2609,6 +3619,16 @@ let pexp_function'const view value =
   | _ -> View.error
 
 let pexp_let'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_let (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let elet'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2625,6 +3645,16 @@ let pexp_let'const view value =
   | _ -> View.error
 
 let pexp_constant'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_constant arg -> view arg
+  | _ -> View.error
+
+let econstant'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2641,6 +3671,16 @@ let pexp_constant'const view value =
   | _ -> View.error
 
 let pexp_ident'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_ident arg -> view arg
+  | _ -> View.error
+
+let eident'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -2681,6 +3721,16 @@ let pexp_desc'match view value =
   view concrete.Expression.pexp_desc
 
 let ppat_open'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_open (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let popen'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2697,6 +3747,16 @@ let ppat_open'const view value =
   | _ -> View.error
 
 let ppat_extension'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_extension arg -> view arg
+  | _ -> View.error
+
+let pextension'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2713,6 +3773,16 @@ let ppat_extension'const view value =
   | _ -> View.error
 
 let ppat_exception'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_exception arg -> view arg
+  | _ -> View.error
+
+let pexception'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2729,6 +3799,16 @@ let ppat_exception'const view value =
   | _ -> View.error
 
 let ppat_unpack'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_unpack arg -> view arg
+  | _ -> View.error
+
+let punpack'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2745,6 +3825,16 @@ let ppat_unpack'const view value =
   | _ -> View.error
 
 let ppat_lazy'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_lazy arg -> view arg
+  | _ -> View.error
+
+let plazy'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2761,6 +3851,16 @@ let ppat_lazy'const view value =
   | _ -> View.error
 
 let ppat_type'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_type arg -> view arg
+  | _ -> View.error
+
+let ptype'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2777,6 +3877,16 @@ let ppat_type'const view value =
   | _ -> View.error
 
 let ppat_constraint'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_constraint (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let pconstraint'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2793,6 +3903,16 @@ let ppat_constraint'const view value =
   | _ -> View.error
 
 let ppat_or'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_or (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let por'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2809,6 +3929,16 @@ let ppat_or'const view value =
   | _ -> View.error
 
 let ppat_array'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_array arg -> view arg
+  | _ -> View.error
+
+let parray'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2825,6 +3955,16 @@ let ppat_array'const view value =
   | _ -> View.error
 
 let ppat_record'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_record (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let precord'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2841,6 +3981,16 @@ let ppat_record'const view value =
   | _ -> View.error
 
 let ppat_variant'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_variant (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let pvariant'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2857,6 +4007,16 @@ let ppat_variant'const view value =
   | _ -> View.error
 
 let ppat_construct'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_construct (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let pconstruct'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2873,6 +4033,16 @@ let ppat_construct'const view value =
   | _ -> View.error
 
 let ppat_tuple'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_tuple arg -> view arg
+  | _ -> View.error
+
+let ptuple'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2889,6 +4059,16 @@ let ppat_tuple'const view value =
   | _ -> View.error
 
 let ppat_interval'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_interval (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let pinterval'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2905,6 +4085,16 @@ let ppat_interval'const view value =
   | _ -> View.error
 
 let ppat_constant'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_constant arg -> view arg
+  | _ -> View.error
+
+let pconstant'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2921,6 +4111,16 @@ let ppat_constant'const view value =
   | _ -> View.error
 
 let ppat_alias'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_alias (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let palias'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2937,6 +4137,16 @@ let ppat_alias'const view value =
   | _ -> View.error
 
 let ppat_var'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_var arg -> view arg
+  | _ -> View.error
+
+let pvar'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -2953,6 +4163,16 @@ let ppat_var'const view value =
   | _ -> View.error
 
 let ppat_any'const value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_any -> View.ok
+  | _ -> View.error
+
+let pany'const value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -3041,6 +4261,16 @@ let package_type'const view value =
   view concrete0
 
 let ptyp_extension'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_extension arg -> view arg
+  | _ -> View.error
+
+let textension'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3057,6 +4287,16 @@ let ptyp_extension'const view value =
   | _ -> View.error
 
 let ptyp_package'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_package arg -> view arg
+  | _ -> View.error
+
+let tpackage'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3073,6 +4313,16 @@ let ptyp_package'const view value =
   | _ -> View.error
 
 let ptyp_poly'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_poly (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let tpoly'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3089,6 +4339,16 @@ let ptyp_poly'const view value =
   | _ -> View.error
 
 let ptyp_variant'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_variant (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let tvariant'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3105,6 +4365,16 @@ let ptyp_variant'const view value =
   | _ -> View.error
 
 let ptyp_alias'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_alias (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let talias'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3121,6 +4391,16 @@ let ptyp_alias'const view value =
   | _ -> View.error
 
 let ptyp_class'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_class (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let tclass'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3137,6 +4417,16 @@ let ptyp_class'const view value =
   | _ -> View.error
 
 let ptyp_object'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_object (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let tobject'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3153,6 +4443,16 @@ let ptyp_object'const view value =
   | _ -> View.error
 
 let ptyp_constr'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_constr (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let tconstr'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3169,6 +4469,16 @@ let ptyp_constr'const view value =
   | _ -> View.error
 
 let ptyp_tuple'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_tuple arg -> view arg
+  | _ -> View.error
+
+let ttuple'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3185,6 +4495,16 @@ let ptyp_tuple'const view value =
   | _ -> View.error
 
 let ptyp_arrow'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_arrow (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let tarrow'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3201,6 +4521,16 @@ let ptyp_arrow'const view value =
   | _ -> View.error
 
 let ptyp_var'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_var arg -> view arg
+  | _ -> View.error
+
+let tvar'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -3217,6 +4547,16 @@ let ptyp_var'const view value =
   | _ -> View.error
 
 let ptyp_any'const value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_any -> View.ok
+  | _ -> View.error
+
+let tany'const value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"

--- a/ast/viewer_unstable_for_testing.mli
+++ b/ast/viewer_unstable_for_testing.mli
@@ -4,13 +4,19 @@ open Viewlib
 open Versions
 open Unstable_for_testing
 include module type of Viewer_common
+
 val pdir_bool'const : (bool, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+
 val pdir_ident'const : (Longident.t, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+
 val pdir_int'const : ((char option * string), 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+
 val pdir_string'const : (string, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
 
 val pdir_none'const : (Directive_argument.t, 'a, 'a) View.t
+
 val ptop_dir'const : ((Directive_argument.t * string), 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+
 val ptop_def'const : (Structure.t, 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
 
 val pmb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
@@ -28,42 +34,112 @@ val pvb_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Value_binding.t, 'i
 val pvb_expr'match : (Expression.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
 
 val pvb_pat'match : (Pattern.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
-val pstr_extension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_include'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_class'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_open'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_recmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_module'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_type'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_primitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_value'const : ((Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_eval'const : ((Attributes.t * Expression.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_extension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strextension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strattribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_include'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strinclude'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strclass_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_class'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strclass'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_open'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val stropen'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strmodtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_recmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strrecmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_module'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strmodule'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strexception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strtypext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_type'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strtype'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_primitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strprimitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_value'const : ((Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strvalue'const : ((Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_eval'const : ((Attributes.t * Expression.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val streval'const : ((Attributes.t * Expression.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 
 val pstr_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 
 val pstr_desc'match : (Structure_item_desc.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 val structure'const: (Structure_item.t list, 'i, 'o) View.t -> (Structure.t, 'i, 'o) View.t
-val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_constraint'const : ((Module_type.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_apply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_functor'const : ((Module_expr.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_structure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meextension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meunpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_constraint'const : ((Module_type.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meconstraint'const : ((Module_type.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_apply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meapply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_functor'const : ((Module_expr.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val mefunctor'const : ((Module_expr.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_structure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val mestructure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
 val pmod_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
 val pmod_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
 val pmod_desc'match : (Module_expr_desc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
 val pwith_modsubst'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+
 val pwith_typesubst'const : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+
 val pwith_module'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+
 val pwith_type'const : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
 val include_declaration'const: (Module_expr.t Include_infos.t, 'i, 'o) View.t -> (Include_declaration.t, 'i, 'o) View.t
 val include_description'const: (Module_type.t Include_infos.t, 'i, 'o) View.t -> (Include_description.t, 'i, 'o) View.t
@@ -97,31 +173,91 @@ val pmd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_declaration.
 val pmd_type'match : (Module_type.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
 
 val pmd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
-val psig_extension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_class'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_include'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_open'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_recmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_module'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_type'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_value'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_extension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigextension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigattribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigclass_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_class'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigclass'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_include'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val siginclude'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_open'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigopen'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigmodtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_recmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigrecmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_module'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigmodule'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigexception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigtypext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_type'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigtype'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_value'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigvalue'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
 val psig_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
 val psig_desc'match : (Signature_item_desc.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 val signature'const: (Signature_item.t list, 'i, 'o) View.t -> (Signature.t, 'i, 'o) View.t
-val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_with'const : ((With_constraint.t list * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_functor'const : ((Module_type.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_signature'const : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtalias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtextension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mttypeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_with'const : ((With_constraint.t list * Module_type.t), 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtwith'const : ((With_constraint.t list * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_functor'const : ((Module_type.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtfunctor'const : ((Module_type.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_signature'const : (Signature.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtsignature'const : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
 val pmty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
@@ -129,15 +265,38 @@ val pmty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_type.t, 'i, '
 
 val pmty_desc'match : (Module_type_desc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 val class_declaration'const: (Class_expr.t Class_infos.t, 'i, 'o) View.t -> (Class_declaration.t, 'i, 'o) View.t
+
 val cfk_concrete'const : ((Expression.t * Override_flag.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+
 val cfk_virtual'const : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
-val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_method'const : ((Class_field_kind.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_val'const : ((Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_inherit'const : ((string Astlib.Loc.t option * Class_expr.t * Override_flag.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfextension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfattribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfinitializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfconstraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_method'const : ((Class_field_kind.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfmethod'const : ((Class_field_kind.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_val'const : ((Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfval'const : ((Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_inherit'const : ((string Astlib.Loc.t option * Class_expr.t * Override_flag.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfinherit'const : ((string Astlib.Loc.t option * Class_expr.t * Override_flag.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 
 val pcf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 
@@ -148,14 +307,38 @@ val pcf_desc'match : (Class_field_desc.t, 'i, 'o) View.t -> (Class_field.t, 'i, 
 val pcstr_fields'match : (Class_field.t list, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
 
 val pcstr_self'match : (Pattern.t, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
-val pcl_open'const : ((Class_expr.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_constraint'const : ((Class_type.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_let'const : ((Class_expr.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_apply'const : (((Expression.t * Arg_label.t) list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_fun'const : ((Class_expr.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_structure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_open'const : ((Class_expr.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceopen'const : ((Class_expr.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceextension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_constraint'const : ((Class_type.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceconstraint'const : ((Class_type.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_let'const : ((Class_expr.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val celet'const : ((Class_expr.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_apply'const : (((Expression.t * Arg_label.t) list * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceapply'const : (((Expression.t * Arg_label.t) list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_fun'const : ((Class_expr.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val cefun'const : ((Class_expr.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_structure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val cestructure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceconstr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
 val pcl_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
@@ -176,12 +359,30 @@ val pci_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> ('a node Class_info
 val pci_params'match : ((Variance.t * Core_type.t) list, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
 
 val pci_virt'match : (Virtual_flag.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
-val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_method'const : ((Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_val'const : ((Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfextension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfattribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfconstraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_method'const : ((Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfmethod'const : ((Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_val'const : ((Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfval'const : ((Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfinherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 
 val pctf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 
@@ -192,18 +393,35 @@ val pctf_desc'match : (Class_type_field_desc.t, 'i, 'o) View.t -> (Class_type_fi
 val pcsig_fields'match : (Class_type_field.t list, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
 
 val pcsig_self'match : (Core_type.t, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
-val pcty_open'const : ((Class_type.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-val pcty_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-val pcty_arrow'const : ((Class_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-val pcty_signature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-val pcty_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_open'const : ((Class_type.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctopen'const : ((Class_type.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctextension'const : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_arrow'const : ((Class_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctarrow'const : ((Class_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_signature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctsignature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctconstr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
 val pcty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
 val pcty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
 val pcty_desc'match : (Class_type_desc.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
 val pext_rebind'const : (Longident_loc.t, 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+
 val pext_decl'const : ((Core_type.t option * Constructor_arguments.t), 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
 
 val pext_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
@@ -223,7 +441,9 @@ val ptyext_constructors'match : (Extension_constructor.t list, 'i, 'o) View.t ->
 val ptyext_params'match : ((Variance.t * Core_type.t) list, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
 
 val ptyext_path'match : (Longident_loc.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+
 val pcstr_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+
 val pcstr_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
 
 val pcd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
@@ -247,7 +467,9 @@ val pld_mutable'match : (Mutable_flag.t, 'i, 'o) View.t -> (Label_declaration.t,
 val pld_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
 
 val ptype_open'const : (Type_kind.t, 'a, 'a) View.t
+
 val ptype_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+
 val ptype_variant'const : (Constructor_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
 
 val ptype_abstract'const : (Type_kind.t, 'a, 'a) View.t
@@ -284,107 +506,314 @@ val pc_guard'match : (Expression.t option, 'i, 'o) View.t -> (Case.t, 'i, 'o) Vi
 
 val pc_lhs'match : (Pattern.t, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
 
-val pexp_unreachable'const : (Expression.t, 'a, 'a) View.t
-val pexp_extension'const : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_open'const : ((Expression.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_pack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_newtype'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_object'const : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_poly'const : ((Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_lazy'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_letexception'const : ((Expression.t * Extension_constructor.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_letmodule'const : ((Expression.t * Module_expr.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_override'const : ((Expression.t * string Astlib.Loc.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_setinstvar'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_send'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_coerce'const : ((Core_type.t * Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_constraint'const : ((Core_type.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_for'const : ((Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_while'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_sequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_ifthenelse'const : ((Expression.t option * Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_array'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_field'const : ((Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_record'const : ((Expression.t option * (Expression.t * Longident_loc.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_variant'const : ((Expression.t option * string), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_construct'const : ((Expression.t option * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_try'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_match'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_apply'const : (((Expression.t * Arg_label.t) list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_fun'const : ((Expression.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_function'const : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_let'const : ((Expression.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_constant'const : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_unreachable'const : (Expression_desc.t, 'a, 'a) View.t
+
+val eunreachable'const : (Expression.t, 'a, 'a) View.t
+
+val pexp_extension'const : (Extension.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eextension'const : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_open'const : ((Expression.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eopen'const : ((Expression.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_pack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val epack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_newtype'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val enewtype'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_object'const : (Class_structure.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eobject'const : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_poly'const : ((Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val epoly'const : ((Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_lazy'const : (Expression.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val elazy'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eassert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_letexception'const : ((Expression.t * Extension_constructor.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eletexception'const : ((Expression.t * Extension_constructor.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_letmodule'const : ((Expression.t * Module_expr.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eletmodule'const : ((Expression.t * Module_expr.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_override'const : ((Expression.t * string Astlib.Loc.t) list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eoverride'const : ((Expression.t * string Astlib.Loc.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_setinstvar'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val esetinstvar'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val enew'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_send'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val esend'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_coerce'const : ((Core_type.t * Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val ecoerce'const : ((Core_type.t * Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_constraint'const : ((Core_type.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val econstraint'const : ((Core_type.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_for'const : ((Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val efor'const : ((Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_while'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val ewhile'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_sequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val esequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_ifthenelse'const : ((Expression.t option * Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eifthenelse'const : ((Expression.t option * Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_array'const : (Expression.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val earray'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val esetfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_field'const : ((Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val efield'const : ((Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_record'const : ((Expression.t option * (Expression.t * Longident_loc.t) list), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val erecord'const : ((Expression.t option * (Expression.t * Longident_loc.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_variant'const : ((Expression.t option * string), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val evariant'const : ((Expression.t option * string), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_construct'const : ((Expression.t option * Longident_loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val econstruct'const : ((Expression.t option * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val etuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_try'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val etry'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_match'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val ematch'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_apply'const : (((Expression.t * Arg_label.t) list * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eapply'const : (((Expression.t * Arg_label.t) list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_fun'const : ((Expression.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val efun'const : ((Expression.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_function'const : (Case.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val efunction'const : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_let'const : ((Expression.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val elet'const : ((Expression.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_constant'const : (Constant.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val econstant'const : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
 val pexp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
 val pexp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
 val pexp_desc'match : (Expression_desc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val ppat_open'const : ((Pattern.t * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_extension'const : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_exception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_lazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_type'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_constraint'const : ((Core_type.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_record'const : ((Closed_flag.t * (Pattern.t * Longident_loc.t) list), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_variant'const : ((Pattern.t option * string), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_construct'const : ((Pattern.t option * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_constant'const : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_alias'const : ((string Astlib.Loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
-val ppat_any'const : (Pattern.t, 'a, 'a) View.t
+val ppat_open'const : ((Pattern.t * Longident_loc.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val popen'const : ((Pattern.t * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_extension'const : (Extension.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pextension'const : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_exception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pexception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val punpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_lazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val plazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_type'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val ptype'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_constraint'const : ((Core_type.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pconstraint'const : ((Core_type.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val por'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val parray'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_record'const : ((Closed_flag.t * (Pattern.t * Longident_loc.t) list), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val precord'const : ((Closed_flag.t * (Pattern.t * Longident_loc.t) list), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_variant'const : ((Pattern.t option * string), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pvariant'const : ((Pattern.t option * string), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_construct'const : ((Pattern.t option * Longident_loc.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pconstruct'const : ((Pattern.t option * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val ptuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pinterval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_constant'const : (Constant.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pconstant'const : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_alias'const : ((string Astlib.Loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val palias'const : ((string Astlib.Loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pvar'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_any'const : (Pattern_desc.t, 'a, 'a) View.t
+
+val pany'const : (Pattern.t, 'a, 'a) View.t
 
 val ppat_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
 val ppat_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
 val ppat_desc'match : (Pattern_desc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
 val oinherit'const : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+
 val otag'const : ((Core_type.t * Attributes.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+
 val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+
 val rtag'const : ((Core_type.t list * bool * Attributes.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
 val package_type'const: (((Core_type.t * Longident_loc.t) list * Longident_loc.t), 'i, 'o) View.t -> (Package_type.t, 'i, 'o) View.t
-val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_poly'const : ((Core_type.t * string Astlib.Loc.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_variant'const : ((string list option * Closed_flag.t * Row_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_alias'const : ((string * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_class'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_object'const : ((Closed_flag.t * Object_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_arrow'const : ((Core_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_var'const : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 
-val ptyp_any'const : (Core_type.t, 'a, 'a) View.t
+val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val textension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tpackage'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_poly'const : ((Core_type.t * string Astlib.Loc.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tpoly'const : ((Core_type.t * string Astlib.Loc.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_variant'const : ((string list option * Closed_flag.t * Row_field.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tvariant'const : ((string list option * Closed_flag.t * Row_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_alias'const : ((string * Core_type.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val talias'const : ((string * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_class'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tclass'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_object'const : ((Closed_flag.t * Object_field.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tobject'const : ((Closed_flag.t * Object_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tconstr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val ttuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_arrow'const : ((Core_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tarrow'const : ((Core_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_var'const : (string, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tvar'const : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_any'const : (Core_type_desc.t, 'a, 'a) View.t
+
+val tany'const : (Core_type.t, 'a, 'a) View.t
 
 val ptyp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 
 val ptyp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 
 val ptyp_desc'match : (Core_type_desc.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
 val ppat'const : ((Expression.t option * Pattern.t), 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+
 val ptyp'const : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+
 val psig'const : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+
 val pstr'const : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
 val attributes'const: (Attribute.t list, 'i, 'o) View.t -> (Attributes.t, 'i, 'o) View.t
 val extension'const: ((Payload.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Extension.t, 'i, 'o) View.t
 val attribute'const: ((Payload.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Attribute.t, 'i, 'o) View.t
+
 val pconst_float'const : ((char option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+
 val pconst_string'const : ((string option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+
 val pconst_char'const : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+
 val pconst_integer'const : ((char option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
 
 val invariant'const : (Variance.t, 'a, 'a) View.t
@@ -392,7 +821,9 @@ val invariant'const : (Variance.t, 'a, 'a) View.t
 val contravariant'const : (Variance.t, 'a, 'a) View.t
 
 val covariant'const : (Variance.t, 'a, 'a) View.t
+
 val optional'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+
 val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
 
 val nolabel'const : (Arg_label.t, 'a, 'a) View.t
@@ -425,7 +856,10 @@ val recursive'const : (Rec_flag.t, 'a, 'a) View.t
 
 val nonrecursive'const : (Rec_flag.t, 'a, 'a) View.t
 val longident_loc'const: (Longident.t Astlib.Loc.t, 'i, 'o) View.t -> (Longident_loc.t, 'i, 'o) View.t
+
 val lapply'const : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+
 val ldot'const : ((string * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+
 val lident'const : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
 (*$*)

--- a/ast/viewer_v4_07.ml
+++ b/ast/viewer_v4_07.ml
@@ -373,6 +373,16 @@ let ptyp_attributes'match view value =
   view concrete.Core_type.ptyp_attributes
 
 let ptyp_any'const value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_any -> View.ok
+  | _ -> View.error
+
+let tany'const value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -389,6 +399,16 @@ let ptyp_any'const value =
   | _ -> View.error
 
 let ptyp_var'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_var arg -> view arg
+  | _ -> View.error
+
+let tvar'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -405,6 +425,16 @@ let ptyp_var'const view value =
   | _ -> View.error
 
 let ptyp_arrow'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_arrow (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let tarrow'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -421,6 +451,16 @@ let ptyp_arrow'const view value =
   | _ -> View.error
 
 let ptyp_tuple'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_tuple arg -> view arg
+  | _ -> View.error
+
+let ttuple'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -437,6 +477,16 @@ let ptyp_tuple'const view value =
   | _ -> View.error
 
 let ptyp_constr'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_constr (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let tconstr'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -453,6 +503,16 @@ let ptyp_constr'const view value =
   | _ -> View.error
 
 let ptyp_object'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_object (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let tobject'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -469,6 +529,16 @@ let ptyp_object'const view value =
   | _ -> View.error
 
 let ptyp_class'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_class (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let tclass'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -485,6 +555,16 @@ let ptyp_class'const view value =
   | _ -> View.error
 
 let ptyp_alias'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_alias (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let talias'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -501,6 +581,16 @@ let ptyp_alias'const view value =
   | _ -> View.error
 
 let ptyp_variant'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_variant (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let tvariant'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -517,6 +607,16 @@ let ptyp_variant'const view value =
   | _ -> View.error
 
 let ptyp_poly'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_poly (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let tpoly'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -533,6 +633,16 @@ let ptyp_poly'const view value =
   | _ -> View.error
 
 let ptyp_package'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_package arg -> view arg
+  | _ -> View.error
+
+let tpackage'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -549,6 +659,16 @@ let ptyp_package'const view value =
   | _ -> View.error
 
 let ptyp_extension'const view value =
+  let concrete =
+    match Core_type_desc.to_concrete value with
+    | None -> conversion_failed "core_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Core_type_desc.Ptyp_extension arg -> view arg
+  | _ -> View.error
+
+let textension'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
     | None -> conversion_failed "core_type"
@@ -637,6 +757,16 @@ let ppat_attributes'match view value =
   view concrete.Pattern.ppat_attributes
 
 let ppat_any'const value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_any -> View.ok
+  | _ -> View.error
+
+let pany'const value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -653,6 +783,16 @@ let ppat_any'const value =
   | _ -> View.error
 
 let ppat_var'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_var arg -> view arg
+  | _ -> View.error
+
+let pvar'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -669,6 +809,16 @@ let ppat_var'const view value =
   | _ -> View.error
 
 let ppat_alias'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_alias (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let palias'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -685,6 +835,16 @@ let ppat_alias'const view value =
   | _ -> View.error
 
 let ppat_constant'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_constant arg -> view arg
+  | _ -> View.error
+
+let pconstant'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -701,6 +861,16 @@ let ppat_constant'const view value =
   | _ -> View.error
 
 let ppat_interval'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_interval (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let pinterval'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -717,6 +887,16 @@ let ppat_interval'const view value =
   | _ -> View.error
 
 let ppat_tuple'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_tuple arg -> view arg
+  | _ -> View.error
+
+let ptuple'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -733,6 +913,16 @@ let ppat_tuple'const view value =
   | _ -> View.error
 
 let ppat_construct'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_construct (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let pconstruct'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -749,6 +939,16 @@ let ppat_construct'const view value =
   | _ -> View.error
 
 let ppat_variant'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_variant (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let pvariant'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -765,6 +965,16 @@ let ppat_variant'const view value =
   | _ -> View.error
 
 let ppat_record'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_record (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let precord'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -781,6 +991,16 @@ let ppat_record'const view value =
   | _ -> View.error
 
 let ppat_array'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_array arg -> view arg
+  | _ -> View.error
+
+let parray'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -797,6 +1017,16 @@ let ppat_array'const view value =
   | _ -> View.error
 
 let ppat_or'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_or (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let por'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -813,6 +1043,16 @@ let ppat_or'const view value =
   | _ -> View.error
 
 let ppat_constraint'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_constraint (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let pconstraint'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -829,6 +1069,16 @@ let ppat_constraint'const view value =
   | _ -> View.error
 
 let ppat_type'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_type arg -> view arg
+  | _ -> View.error
+
+let ptype'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -845,6 +1095,16 @@ let ppat_type'const view value =
   | _ -> View.error
 
 let ppat_lazy'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_lazy arg -> view arg
+  | _ -> View.error
+
+let plazy'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -861,6 +1121,16 @@ let ppat_lazy'const view value =
   | _ -> View.error
 
 let ppat_unpack'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_unpack arg -> view arg
+  | _ -> View.error
+
+let punpack'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -877,6 +1147,16 @@ let ppat_unpack'const view value =
   | _ -> View.error
 
 let ppat_exception'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_exception arg -> view arg
+  | _ -> View.error
+
+let pexception'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -893,6 +1173,16 @@ let ppat_exception'const view value =
   | _ -> View.error
 
 let ppat_extension'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_extension arg -> view arg
+  | _ -> View.error
+
+let pextension'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -909,6 +1199,16 @@ let ppat_extension'const view value =
   | _ -> View.error
 
 let ppat_open'const view value =
+  let concrete =
+    match Pattern_desc.to_concrete value with
+    | None -> conversion_failed "pattern_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Pattern_desc.Ppat_open (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let popen'const view value =
   let parent_concrete =
     match Pattern.to_concrete value with
     | None -> conversion_failed "pattern"
@@ -949,6 +1249,16 @@ let pexp_attributes'match view value =
   view concrete.Expression.pexp_attributes
 
 let pexp_ident'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_ident arg -> view arg
+  | _ -> View.error
+
+let eident'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -965,6 +1275,16 @@ let pexp_ident'const view value =
   | _ -> View.error
 
 let pexp_constant'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_constant arg -> view arg
+  | _ -> View.error
+
+let econstant'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -981,6 +1301,16 @@ let pexp_constant'const view value =
   | _ -> View.error
 
 let pexp_let'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_let (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let elet'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -997,6 +1327,16 @@ let pexp_let'const view value =
   | _ -> View.error
 
 let pexp_function'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_function arg -> view arg
+  | _ -> View.error
+
+let efunction'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1013,6 +1353,16 @@ let pexp_function'const view value =
   | _ -> View.error
 
 let pexp_fun'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_fun (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
+  | _ -> View.error
+
+let efun'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1029,6 +1379,16 @@ let pexp_fun'const view value =
   | _ -> View.error
 
 let pexp_apply'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_apply (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let eapply'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1045,6 +1405,16 @@ let pexp_apply'const view value =
   | _ -> View.error
 
 let pexp_match'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_match (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ematch'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1061,6 +1431,16 @@ let pexp_match'const view value =
   | _ -> View.error
 
 let pexp_try'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_try (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let etry'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1077,6 +1457,16 @@ let pexp_try'const view value =
   | _ -> View.error
 
 let pexp_tuple'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_tuple arg -> view arg
+  | _ -> View.error
+
+let etuple'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1093,6 +1483,16 @@ let pexp_tuple'const view value =
   | _ -> View.error
 
 let pexp_construct'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_construct (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let econstruct'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1109,6 +1509,16 @@ let pexp_construct'const view value =
   | _ -> View.error
 
 let pexp_variant'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_variant (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let evariant'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1125,6 +1535,16 @@ let pexp_variant'const view value =
   | _ -> View.error
 
 let pexp_record'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_record (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let erecord'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1141,6 +1561,16 @@ let pexp_record'const view value =
   | _ -> View.error
 
 let pexp_field'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_field (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let efield'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1157,6 +1587,16 @@ let pexp_field'const view value =
   | _ -> View.error
 
 let pexp_setfield'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_setfield (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let esetfield'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1173,6 +1613,16 @@ let pexp_setfield'const view value =
   | _ -> View.error
 
 let pexp_array'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_array arg -> view arg
+  | _ -> View.error
+
+let earray'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1189,6 +1639,16 @@ let pexp_array'const view value =
   | _ -> View.error
 
 let pexp_ifthenelse'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_ifthenelse (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let eifthenelse'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1205,6 +1665,16 @@ let pexp_ifthenelse'const view value =
   | _ -> View.error
 
 let pexp_sequence'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_sequence (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let esequence'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1221,6 +1691,16 @@ let pexp_sequence'const view value =
   | _ -> View.error
 
 let pexp_while'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_while (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ewhile'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1237,6 +1717,16 @@ let pexp_while'const view value =
   | _ -> View.error
 
 let pexp_for'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_for (arg0, arg1, arg2, arg3, arg4) -> view (arg0, arg1, arg2, arg3, arg4)
+  | _ -> View.error
+
+let efor'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1253,6 +1743,16 @@ let pexp_for'const view value =
   | _ -> View.error
 
 let pexp_constraint'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_constraint (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let econstraint'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1269,6 +1769,16 @@ let pexp_constraint'const view value =
   | _ -> View.error
 
 let pexp_coerce'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_coerce (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let ecoerce'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1285,6 +1795,16 @@ let pexp_coerce'const view value =
   | _ -> View.error
 
 let pexp_send'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_send (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let esend'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1301,6 +1821,16 @@ let pexp_send'const view value =
   | _ -> View.error
 
 let pexp_new'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_new arg -> view arg
+  | _ -> View.error
+
+let enew'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1317,6 +1847,16 @@ let pexp_new'const view value =
   | _ -> View.error
 
 let pexp_setinstvar'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_setinstvar (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let esetinstvar'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1333,6 +1873,16 @@ let pexp_setinstvar'const view value =
   | _ -> View.error
 
 let pexp_override'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_override arg -> view arg
+  | _ -> View.error
+
+let eoverride'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1349,6 +1899,16 @@ let pexp_override'const view value =
   | _ -> View.error
 
 let pexp_letmodule'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_letmodule (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let eletmodule'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1365,6 +1925,16 @@ let pexp_letmodule'const view value =
   | _ -> View.error
 
 let pexp_letexception'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_letexception (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let eletexception'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1381,6 +1951,16 @@ let pexp_letexception'const view value =
   | _ -> View.error
 
 let pexp_assert'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_assert arg -> view arg
+  | _ -> View.error
+
+let eassert'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1397,6 +1977,16 @@ let pexp_assert'const view value =
   | _ -> View.error
 
 let pexp_lazy'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_lazy arg -> view arg
+  | _ -> View.error
+
+let elazy'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1413,6 +2003,16 @@ let pexp_lazy'const view value =
   | _ -> View.error
 
 let pexp_poly'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_poly (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let epoly'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1429,6 +2029,16 @@ let pexp_poly'const view value =
   | _ -> View.error
 
 let pexp_object'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_object arg -> view arg
+  | _ -> View.error
+
+let eobject'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1445,6 +2055,16 @@ let pexp_object'const view value =
   | _ -> View.error
 
 let pexp_newtype'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_newtype (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let enewtype'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1461,6 +2081,16 @@ let pexp_newtype'const view value =
   | _ -> View.error
 
 let pexp_pack'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_pack arg -> view arg
+  | _ -> View.error
+
+let epack'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1477,6 +2107,16 @@ let pexp_pack'const view value =
   | _ -> View.error
 
 let pexp_open'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let eopen'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1493,6 +2133,16 @@ let pexp_open'const view value =
   | _ -> View.error
 
 let pexp_extension'const view value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_extension arg -> view arg
+  | _ -> View.error
+
+let eextension'const view value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1509,6 +2159,16 @@ let pexp_extension'const view value =
   | _ -> View.error
 
 let pexp_unreachable'const value =
+  let concrete =
+    match Expression_desc.to_concrete value with
+    | None -> conversion_failed "expression_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Expression_desc.Pexp_unreachable -> View.ok
+  | _ -> View.error
+
+let eunreachable'const value =
   let parent_concrete =
     match Expression.to_concrete value with
     | None -> conversion_failed "expression"
@@ -1909,6 +2569,16 @@ let pcty_attributes'match view value =
   view concrete.Class_type.pcty_attributes
 
 let pcty_constr'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_constr (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ctconstr'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -1925,6 +2595,16 @@ let pcty_constr'const view value =
   | _ -> View.error
 
 let pcty_signature'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_signature arg -> view arg
+  | _ -> View.error
+
+let ctsignature'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -1941,6 +2621,16 @@ let pcty_signature'const view value =
   | _ -> View.error
 
 let pcty_arrow'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_arrow (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let ctarrow'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -1957,6 +2647,16 @@ let pcty_arrow'const view value =
   | _ -> View.error
 
 let pcty_extension'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_extension arg -> view arg
+  | _ -> View.error
+
+let ctextension'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -1973,6 +2673,16 @@ let pcty_extension'const view value =
   | _ -> View.error
 
 let pcty_open'const view value =
+  let concrete =
+    match Class_type_desc.to_concrete value with
+    | None -> conversion_failed "class_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_desc.Pcty_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let ctopen'const view value =
   let parent_concrete =
     match Class_type.to_concrete value with
     | None -> conversion_failed "class_type"
@@ -2029,6 +2739,16 @@ let pctf_attributes'match view value =
   view concrete.Class_type_field.pctf_attributes
 
 let pctf_inherit'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_inherit arg -> view arg
+  | _ -> View.error
+
+let ctfinherit'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -2045,6 +2765,16 @@ let pctf_inherit'const view value =
   | _ -> View.error
 
 let pctf_val'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_val arg -> view arg
+  | _ -> View.error
+
+let ctfval'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -2061,6 +2791,16 @@ let pctf_val'const view value =
   | _ -> View.error
 
 let pctf_method'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_method arg -> view arg
+  | _ -> View.error
+
+let ctfmethod'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -2077,6 +2817,16 @@ let pctf_method'const view value =
   | _ -> View.error
 
 let pctf_constraint'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_constraint arg -> view arg
+  | _ -> View.error
+
+let ctfconstraint'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -2093,6 +2843,16 @@ let pctf_constraint'const view value =
   | _ -> View.error
 
 let pctf_attribute'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_attribute arg -> view arg
+  | _ -> View.error
+
+let ctfattribute'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -2109,6 +2869,16 @@ let pctf_attribute'const view value =
   | _ -> View.error
 
 let pctf_extension'const view value =
+  let concrete =
+    match Class_type_field_desc.to_concrete value with
+    | None -> conversion_failed "class_type_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_type_field_desc.Pctf_extension arg -> view arg
+  | _ -> View.error
+
+let ctfextension'const view value =
   let parent_concrete =
     match Class_type_field.to_concrete value with
     | None -> conversion_failed "class_type_field"
@@ -2213,6 +2983,16 @@ let pcl_attributes'match view value =
   view concrete.Class_expr.pcl_attributes
 
 let pcl_constr'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_constr (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ceconstr'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -2229,6 +3009,16 @@ let pcl_constr'const view value =
   | _ -> View.error
 
 let pcl_structure'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_structure arg -> view arg
+  | _ -> View.error
+
+let cestructure'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -2245,6 +3035,16 @@ let pcl_structure'const view value =
   | _ -> View.error
 
 let pcl_fun'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_fun (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
+  | _ -> View.error
+
+let cefun'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -2261,6 +3061,16 @@ let pcl_fun'const view value =
   | _ -> View.error
 
 let pcl_apply'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_apply (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ceapply'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -2277,6 +3087,16 @@ let pcl_apply'const view value =
   | _ -> View.error
 
 let pcl_let'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_let (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let celet'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -2293,6 +3113,16 @@ let pcl_let'const view value =
   | _ -> View.error
 
 let pcl_constraint'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_constraint (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let ceconstraint'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -2309,6 +3139,16 @@ let pcl_constraint'const view value =
   | _ -> View.error
 
 let pcl_extension'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_extension arg -> view arg
+  | _ -> View.error
+
+let ceextension'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -2325,6 +3165,16 @@ let pcl_extension'const view value =
   | _ -> View.error
 
 let pcl_open'const view value =
+  let concrete =
+    match Class_expr_desc.to_concrete value with
+    | None -> conversion_failed "class_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_expr_desc.Pcl_open (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let ceopen'const view value =
   let parent_concrete =
     match Class_expr.to_concrete value with
     | None -> conversion_failed "class_expr"
@@ -2381,6 +3231,16 @@ let pcf_attributes'match view value =
   view concrete.Class_field.pcf_attributes
 
 let pcf_inherit'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_inherit (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let cfinherit'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -2397,6 +3257,16 @@ let pcf_inherit'const view value =
   | _ -> View.error
 
 let pcf_val'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_val arg -> view arg
+  | _ -> View.error
+
+let cfval'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -2413,6 +3283,16 @@ let pcf_val'const view value =
   | _ -> View.error
 
 let pcf_method'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_method arg -> view arg
+  | _ -> View.error
+
+let cfmethod'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -2429,6 +3309,16 @@ let pcf_method'const view value =
   | _ -> View.error
 
 let pcf_constraint'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_constraint arg -> view arg
+  | _ -> View.error
+
+let cfconstraint'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -2445,6 +3335,16 @@ let pcf_constraint'const view value =
   | _ -> View.error
 
 let pcf_initializer'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_initializer arg -> view arg
+  | _ -> View.error
+
+let cfinitializer'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -2461,6 +3361,16 @@ let pcf_initializer'const view value =
   | _ -> View.error
 
 let pcf_attribute'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_attribute arg -> view arg
+  | _ -> View.error
+
+let cfattribute'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -2477,6 +3387,16 @@ let pcf_attribute'const view value =
   | _ -> View.error
 
 let pcf_extension'const view value =
+  let concrete =
+    match Class_field_desc.to_concrete value with
+    | None -> conversion_failed "class_field_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Class_field_desc.Pcf_extension arg -> view arg
+  | _ -> View.error
+
+let cfextension'const view value =
   let parent_concrete =
     match Class_field.to_concrete value with
     | None -> conversion_failed "class_field"
@@ -2545,6 +3465,16 @@ let pmty_attributes'match view value =
   view concrete.Module_type.pmty_attributes
 
 let pmty_ident'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_ident arg -> view arg
+  | _ -> View.error
+
+let mtident'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -2561,6 +3491,16 @@ let pmty_ident'const view value =
   | _ -> View.error
 
 let pmty_signature'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_signature arg -> view arg
+  | _ -> View.error
+
+let mtsignature'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -2577,6 +3517,16 @@ let pmty_signature'const view value =
   | _ -> View.error
 
 let pmty_functor'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_functor (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let mtfunctor'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -2593,6 +3543,16 @@ let pmty_functor'const view value =
   | _ -> View.error
 
 let pmty_with'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_with (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let mtwith'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -2609,6 +3569,16 @@ let pmty_with'const view value =
   | _ -> View.error
 
 let pmty_typeof'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_typeof arg -> view arg
+  | _ -> View.error
+
+let mttypeof'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -2625,6 +3595,16 @@ let pmty_typeof'const view value =
   | _ -> View.error
 
 let pmty_extension'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_extension arg -> view arg
+  | _ -> View.error
+
+let mtextension'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -2641,6 +3621,16 @@ let pmty_extension'const view value =
   | _ -> View.error
 
 let pmty_alias'const view value =
+  let concrete =
+    match Module_type_desc.to_concrete value with
+    | None -> conversion_failed "module_type_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_type_desc.Pmty_alias arg -> view arg
+  | _ -> View.error
+
+let mtalias'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
     | None -> conversion_failed "module_type"
@@ -2681,6 +3671,16 @@ let psig_loc'match view value =
   view concrete.Signature_item.psig_loc
 
 let psig_value'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_value arg -> view arg
+  | _ -> View.error
+
+let sigvalue'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2697,6 +3697,16 @@ let psig_value'const view value =
   | _ -> View.error
 
 let psig_type'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_type (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let sigtype'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2713,6 +3723,16 @@ let psig_type'const view value =
   | _ -> View.error
 
 let psig_typext'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_typext arg -> view arg
+  | _ -> View.error
+
+let sigtypext'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2729,6 +3749,16 @@ let psig_typext'const view value =
   | _ -> View.error
 
 let psig_exception'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_exception arg -> view arg
+  | _ -> View.error
+
+let sigexception'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2745,6 +3775,16 @@ let psig_exception'const view value =
   | _ -> View.error
 
 let psig_module'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_module arg -> view arg
+  | _ -> View.error
+
+let sigmodule'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2761,6 +3801,16 @@ let psig_module'const view value =
   | _ -> View.error
 
 let psig_recmodule'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_recmodule arg -> view arg
+  | _ -> View.error
+
+let sigrecmodule'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2777,6 +3827,16 @@ let psig_recmodule'const view value =
   | _ -> View.error
 
 let psig_modtype'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_modtype arg -> view arg
+  | _ -> View.error
+
+let sigmodtype'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2793,6 +3853,16 @@ let psig_modtype'const view value =
   | _ -> View.error
 
 let psig_open'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_open arg -> view arg
+  | _ -> View.error
+
+let sigopen'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2809,6 +3879,16 @@ let psig_open'const view value =
   | _ -> View.error
 
 let psig_include'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_include arg -> view arg
+  | _ -> View.error
+
+let siginclude'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2825,6 +3905,16 @@ let psig_include'const view value =
   | _ -> View.error
 
 let psig_class'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_class arg -> view arg
+  | _ -> View.error
+
+let sigclass'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2841,6 +3931,16 @@ let psig_class'const view value =
   | _ -> View.error
 
 let psig_class_type'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_class_type arg -> view arg
+  | _ -> View.error
+
+let sigclass_type'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2857,6 +3957,16 @@ let psig_class_type'const view value =
   | _ -> View.error
 
 let psig_attribute'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_attribute arg -> view arg
+  | _ -> View.error
+
+let sigattribute'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -2873,6 +3983,16 @@ let psig_attribute'const view value =
   | _ -> View.error
 
 let psig_extension'const view value =
+  let concrete =
+    match Signature_item_desc.to_concrete value with
+    | None -> conversion_failed "signature_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Signature_item_desc.Psig_extension (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let sigextension'const view value =
   let parent_concrete =
     match Signature_item.to_concrete value with
     | None -> conversion_failed "signature_item"
@@ -3089,6 +4209,16 @@ let pmod_attributes'match view value =
   view concrete.Module_expr.pmod_attributes
 
 let pmod_ident'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_ident arg -> view arg
+  | _ -> View.error
+
+let meident'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -3105,6 +4235,16 @@ let pmod_ident'const view value =
   | _ -> View.error
 
 let pmod_structure'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_structure arg -> view arg
+  | _ -> View.error
+
+let mestructure'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -3121,6 +4261,16 @@ let pmod_structure'const view value =
   | _ -> View.error
 
 let pmod_functor'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_functor (arg0, arg1, arg2) -> view (arg0, arg1, arg2)
+  | _ -> View.error
+
+let mefunctor'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -3137,6 +4287,16 @@ let pmod_functor'const view value =
   | _ -> View.error
 
 let pmod_apply'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_apply (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let meapply'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -3153,6 +4313,16 @@ let pmod_apply'const view value =
   | _ -> View.error
 
 let pmod_constraint'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_constraint (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let meconstraint'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -3169,6 +4339,16 @@ let pmod_constraint'const view value =
   | _ -> View.error
 
 let pmod_unpack'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_unpack arg -> view arg
+  | _ -> View.error
+
+let meunpack'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -3185,6 +4365,16 @@ let pmod_unpack'const view value =
   | _ -> View.error
 
 let pmod_extension'const view value =
+  let concrete =
+    match Module_expr_desc.to_concrete value with
+    | None -> conversion_failed "module_expr_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Module_expr_desc.Pmod_extension arg -> view arg
+  | _ -> View.error
+
+let meextension'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
     | None -> conversion_failed "module_expr"
@@ -3225,6 +4415,16 @@ let pstr_loc'match view value =
   view concrete.Structure_item.pstr_loc
 
 let pstr_eval'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_eval (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let streval'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3241,6 +4441,16 @@ let pstr_eval'const view value =
   | _ -> View.error
 
 let pstr_value'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_value (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let strvalue'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3257,6 +4467,16 @@ let pstr_value'const view value =
   | _ -> View.error
 
 let pstr_primitive'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_primitive arg -> view arg
+  | _ -> View.error
+
+let strprimitive'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3273,6 +4493,16 @@ let pstr_primitive'const view value =
   | _ -> View.error
 
 let pstr_type'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_type (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let strtype'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3289,6 +4519,16 @@ let pstr_type'const view value =
   | _ -> View.error
 
 let pstr_typext'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_typext arg -> view arg
+  | _ -> View.error
+
+let strtypext'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3305,6 +4545,16 @@ let pstr_typext'const view value =
   | _ -> View.error
 
 let pstr_exception'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_exception arg -> view arg
+  | _ -> View.error
+
+let strexception'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3321,6 +4571,16 @@ let pstr_exception'const view value =
   | _ -> View.error
 
 let pstr_module'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_module arg -> view arg
+  | _ -> View.error
+
+let strmodule'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3337,6 +4597,16 @@ let pstr_module'const view value =
   | _ -> View.error
 
 let pstr_recmodule'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_recmodule arg -> view arg
+  | _ -> View.error
+
+let strrecmodule'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3353,6 +4623,16 @@ let pstr_recmodule'const view value =
   | _ -> View.error
 
 let pstr_modtype'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_modtype arg -> view arg
+  | _ -> View.error
+
+let strmodtype'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3369,6 +4649,16 @@ let pstr_modtype'const view value =
   | _ -> View.error
 
 let pstr_open'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_open arg -> view arg
+  | _ -> View.error
+
+let stropen'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3385,6 +4675,16 @@ let pstr_open'const view value =
   | _ -> View.error
 
 let pstr_class'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_class arg -> view arg
+  | _ -> View.error
+
+let strclass'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3401,6 +4701,16 @@ let pstr_class'const view value =
   | _ -> View.error
 
 let pstr_class_type'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_class_type arg -> view arg
+  | _ -> View.error
+
+let strclass_type'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3417,6 +4727,16 @@ let pstr_class_type'const view value =
   | _ -> View.error
 
 let pstr_include'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_include arg -> view arg
+  | _ -> View.error
+
+let strinclude'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3433,6 +4753,16 @@ let pstr_include'const view value =
   | _ -> View.error
 
 let pstr_attribute'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_attribute arg -> view arg
+  | _ -> View.error
+
+let strattribute'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"
@@ -3449,6 +4779,16 @@ let pstr_attribute'const view value =
   | _ -> View.error
 
 let pstr_extension'const view value =
+  let concrete =
+    match Structure_item_desc.to_concrete value with
+    | None -> conversion_failed "structure_item_desc"
+    | Some n -> n
+  in
+  match concrete with
+  | Structure_item_desc.Pstr_extension (arg0, arg1) -> view (arg0, arg1)
+  | _ -> View.error
+
+let strextension'const view value =
   let parent_concrete =
     match Structure_item.to_concrete value with
     | None -> conversion_failed "structure_item"

--- a/ast/viewer_v4_07.mli
+++ b/ast/viewer_v4_07.mli
@@ -4,8 +4,11 @@ open Viewlib
 open Versions
 open V4_07
 include module type of Viewer_common
+
 val lident'const : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+
 val ldot'const : ((Longident.t * string), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+
 val lapply'const : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
 val longident_loc'const: (Longident.t Astlib.Loc.t, 'i, 'o) View.t -> (Longident_loc.t, 'i, 'o) View.t
 
@@ -38,7 +41,9 @@ val closed'const : (Closed_flag.t, 'a, 'a) View.t
 val open'const : (Closed_flag.t, 'a, 'a) View.t
 
 val nolabel'const : (Arg_label.t, 'a, 'a) View.t
+
 val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+
 val optional'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
 
 val covariant'const : (Variance.t, 'a, 'a) View.t
@@ -46,16 +51,24 @@ val covariant'const : (Variance.t, 'a, 'a) View.t
 val contravariant'const : (Variance.t, 'a, 'a) View.t
 
 val invariant'const : (Variance.t, 'a, 'a) View.t
+
 val pconst_integer'const : ((string * char option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+
 val pconst_char'const : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+
 val pconst_string'const : ((string * string option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+
 val pconst_float'const : ((string * char option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
 val attribute'const: ((string Astlib.Loc.t * Payload.t), 'i, 'o) View.t -> (Attribute.t, 'i, 'o) View.t
 val extension'const: ((string Astlib.Loc.t * Payload.t), 'i, 'o) View.t -> (Extension.t, 'i, 'o) View.t
 val attributes'const: (Attribute.t list, 'i, 'o) View.t -> (Attributes.t, 'i, 'o) View.t
+
 val pstr'const : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+
 val psig'const : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+
 val ptyp'const : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+
 val ppat'const : ((Pattern.t * Expression.t option), 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
 
 val ptyp_desc'match : (Core_type_desc.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
@@ -64,22 +77,61 @@ val ptyp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o)
 
 val ptyp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 
-val ptyp_any'const : (Core_type.t, 'a, 'a) View.t
-val ptyp_var'const : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_arrow'const : ((Arg_label.t * Core_type.t * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_object'const : ((Object_field.t list * Closed_flag.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_class'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_alias'const : ((Core_type.t * string), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_variant'const : ((Row_field.t list * Closed_flag.t * string list option), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_poly'const : ((string Astlib.Loc.t list * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ptyp_any'const : (Core_type_desc.t, 'a, 'a) View.t
+
+val tany'const : (Core_type.t, 'a, 'a) View.t
+
+val ptyp_var'const : (string, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tvar'const : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_arrow'const : ((Arg_label.t * Core_type.t * Core_type.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tarrow'const : ((Arg_label.t * Core_type.t * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val ttuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tconstr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_object'const : ((Object_field.t list * Closed_flag.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tobject'const : ((Object_field.t list * Closed_flag.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_class'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tclass'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_alias'const : ((Core_type.t * string), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val talias'const : ((Core_type.t * string), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_variant'const : ((Row_field.t list * Closed_flag.t * string list option), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tvariant'const : ((Row_field.t list * Closed_flag.t * string list option), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_poly'const : ((string Astlib.Loc.t list * Core_type.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tpoly'const : ((string Astlib.Loc.t list * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val tpackage'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+
+val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+
+val textension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val package_type'const: ((Longident_loc.t * (Longident_loc.t * Core_type.t) list), 'i, 'o) View.t -> (Package_type.t, 'i, 'o) View.t
+
 val rtag'const : ((string Astlib.Loc.t * Attributes.t * bool * Core_type.t list), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+
 val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+
 val otag'const : ((string Astlib.Loc.t * Attributes.t * Core_type.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+
 val oinherit'const : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
 
 val ppat_desc'match : (Pattern_desc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
@@ -88,67 +140,227 @@ val ppat_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) V
 
 val ppat_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
-val ppat_any'const : (Pattern.t, 'a, 'a) View.t
-val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_alias'const : ((Pattern.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_constant'const : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_construct'const : ((Longident_loc.t * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_variant'const : ((string * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_record'const : (((Longident_loc.t * Pattern.t) list * Closed_flag.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_constraint'const : ((Pattern.t * Core_type.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_type'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_lazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_exception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_extension'const : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_open'const : ((Longident_loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ppat_any'const : (Pattern_desc.t, 'a, 'a) View.t
+
+val pany'const : (Pattern.t, 'a, 'a) View.t
+
+val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pvar'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_alias'const : ((Pattern.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val palias'const : ((Pattern.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_constant'const : (Constant.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pconstant'const : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pinterval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val ptuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_construct'const : ((Longident_loc.t * Pattern.t option), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pconstruct'const : ((Longident_loc.t * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_variant'const : ((string * Pattern.t option), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pvariant'const : ((string * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_record'const : (((Longident_loc.t * Pattern.t) list * Closed_flag.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val precord'const : (((Longident_loc.t * Pattern.t) list * Closed_flag.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val parray'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val por'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_constraint'const : ((Pattern.t * Core_type.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pconstraint'const : ((Pattern.t * Core_type.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_type'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val ptype'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_lazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val plazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val punpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_exception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pexception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_extension'const : (Extension.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val pextension'const : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+
+val ppat_open'const : ((Longident_loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+
+val popen'const : ((Longident_loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 
 val pexp_desc'match : (Expression_desc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
 val pexp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
 val pexp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_constant'const : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_let'const : ((Rec_flag.t * Value_binding.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_function'const : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_fun'const : ((Arg_label.t * Expression.t option * Pattern.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_apply'const : ((Expression.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_match'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_try'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_construct'const : ((Longident_loc.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_variant'const : ((string * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_record'const : (((Longident_loc.t * Expression.t) list * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_field'const : ((Expression.t * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_array'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_ifthenelse'const : ((Expression.t * Expression.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_sequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_while'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_for'const : ((Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_constraint'const : ((Expression.t * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_coerce'const : ((Expression.t * Core_type.t option * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_send'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_setinstvar'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_override'const : ((string Astlib.Loc.t * Expression.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_letmodule'const : ((string Astlib.Loc.t * Module_expr.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_letexception'const : ((Extension_constructor.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_lazy'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_poly'const : ((Expression.t * Core_type.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_object'const : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_newtype'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_pack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_open'const : ((Override_flag.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_extension'const : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 
-val pexp_unreachable'const : (Expression.t, 'a, 'a) View.t
+val pexp_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_constant'const : (Constant.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val econstant'const : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_let'const : ((Rec_flag.t * Value_binding.t list * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val elet'const : ((Rec_flag.t * Value_binding.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_function'const : (Case.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val efunction'const : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_fun'const : ((Arg_label.t * Expression.t option * Pattern.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val efun'const : ((Arg_label.t * Expression.t option * Pattern.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_apply'const : ((Expression.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eapply'const : ((Expression.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_match'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val ematch'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_try'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val etry'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val etuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_construct'const : ((Longident_loc.t * Expression.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val econstruct'const : ((Longident_loc.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_variant'const : ((string * Expression.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val evariant'const : ((string * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_record'const : (((Longident_loc.t * Expression.t) list * Expression.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val erecord'const : (((Longident_loc.t * Expression.t) list * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_field'const : ((Expression.t * Longident_loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val efield'const : ((Expression.t * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val esetfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_array'const : (Expression.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val earray'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_ifthenelse'const : ((Expression.t * Expression.t * Expression.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eifthenelse'const : ((Expression.t * Expression.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_sequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val esequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_while'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val ewhile'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_for'const : ((Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val efor'const : ((Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_constraint'const : ((Expression.t * Core_type.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val econstraint'const : ((Expression.t * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_coerce'const : ((Expression.t * Core_type.t option * Core_type.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val ecoerce'const : ((Expression.t * Core_type.t option * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_send'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val esend'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val enew'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_setinstvar'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val esetinstvar'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_override'const : ((string Astlib.Loc.t * Expression.t) list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eoverride'const : ((string Astlib.Loc.t * Expression.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_letmodule'const : ((string Astlib.Loc.t * Module_expr.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eletmodule'const : ((string Astlib.Loc.t * Module_expr.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_letexception'const : ((Extension_constructor.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eletexception'const : ((Extension_constructor.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eassert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_lazy'const : (Expression.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val elazy'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_poly'const : ((Expression.t * Core_type.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val epoly'const : ((Expression.t * Core_type.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_object'const : (Class_structure.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eobject'const : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_newtype'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val enewtype'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_pack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val epack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_open'const : ((Override_flag.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eopen'const : ((Override_flag.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_extension'const : (Extension.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+
+val eextension'const : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+
+val pexp_unreachable'const : (Expression_desc.t, 'a, 'a) View.t
+
+val eunreachable'const : (Expression.t, 'a, 'a) View.t
 
 val pc_lhs'match : (Pattern.t, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
 
@@ -183,7 +395,9 @@ val ptype_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Type_declaration.
 val ptype_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
 
 val ptype_abstract'const : (Type_kind.t, 'a, 'a) View.t
+
 val ptype_variant'const : (Constructor_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+
 val ptype_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
 
 val ptype_open'const : (Type_kind.t, 'a, 'a) View.t
@@ -207,7 +421,9 @@ val pcd_res'match : (Core_type.t option, 'i, 'o) View.t -> (Constructor_declarat
 val pcd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
 
 val pcd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+
 val pcstr_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+
 val pcstr_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
 
 val ptyext_path'match : (Longident_loc.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
@@ -227,7 +443,9 @@ val pext_kind'match : (Extension_constructor_kind.t, 'i, 'o) View.t -> (Extensio
 val pext_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
 
 val pext_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
+
 val pext_decl'const : ((Constructor_arguments.t * Core_type.t option), 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+
 val pext_rebind'const : (Longident_loc.t, 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
 
 val pcty_desc'match : (Class_type_desc.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
@@ -235,11 +453,26 @@ val pcty_desc'match : (Class_type_desc.t, 'i, 'o) View.t -> (Class_type.t, 'i, '
 val pcty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
 val pcty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-val pcty_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-val pcty_signature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-val pcty_arrow'const : ((Arg_label.t * Core_type.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-val pcty_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
-val pcty_open'const : ((Override_flag.t * Longident_loc.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctconstr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_signature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctsignature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_arrow'const : ((Arg_label.t * Core_type.t * Class_type.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctarrow'const : ((Arg_label.t * Core_type.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctextension'const : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+
+val pcty_open'const : ((Override_flag.t * Longident_loc.t * Class_type.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+
+val ctopen'const : ((Override_flag.t * Longident_loc.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
 
 val pcsig_self'match : (Core_type.t, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
 
@@ -250,12 +483,30 @@ val pctf_desc'match : (Class_type_field_desc.t, 'i, 'o) View.t -> (Class_type_fi
 val pctf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 
 val pctf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_val'const : ((string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_method'const : ((string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfinherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_val'const : ((string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfval'const : ((string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_method'const : ((string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfmethod'const : ((string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfconstraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfattribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+
+val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+
+val ctfextension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 
 val pci_virt'match : (Virtual_flag.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
 
@@ -276,14 +527,38 @@ val pcl_desc'match : (Class_expr_desc.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o
 val pcl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
 val pcl_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_structure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_fun'const : ((Arg_label.t * Expression.t option * Pattern.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_apply'const : ((Class_expr.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_let'const : ((Rec_flag.t * Value_binding.t list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_constraint'const : ((Class_expr.t * Class_type.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val pcl_open'const : ((Override_flag.t * Longident_loc.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceconstr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_structure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val cestructure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_fun'const : ((Arg_label.t * Expression.t option * Pattern.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val cefun'const : ((Arg_label.t * Expression.t option * Pattern.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_apply'const : ((Class_expr.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceapply'const : ((Class_expr.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_let'const : ((Rec_flag.t * Value_binding.t list * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val celet'const : ((Rec_flag.t * Value_binding.t list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_constraint'const : ((Class_expr.t * Class_type.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceconstraint'const : ((Class_expr.t * Class_type.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceextension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+
+val pcl_open'const : ((Override_flag.t * Longident_loc.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+
+val ceopen'const : ((Override_flag.t * Longident_loc.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
 val pcstr_self'match : (Pattern.t, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
 
@@ -294,14 +569,37 @@ val pcf_desc'match : (Class_field_desc.t, 'i, 'o) View.t -> (Class_field.t, 'i, 
 val pcf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 
 val pcf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_inherit'const : ((Override_flag.t * Class_expr.t * string Astlib.Loc.t option), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_val'const : ((string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_method'const : ((string Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_inherit'const : ((Override_flag.t * Class_expr.t * string Astlib.Loc.t option), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfinherit'const : ((Override_flag.t * Class_expr.t * string Astlib.Loc.t option), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_val'const : ((string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfval'const : ((string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_method'const : ((string Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfmethod'const : ((string Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfconstraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfinitializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfattribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
+val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+
+val cfextension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+
 val cfk_virtual'const : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+
 val cfk_concrete'const : ((Override_flag.t * Expression.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
 val class_declaration'const: (Class_expr.t Class_infos.t, 'i, 'o) View.t -> (Class_declaration.t, 'i, 'o) View.t
 
@@ -310,31 +608,91 @@ val pmty_desc'match : (Module_type_desc.t, 'i, 'o) View.t -> (Module_type.t, 'i,
 val pmty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
 val pmty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_signature'const : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_functor'const : ((string Astlib.Loc.t * Module_type.t option * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_with'const : ((Module_type.t * With_constraint.t list), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_signature'const : (Signature.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtsignature'const : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_functor'const : ((string Astlib.Loc.t * Module_type.t option * Module_type.t), 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtfunctor'const : ((string Astlib.Loc.t * Module_type.t option * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_with'const : ((Module_type.t * With_constraint.t list), 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtwith'const : ((Module_type.t * With_constraint.t list), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mttypeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtextension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+
+val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+
+val mtalias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 val signature'const: (Signature_item.t list, 'i, 'o) View.t -> (Signature.t, 'i, 'o) View.t
 
 val psig_desc'match : (Signature_item_desc.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
 val psig_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_value'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_type'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_module'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_recmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_open'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_include'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_class'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val psig_extension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_value'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigvalue'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_type'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigtype'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigtypext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigexception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_module'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigmodule'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_recmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigrecmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigmodtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_open'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigopen'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_include'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val siginclude'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_class'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigclass'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigclass_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigattribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+
+val psig_extension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+
+val sigextension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
 val pmd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
 
@@ -367,9 +725,13 @@ val pincl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node Include_inf
 val pincl_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
 val include_description'const: (Module_type.t Include_infos.t, 'i, 'o) View.t -> (Include_description.t, 'i, 'o) View.t
 val include_declaration'const: (Module_expr.t Include_infos.t, 'i, 'o) View.t -> (Include_declaration.t, 'i, 'o) View.t
+
 val pwith_type'const : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+
 val pwith_module'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+
 val pwith_typesubst'const : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+
 val pwith_modsubst'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
 
 val pmod_desc'match : (Module_expr_desc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
@@ -377,33 +739,99 @@ val pmod_desc'match : (Module_expr_desc.t, 'i, 'o) View.t -> (Module_expr.t, 'i,
 val pmod_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 
 val pmod_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_structure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_functor'const : ((string Astlib.Loc.t * Module_type.t option * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_apply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_constraint'const : ((Module_expr.t * Module_type.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_structure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val mestructure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_functor'const : ((string Astlib.Loc.t * Module_type.t option * Module_expr.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val mefunctor'const : ((string Astlib.Loc.t * Module_type.t option * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_apply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meapply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_constraint'const : ((Module_expr.t * Module_type.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meconstraint'const : ((Module_expr.t * Module_type.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meunpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+
+val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+
+val meextension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 val structure'const: (Structure_item.t list, 'i, 'o) View.t -> (Structure.t, 'i, 'o) View.t
 
 val pstr_desc'match : (Structure_item_desc.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 
 val pstr_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_eval'const : ((Expression.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_value'const : ((Rec_flag.t * Value_binding.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_primitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_type'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_module'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_recmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_open'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_class'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_include'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val pstr_extension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_eval'const : ((Expression.t * Attributes.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val streval'const : ((Expression.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_value'const : ((Rec_flag.t * Value_binding.t list), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strvalue'const : ((Rec_flag.t * Value_binding.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_primitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strprimitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_type'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strtype'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strtypext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strexception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_module'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strmodule'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_recmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strrecmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strmodtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_open'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val stropen'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_class'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strclass'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strclass_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_include'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strinclude'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strattribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+
+val pstr_extension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+
+val strextension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 
 val pvb_pat'match : (Pattern.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
 
@@ -420,12 +848,18 @@ val pmb_expr'match : (Module_expr.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o
 val pmb_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
 
 val pmb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
+
 val ptop_def'const : (Structure.t, 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+
 val ptop_dir'const : ((string * Directive_argument.t), 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
 
 val pdir_none'const : (Directive_argument.t, 'a, 'a) View.t
+
 val pdir_string'const : (string, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+
 val pdir_int'const : ((string * char option), 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+
 val pdir_ident'const : (Longident.t, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+
 val pdir_bool'const : (bool, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
 (*$*)

--- a/bootstrap/test/test_ppx_bootstrap.ml
+++ b/bootstrap/test/test_ppx_bootstrap.ml
@@ -13,5 +13,5 @@ let sig_  = [%sig: module M : S type t = unit]
 let f_view x =
   let open Ppx_ast.V4_07 in
   match%view x with
-  | Pexp_constraint (expr, core_type) -> Some (expr, core_type)
+  | Econstraint (expr, core_type) -> Some (expr, core_type)
   | _ -> None

--- a/ppx_view/test/test.ml
+++ b/ppx_view/test/test.ml
@@ -25,7 +25,7 @@ let class_infos =
 
 let%expect_test "match failure" =
   begin try match%view int 3 with
-    | Pexp_constant (Pconst_integer ("2", _)) ->
+    | Econstant (Pconst_integer ("2", _)) ->
       print_string "matched"
   with e ->
     print_string (Printexc.to_string e)
@@ -33,9 +33,9 @@ let%expect_test "match failure" =
 
 let%expect_test "match simple" =
   let match_3 = function%view
-    | Pexp_constant (Pconst_integer ("3", _)) ->
+    | Econstant (Pconst_integer ("3", _)) ->
       print_string "3"
-    | Pexp_tuple _ ->
+    | Etuple _ ->
       print_string "tuple"
     | _ ->
       print_string "KO"
@@ -46,7 +46,7 @@ let%expect_test "match simple" =
 
 let%expect_test "match with guard" =
   let match_3 = function%view
-    | Pexp_constant (Pconst_integer (s, _)) when s = "3" ->
+    | Econstant (Pconst_integer (s, _)) when s = "3" ->
       print_string "3"
     | _ ->
       print_string "KO"
@@ -57,8 +57,8 @@ let%expect_test "match with guard" =
 
 let%expect_test "match or-pattern" =
   let match_3 = function%view
-    | Pexp_constant (Pconst_integer ("3",  _))
-    | Pexp_constant (Pconst_float   ("3.", _)) ->
+    | Econstant (Pconst_integer ("3",  _))
+    | Econstant (Pconst_float   ("3.", _)) ->
       print_string "3"
     | _ ->
       print_string "KO"
@@ -71,8 +71,8 @@ let%expect_test "match or-pattern" =
 
 let%expect_test "match or-pattern with variable" =
   let match_3xyz = function%view
-    | Pexp_constant (Pconst_integer (s, _))
-    | Pexp_constant (Pconst_float   (s, _)) when s.[0] = '3' ->
+    | Econstant (Pconst_integer (s, _))
+    | Econstant (Pconst_float   (s, _)) when s.[0] = '3' ->
       print_string "3"
     | _ ->
       print_string "KO"
@@ -85,7 +85,7 @@ let%expect_test "match or-pattern with variable" =
 
 let%expect_test "match deep or-pattern" =
   let match_3_4 = function%view
-    | Pexp_constant (Pconst_integer (("3" | "4"),  _)) ->
+    | Econstant (Pconst_integer (("3" | "4"),  _)) ->
       print_string "34"
     | _ ->
       print_string "KO"
@@ -97,7 +97,7 @@ let%expect_test "match deep or-pattern" =
 
 let%expect_test "match with alias" =
   let match_3 = function%view
-    | Pexp_constant (Pconst_integer ("3" as s,  _)) ->
+    | Econstant (Pconst_integer ("3" as s,  _)) ->
       print_string s
     | _ ->
       print_string "KO"
@@ -108,7 +108,7 @@ let%expect_test "match with alias" =
 
 let%expect_test "match with record" =
   let match_ident = function%view
-    | Pexp_ident (Longident_loc { txt = Lident id; _}) -> print_string id
+    | Eident (Longident_loc { txt = Lident id; _}) -> print_string id
     | _ -> print_string "KO"
   in
   begin
@@ -120,11 +120,19 @@ let%expect_test "match with polymorphic AST type" =
    | { pci_virt = Virtual
      ; pci_params = []
      ; pci_name = {txt = "name"; _}
-     ; pci_expr = Pcty_extension _ext
+     ; pci_expr = Ctextension _ext
      ; _
      } ->
      print_string "OK"
    | _ -> print_string "KO");
+  [%expect {|OK|}]
+
+let%expect_test "non shortcut desc" =
+  (match%view (int 3) with
+   | {pexp_desc = Pexp_constant (Pconst_integer ("3", None)); _} ->
+     print_string "OK"
+   | _ ->
+     print_string "KO");
   [%expect {|OK|}]
 
 type custom = Int of int | Unit of unit | Nothing


### PR DESCRIPTION
This modifies `Ppx_ast.Viewer` so that it provides both shortcuts and regular views for a desc types.

E.g. for the `Pexp_constant` constructor it will now generate:
```ocaml
val pexp_constant'const : (constant, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
val econstant'const : (constant, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
```
instead of
```ocaml
val pexp_constant'const : (constant, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
```

Using the full constructor name will give you the regular view, while using the shortened one will give you the shortcut.

You can see how the short names are built [here](https://github.com/ocaml-ppx/ppx/pull/65/files#diff-7ac1c0bfca27b56b8b3135ba6275c084R11). I'm happy to change those if you have a better naming scheme in mind!