### PR TITLE
Remove unversioned nodes

### DIFF
--- a/ast/builder_common.ml
+++ b/ast/builder_common.ml
@@ -3,7 +3,7 @@ open Versions.V4_07
 open Builder_v4_07
 
 module Located = struct
-  let longident ~loc longident = Astlib.Loc.create ~loc ~txt:longident ()
+  let longident ~loc longident = Longident_loc.create (Astlib.Loc.create ~loc ~txt:longident ())
   let lident ~loc x = longident ~loc (Longident.lident x)
 
   let dotted ~loc list =

--- a/ast/builder_common.mli
+++ b/ast/builder_common.mli
@@ -1,8 +1,8 @@
 module Located : sig
   val longident
-    : loc: Astlib.Location.t -> Versions.longident -> Versions.longident Astlib.Loc.t
-  val lident : loc: Astlib.Location.t -> string -> Versions.longident Astlib.Loc.t
-  val dotted : loc: Astlib.Location.t -> string list -> Versions.longident Astlib.Loc.t
+    : loc: Astlib.Location.t -> Versions.longident -> Versions.longident_loc
+  val lident : loc: Astlib.Location.t -> string -> Versions.longident_loc
+  val dotted : loc: Astlib.Location.t -> string list -> Versions.longident_loc
 end
 
 val echar : loc: Astlib.Location.t -> char -> Versions.expression

--- a/ast/builder_unstable_for_testing.mli
+++ b/ast/builder_unstable_for_testing.mli
@@ -224,11 +224,11 @@ val pcf_constraint :
   -> Class_field.t
 val pcf_method :
   loc:Astlib.Location.t
-  -> (Class_field_kind.t * Private_flag.t * Label.t Astlib.Loc.t)
+  -> (Class_field_kind.t * Private_flag.t * string Astlib.Loc.t)
   -> Class_field.t
 val pcf_val :
   loc:Astlib.Location.t
-  -> (Class_field_kind.t * Mutable_flag.t * Label.t Astlib.Loc.t)
+  -> (Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t)
   -> Class_field.t
 val pcf_inherit :
   loc:Astlib.Location.t
@@ -296,11 +296,11 @@ val pctf_constraint :
   -> Class_type_field.t
 val pctf_method :
   loc:Astlib.Location.t
-  -> (Core_type.t * Virtual_flag.t * Private_flag.t * Label.t Astlib.Loc.t)
+  -> (Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t)
   -> Class_type_field.t
 val pctf_val :
   loc:Astlib.Location.t
-  -> (Core_type.t * Virtual_flag.t * Mutable_flag.t * Label.t Astlib.Loc.t)
+  -> (Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t)
   -> Class_type_field.t
 val pctf_inherit :
   loc:Astlib.Location.t
@@ -430,12 +430,12 @@ val pexp_letmodule :
   -> Expression.t
 val pexp_override :
   loc:Astlib.Location.t
-  -> (Expression.t * Label.t Astlib.Loc.t) list
+  -> (Expression.t * string Astlib.Loc.t) list
   -> Expression.t
 val pexp_setinstvar :
   loc:Astlib.Location.t
   -> Expression.t
-  -> Label.t Astlib.Loc.t
+  -> string Astlib.Loc.t
   -> Expression.t
 val pexp_new :
   loc:Astlib.Location.t
@@ -443,7 +443,7 @@ val pexp_new :
   -> Expression.t
 val pexp_send :
   loc:Astlib.Location.t
-  -> Label.t Astlib.Loc.t
+  -> string Astlib.Loc.t
   -> Expression.t
   -> Expression.t
 val pexp_coerce :
@@ -504,7 +504,7 @@ val pexp_record :
 val pexp_variant :
   loc:Astlib.Location.t
   -> Expression.t option
-  -> Label.t
+  -> string
   -> Expression.t
 val pexp_construct :
   loc:Astlib.Location.t
@@ -602,7 +602,7 @@ val ppat_record :
 val ppat_variant :
   loc:Astlib.Location.t
   -> Pattern.t option
-  -> Label.t
+  -> string
   -> Pattern.t
 val ppat_construct :
   loc:Astlib.Location.t
@@ -649,7 +649,7 @@ val ptyp_poly :
   -> Core_type.t
 val ptyp_variant :
   loc:Astlib.Location.t
-  -> Label.t list option
+  -> string list option
   -> Closed_flag.t
   -> Row_field.t list
   -> Core_type.t

--- a/ast/builder_v4_07.mli
+++ b/ast/builder_v4_07.mli
@@ -41,7 +41,7 @@ val ptyp_variant :
   loc:Astlib.Location.t
   -> Row_field.t list
   -> Closed_flag.t
-  -> Label.t list option
+  -> string list option
   -> Core_type.t
 val ptyp_poly :
   loc:Astlib.Location.t
@@ -88,7 +88,7 @@ val ppat_construct :
   -> Pattern.t
 val ppat_variant :
   loc:Astlib.Location.t
-  -> Label.t
+  -> string
   -> Pattern.t option
   -> Pattern.t
 val ppat_record :
@@ -186,7 +186,7 @@ val pexp_construct :
   -> Expression.t
 val pexp_variant :
   loc:Astlib.Location.t
-  -> Label.t
+  -> string
   -> Expression.t option
   -> Expression.t
 val pexp_record :
@@ -247,7 +247,7 @@ val pexp_coerce :
 val pexp_send :
   loc:Astlib.Location.t
   -> Expression.t
-  -> Label.t Astlib.Loc.t
+  -> string Astlib.Loc.t
   -> Expression.t
 val pexp_new :
   loc:Astlib.Location.t
@@ -255,12 +255,12 @@ val pexp_new :
   -> Expression.t
 val pexp_setinstvar :
   loc:Astlib.Location.t
-  -> Label.t Astlib.Loc.t
+  -> string Astlib.Loc.t
   -> Expression.t
   -> Expression.t
 val pexp_override :
   loc:Astlib.Location.t
-  -> (Label.t Astlib.Loc.t * Expression.t) list
+  -> (string Astlib.Loc.t * Expression.t) list
   -> Expression.t
 val pexp_letmodule :
   loc:Astlib.Location.t
@@ -390,11 +390,11 @@ val pctf_inherit :
   -> Class_type_field.t
 val pctf_val :
   loc:Astlib.Location.t
-  -> (Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
+  -> (string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
   -> Class_type_field.t
 val pctf_method :
   loc:Astlib.Location.t
-  -> (Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
+  -> (string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
   -> Class_type_field.t
 val pctf_constraint :
   loc:Astlib.Location.t
@@ -462,11 +462,11 @@ val pcf_inherit :
   -> Class_field.t
 val pcf_val :
   loc:Astlib.Location.t
-  -> (Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
+  -> (string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
   -> Class_field.t
 val pcf_method :
   loc:Astlib.Location.t
-  -> (Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
+  -> (string Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
   -> Class_field.t
 val pcf_constraint :
   loc:Astlib.Location.t

--- a/ast/cinaps/gen_builder.ml
+++ b/ast/cinaps/gen_builder.ml
@@ -263,16 +263,13 @@ let builders name (grammar : Astlib.Grammar.kind) shortcut =
   | Poly (_, _) -> []
   | Mono decl ->
     match decl with
-    | Unversioned _ -> []
-    | Versioned versioned ->
-      match versioned with
-      | Wrapper _ -> []
-      | Record r ->
-        begin match Builder.of_record name r shortcut with
-        | None -> []
-        | Some r -> [r]
-        end
-      | Variant v -> Builder.of_variant name v shortcut
+    | Wrapper _ -> []
+    | Record r ->
+      begin match Builder.of_record name r shortcut with
+      | None -> []
+      | Some r -> [r]
+      end
+    | Variant v -> Builder.of_variant name v shortcut
 
 let print_builder_ml version =
   Print.newline ();

--- a/ast/cinaps/gen_conversion.ml
+++ b/ast/cinaps/gen_conversion.ml
@@ -160,10 +160,10 @@ let output_ty ty ~conv =
 
 let tuple_var i = Ml.id (Printf.sprintf "x%d" (i + 1))
 
-let define_conversion versioned ~node_name ~env ~conv =
+let define_conversion decl ~node_name ~env ~conv =
   let name = Name.make [concrete_prefix ~conv; node_name] (Poly_env.args env) in
   let node_ty = node_ty ~node_name ~env in
-  match (versioned : Astlib.Grammar.versioned) with
+  match (decl : Astlib.Grammar.decl) with
   | Wrapper ty ->
     Print.println "and %s x =" name;
     Print.indented (fun () ->
@@ -222,23 +222,6 @@ let define_conversion versioned ~node_name ~env ~conv =
                  (List.map record ~f:(fun (field, _) -> Ml.id field))))))
 
 let print_conversion_impl decl ~node_name ~env ~is_initial =
-  match (decl : Astlib.Grammar.decl) with
-  | Unversioned ty ->
-    Print.println
-      "%s %s x ="
-      (if is_initial then "let rec" else "and")
-      (Name.make ["ast_of"; node_name] (Poly_env.args env));
-    Print.indented (fun () ->
-      Print.println "%s x"
-        (fn_value (ty_conversion ~conv:`concrete_of (Poly_env.subst_ty ty ~env))));
-    Print.newline ();
-    Print.println
-      "and %s x ="
-      (Name.make ["ast_to"; node_name] (Poly_env.args env));
-    Print.indented (fun () ->
-      Print.println "%s x"
-        (fn_value (ty_conversion ~conv:`concrete_to (Poly_env.subst_ty ty ~env))))
-  | Versioned versioned ->
     Print.println
       "%s %s x ="
       (if is_initial then "let rec" else "and")
@@ -250,7 +233,7 @@ let print_conversion_impl decl ~node_name ~env ~is_initial =
         "of_concrete"
         (Name.make ["concrete_of"; node_name] (Poly_env.args env)));
     Print.newline ();
-    define_conversion versioned ~node_name ~env ~conv:`concrete_of;
+    define_conversion decl ~node_name ~env ~conv:`concrete_of;
     Print.newline ();
     Print.println "and %s x =" (Name.make ["ast_to"; node_name] (Poly_env.args env));
     Print.indented (fun () ->
@@ -269,7 +252,7 @@ let print_conversion_impl decl ~node_name ~env ~is_initial =
       Print.println "%s concrete"
         (Name.make ["concrete_to"; node_name] (Poly_env.args env)));
     Print.newline ();
-    define_conversion versioned ~node_name ~env ~conv:`concrete_to
+    define_conversion decl ~node_name ~env ~conv:`concrete_to
 
 let print_conversion_mli () =
   let grammar = Astlib.History.find_grammar Astlib.history ~version in

--- a/ast/cinaps/gen_traverse.ml
+++ b/ast/cinaps/gen_traverse.ml
@@ -203,10 +203,10 @@ let print_method_body
       ~targs
       ~node_name
       ~var
-      (versioned : Astlib.Grammar.versioned)
+      (decl : Astlib.Grammar.decl)
   =
   let value_kind = Ast_type {node_name; targs} in
-  match versioned with
+  match decl with
   | Wrapper ty -> print_method_for_alias ~traversal ~value_kind ~var ty
   | Record fields ->
     let deconstructed = deconstruct_record ~traversal fields in
@@ -489,14 +489,9 @@ let print_to_concrete node_name =
 
 let print_method_value ~traversal ~targs ~node_name decl =
   let args = traversal.args (Ml.id node_name) in
-  match (decl : Astlib.Grammar.decl) with
-  | Unversioned ty ->
-    Ml.define_anon_fun ~args (fun () ->
-      print_method_for_alias ~traversal ~value_kind:Abstract ~var:node_name ty)
-  | Versioned versioned ->
-    Ml.define_anon_fun ~args (fun () ->
-      print_to_concrete node_name;
-      print_method_body ~traversal ~targs ~node_name ~var:"concrete" versioned)
+  Ml.define_anon_fun ~args (fun () ->
+    print_to_concrete node_name;
+    print_method_body ~traversal ~targs ~node_name ~var:"concrete" decl)
 
 let declare_node_methods ~env_table ~signature (node_name, kind) =
   match (kind : Astlib.Grammar.kind) with

--- a/ast/cinaps/gen_viewer.ml
+++ b/ast/cinaps/gen_viewer.ml
@@ -5,7 +5,23 @@ let string_of_ty ty = Grammar.string_of_ty ~internal:false ty
 let variant_viewer_name cname =
   Ml.id (cname ^ "'const")
 
+let wrapper_types grammar =
+  let init = String.Map.empty in
+  List.fold_left ~init grammar
+    ~f:(fun acc (name, kind) ->
+      match (kind : Astlib.Grammar.kind) with
+      | Mono (Wrapper ty) -> String.Map.add acc name ([], ty)
+      | Poly (targs, Wrapper ty) -> String.Map.add acc name (targs, ty)
+      | _ -> acc)
+
 module type VIEWER_PRINTER = sig
+  val print_wrapper_viewer :
+    wrapper_types: (string list * Astlib.Grammar.ty) String.Map.t ->
+    targs: string list ->
+    name: string ->
+    Astlib.Grammar.ty ->
+    unit
+
   val print_field_viewer :
     targs: string list ->
     name: string ->
@@ -37,6 +53,43 @@ module Structure : VIEWER_PRINTER = struct
     | _ ->
       let vars = List.mapi tyl ~f:(fun i _ -> Printf.sprintf "arg%d" i) in
       Ml.tuple vars
+
+  (** Returns the list of types until a non-wrapper type is reached.
+      It's used to determine which `to_concrete` functions should be applied
+      until the result can be matched over.
+      E.g. if you consider a grammar describing:
+      [{
+      type ('a, 'b) t = {a : 'a; b = 'b}
+      type 'a u = ('a, int) t
+      type v = int u
+      }]
+      [unwrap_chain ~wrapper_types ~name:"v" ~ty:(Instance ("u", [Int])]
+      returns ["v"; "u"] because values of type [v] can only be matched on by
+      unrolling aliases [v] and [u]. It stops without including [t] because [t]
+      is a record type. It can be matched based on the fields [a] and [b]. *)
+  let unwrap_chain ~wrapper_types ~name ~ty =
+    let rec aux acc ty =
+      match (ty : Astlib.Grammar.ty) with
+      | Name n | Instance (n, _) ->
+        (match String.Map.find wrapper_types n with
+         | Some (_targs, ty) -> aux (n::acc) ty
+         | None -> List.rev acc)
+      | Var _ | Bool | Char | Int | String | Location | Loc _ | List _
+      | Option _ | Tuple _ ->
+        List.rev acc
+    in
+    aux [name] ty
+
+  let print_wrapper_viewer ~wrapper_types ~targs:_ ~name ty =
+    let unwrap_chain = unwrap_chain ~wrapper_types ~name ~ty in
+    Print.newline ();
+    Print.println "let %s view value =" (variant_viewer_name name);
+    Print.indented (fun () ->
+      let concrete i = Printf.sprintf "concrete%d" i in
+      List.iteri unwrap_chain ~f:(fun i node_name ->
+        let input = if i = 0 then "value" else concrete (i - 1) in
+        To_concrete.print_to_concrete_exn ~node_name ~var_name:(concrete i) input);
+      Print.println "view %s" (concrete (List.length unwrap_chain - 1)))
 
   let print_field_viewer ~targs:_ ~name (fname, _ty) =
     Print.newline ();
@@ -102,6 +155,70 @@ module Signature : VIEWER_PRINTER = struct
     | Var v when List.mem ~set:targs v -> Ml.(poly_inst ~args:[tvar v] "node")
     | _ -> string_of_ty ty
 
+  let rec subst_vars ~substs ty =
+    let open Astlib.Grammar in
+    match ty with
+    | Var s ->
+      (match List.assoc_opt s substs with
+       | Some subst_ty -> subst_ty
+       | None -> assert false)
+    | Loc ty -> Loc (subst_vars ~substs ty)
+    | List ty -> List (subst_vars ~substs ty)
+    | Option ty -> Option (subst_vars ~substs ty)
+    | Tuple tyl -> Tuple (List.map ~f:(subst_vars ~substs) tyl)
+    | Instance (s, tyl) -> Instance (s, List.map ~f:(subst_vars ~substs) tyl)
+    | Bool | Char | Int | String | Location | Name _ -> ty
+
+  (** Recursively follows the type aliases, replacing type variables in
+      polymorphic types instances when needed.
+      This is used to determined the type of the view argument of views for
+      wrapper types.
+      E.g. if you consider the grammar representing the following types:
+      [{
+      type ('a, 'b) t = {a : 'a; b = 'b}
+      type 'a u = ('a, int) t
+      type v = int u
+      }]
+      The view for type v should be a:
+      [((int, int) t, 'i, 'o) View.t -> (v, 'i, 'o) View.t] and therefore
+      [unwrapped_view_type ~wrapper_types ~targs:[] ~name:"t" (Instance ...)]
+      will return [Instance ("t", [Int; Int])]. *)
+  let unwrapped_view_type ~wrapper_types ~targs ty =
+    let rec aux ~substs ty =
+      let substituted_ty = subst_vars ~substs ty in
+      let name_and_tyl = 
+        match substituted_ty with
+        | Name s -> Some (s, [])
+        | Instance (s, l) -> Some (s, l)
+        | Var _ | Bool | Char | Int | String | Location | Loc _ | List _
+        | Option _ | Tuple _ -> None
+      in
+      let next =
+        let open Option.O in
+        name_and_tyl >>= fun (name, tyl) ->
+        String.Map.find wrapper_types name >>| fun (targs, ty) ->
+        let substs = List.combine targs tyl in
+        substs, ty
+      in
+      match next with
+      | None -> substituted_ty
+      | Some (substs, ty) -> aux ~substs ty
+    in
+    let substs = List.map targs ~f:(fun s -> (s, Astlib.Grammar.Var s)) in
+    aux ~substs ty
+
+  let print_wrapper_viewer ~wrapper_types ~targs ~name ty =
+    let in_, out = "'i", "'o" in
+    let value_type = value_type ~targs ~shortcut:None name in
+    let view_type =
+      let ty = unwrapped_view_type ~wrapper_types ~targs ty in
+      view_type ~targs ty
+    in
+    Print.println "val %s: %s -> %s"
+      (variant_viewer_name name)
+      (view_t view_type ~in_ ~out)
+      (view_t value_type ~in_ ~out)
+
   let print_field_viewer ~targs ~name (fname, ty) =
     let value_type = value_type ~targs ~shortcut:None name in
     let view_type = view_type ~targs ty in
@@ -135,7 +252,7 @@ module Signature : VIEWER_PRINTER = struct
     | Record _fields -> ()
 end
 
-let print_viewer ~what ~shortcuts (name, kind) =
+let print_viewer ~what ~shortcuts ~wrapper_types (name, kind) =
   let (module M : VIEWER_PRINTER) =
     match what with
     | `Intf -> (module Signature)
@@ -158,24 +275,26 @@ let print_viewer ~what ~shortcuts (name, kind) =
     assert false
   | _, Record fields ->
     List.iter fields ~f:(M.print_field_viewer ~targs ~name)
-  | _, Wrapper _ ->
-    ()
+  | _, Wrapper ty ->
+    M.print_wrapper_viewer ~wrapper_types ~targs ~name ty
 
 let print_viewer_ml version =
   Print.newline ();
   let grammar = Astlib.History.find_grammar Astlib.history ~version in
+  let wrapper_types = wrapper_types grammar in
   let shortcuts = Shortcut.Map.from_grammar grammar in
   let version = Ml.module_name (Astlib.Version.to_string version) in
   Print.println "open Versions.%s" version;
   Print.println "include Viewer_common";
   To_concrete.define_conversion_failed ~version;
-  List.iter grammar ~f:(print_viewer ~what:`Impl ~shortcuts)
+  List.iter grammar ~f:(print_viewer ~what:`Impl ~shortcuts ~wrapper_types)
 
 let print_viewer_mli version =
   Print.newline ();
   let grammar = Astlib.History.find_grammar Astlib.history ~version in
+  let wrapper_types = wrapper_types grammar in
   let shortcuts = Shortcut.Map.from_grammar grammar in
   Print.println "open Versions";
   Print.println "open %s" (Ml.module_name (Astlib.Version.to_string version));
   Print.println "include module type of Viewer_common";
-  List.iter grammar ~f:(print_viewer ~what:`Intf ~shortcuts)
+  List.iter grammar ~f:(print_viewer ~what:`Intf ~shortcuts ~wrapper_types)

--- a/ast/cinaps/gen_viewer.ml
+++ b/ast/cinaps/gen_viewer.ml
@@ -147,18 +147,18 @@ let print_viewer ~what ~shortcuts (name, kind) =
     | Poly (targs, decl) -> (targs, decl)
   in
   match targs, decl with
-  | [], Versioned (Variant variants) ->
+  | [], Variant variants ->
     let shortcut = Shortcut.Map.find shortcuts name in
     List.iter variants ~f:(M.print_variant_viewer ~name ~shortcut)
-  | _, Versioned (Variant _) ->
+  | _, Variant _ ->
     (* There are no polymorphic variant types in the AST atm. If some are
        added we'll need to handle a few things, including properly generating
        fresh type variables for the input and output type varibales in the
        [View.t] types for empty variants. *)
     assert false
-  | _, Versioned (Record fields) ->
+  | _, Record fields ->
     List.iter fields ~f:(M.print_field_viewer ~targs ~name)
-  | _, (Unversioned _ | Versioned (Wrapper _)) ->
+  | _, Wrapper _ ->
     ()
 
 let print_viewer_ml version =

--- a/ast/cinaps/poly_env.ml
+++ b/ast/cinaps/poly_env.ml
@@ -78,18 +78,12 @@ let subst_clause ~env clause =
 let subst_variants variants ~env =
   List.map variants ~f:(fun (cname, clause) -> (cname, subst_clause ~env clause))
 
-let subst_versioned versioned ~env =
-  let open Astlib.Grammar in
-  match versioned with
-  | Wrapper ty -> Wrapper (subst_ty ~env ty)
-  | Record fields -> Record (subst_fields ~env fields)
-  | Variant variants -> Variant (subst_variants ~env variants)
-
 let subst_decl decl ~env =
   let open Astlib.Grammar in
   match decl with
-  | Unversioned ty -> Unversioned (subst_ty ~env ty)
-  | Versioned versioned -> Versioned (subst_versioned ~env versioned)
+  | Wrapper ty -> Wrapper (subst_ty ~env ty)
+  | Record fields -> Record (subst_fields ~env fields)
+  | Variant variants -> Variant (subst_variants ~env variants)
 
 let rec ty_instances ty =
   match (ty : Astlib.Grammar.ty) with
@@ -113,16 +107,11 @@ let clause_instances clause =
 let variant_instances variant =
   List.concat (List.map variant ~f:(fun (_, clause) -> clause_instances clause))
 
-let versioned_instances versioned =
-  match (versioned : Astlib.Grammar.versioned) with
+let decl_instances decl =
+  match (decl : Astlib.Grammar.decl) with
   | Wrapper ty -> ty_instances ty
   | Record record -> record_instances record
   | Variant variant -> variant_instances variant
-
-let decl_instances decl =
-  match (decl : Astlib.Grammar.decl) with
-  | Unversioned ty -> ty_instances ty
-  | Versioned versioned -> versioned_instances versioned
 
 let rec transitive_instances decl ~grammar_table =
   let instances = decl_instances decl in

--- a/ast/cinaps/shortcut.ml
+++ b/ast/cinaps/shortcut.ml
@@ -65,8 +65,8 @@ module Map = struct
         | Poly (_, _) -> acc
         | Mono decl ->
           match decl with
-          | Unversioned _ | Versioned (Wrapper _ | Variant _) -> acc
-          | Versioned (Record record) ->
+          | Wrapper _ | Variant _ -> acc
+          | Record record ->
             match from_record ~name record with
             | None -> acc
             | Some ({outer_record; inner_variant; _} as shortcut) ->

--- a/ast/conversion.ml
+++ b/ast/conversion.ml
@@ -63,9 +63,20 @@ and concrete_to_longident x : Compiler_types.longident =
     Lapply (x1, x2)
 
 and ast_of_longident_loc x =
+  Versions.V4_07.Longident_loc.of_concrete (concrete_of_longident_loc x)
+
+and concrete_of_longident_loc x =
   (Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_longident) Astlib.Loc.of_loc) x
 
 and ast_to_longident_loc x =
+  let option = Versions.V4_07.Longident_loc.to_concrete x in
+  let concrete =
+    Helpers.Option.value_exn option
+      ~message:"concrete_to_longident_loc: conversion failed"
+  in
+  concrete_to_longident_loc concrete
+
+and concrete_to_longident_loc x =
   (Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_longident)) x
 
 and ast_of_rec_flag x =
@@ -216,9 +227,20 @@ and concrete_to_closed_flag x : Compiler_types.closed_flag =
   | Open -> Open
 
 and ast_of_label x =
+  Versions.V4_07.Label.of_concrete (concrete_of_label x)
+
+and concrete_of_label x =
   Helpers.Fn.id x
 
 and ast_to_label x =
+  let option = Versions.V4_07.Label.to_concrete x in
+  let concrete =
+    Helpers.Option.value_exn option
+      ~message:"concrete_to_label: conversion failed"
+  in
+  concrete_to_label concrete
+
+and concrete_to_label x =
   Helpers.Fn.id x
 
 and ast_of_arg_label x =
@@ -1659,15 +1681,37 @@ and concrete_to_class_infos_class_type
   ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Compiler_types.class_type Compiler_types.class_infos)
 
 and ast_of_class_description x =
+  Versions.V4_07.Class_description.of_concrete (concrete_of_class_description x)
+
+and concrete_of_class_description x =
   ast_of_class_infos_class_type x
 
 and ast_to_class_description x =
+  let option = Versions.V4_07.Class_description.to_concrete x in
+  let concrete =
+    Helpers.Option.value_exn option
+      ~message:"concrete_to_class_description: conversion failed"
+  in
+  concrete_to_class_description concrete
+
+and concrete_to_class_description x =
   ast_to_class_infos_class_type x
 
 and ast_of_class_type_declaration x =
+  Versions.V4_07.Class_type_declaration.of_concrete (concrete_of_class_type_declaration x)
+
+and concrete_of_class_type_declaration x =
   ast_of_class_infos_class_type x
 
 and ast_to_class_type_declaration x =
+  let option = Versions.V4_07.Class_type_declaration.to_concrete x in
+  let concrete =
+    Helpers.Option.value_exn option
+      ~message:"concrete_to_class_type_declaration: conversion failed"
+  in
+  concrete_to_class_type_declaration concrete
+
+and concrete_to_class_type_declaration x =
   ast_to_class_infos_class_type x
 
 and ast_of_class_expr x =
@@ -1929,9 +1973,20 @@ and concrete_to_class_field_kind x : Compiler_types.class_field_kind =
     Cfk_concrete (x1, x2)
 
 and ast_of_class_declaration x =
+  Versions.V4_07.Class_declaration.of_concrete (concrete_of_class_declaration x)
+
+and concrete_of_class_declaration x =
   ast_of_class_infos_class_expr x
 
 and ast_to_class_declaration x =
+  let option = Versions.V4_07.Class_declaration.to_concrete x in
+  let concrete =
+    Helpers.Option.value_exn option
+      ~message:"concrete_to_class_declaration: conversion failed"
+  in
+  concrete_to_class_declaration concrete
+
+and concrete_to_class_declaration x =
   ast_to_class_infos_class_expr x
 
 and ast_of_module_type x =
@@ -2309,15 +2364,37 @@ and concrete_to_include_infos_module_type
   ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_type Compiler_types.include_infos)
 
 and ast_of_include_description x =
+  Versions.V4_07.Include_description.of_concrete (concrete_of_include_description x)
+
+and concrete_of_include_description x =
   ast_of_include_infos_module_type x
 
 and ast_to_include_description x =
+  let option = Versions.V4_07.Include_description.to_concrete x in
+  let concrete =
+    Helpers.Option.value_exn option
+      ~message:"concrete_to_include_description: conversion failed"
+  in
+  concrete_to_include_description concrete
+
+and concrete_to_include_description x =
   ast_to_include_infos_module_type x
 
 and ast_of_include_declaration x =
+  Versions.V4_07.Include_declaration.of_concrete (concrete_of_include_declaration x)
+
+and concrete_of_include_declaration x =
   ast_of_include_infos_module_expr x
 
 and ast_to_include_declaration x =
+  let option = Versions.V4_07.Include_declaration.to_concrete x in
+  let concrete =
+    Helpers.Option.value_exn option
+      ~message:"concrete_to_include_declaration: conversion failed"
+  in
+  concrete_to_include_declaration concrete
+
+and concrete_to_include_declaration x =
   ast_to_include_infos_module_expr x
 
 and ast_of_with_constraint x =

--- a/ast/conversion.ml
+++ b/ast/conversion.ml
@@ -21,6 +21,7 @@ module Helpers = struct
 
   module Fn = struct
     let id x = x
+    [@@warning "-32"]
 
     let compose f g x = f (g x)
   end
@@ -225,23 +226,6 @@ and concrete_to_closed_flag x : Compiler_types.closed_flag =
   match (x : Versions.V4_07.Closed_flag.concrete) with
   | Closed -> Closed
   | Open -> Open
-
-and ast_of_label x =
-  Versions.V4_07.Label.of_concrete (concrete_of_label x)
-
-and concrete_of_label x =
-  Helpers.Fn.id x
-
-and ast_to_label x =
-  let option = Versions.V4_07.Label.to_concrete x in
-  let concrete =
-    Helpers.Option.value_exn option
-      ~message:"concrete_to_label: conversion failed"
-  in
-  concrete_to_label concrete
-
-and concrete_to_label x =
-  Helpers.Fn.id x
 
 and ast_of_arg_label x =
   Versions.V4_07.Arg_label.of_concrete (concrete_of_arg_label x)
@@ -481,7 +465,6 @@ and concrete_of_core_type_desc x : Versions.V4_07.Core_type_desc.concrete =
   | Ptyp_variant (x1, x2, x3) ->
     let x1 = (List.map ~f:ast_of_row_field) x1 in
     let x2 = ast_of_closed_flag x2 in
-    let x3 = (Helpers.Option.map ~f:(List.map ~f:ast_of_label)) x3 in
     Ptyp_variant (x1, x2, x3)
   | Ptyp_poly (x1, x2) ->
     let x1 = (List.map ~f:Astlib.Loc.of_loc) x1 in
@@ -533,7 +516,6 @@ and concrete_to_core_type_desc x : Compiler_types.core_type_desc =
   | Ptyp_variant (x1, x2, x3) ->
     let x1 = (List.map ~f:ast_to_row_field) x1 in
     let x2 = ast_to_closed_flag x2 in
-    let x3 = (Helpers.Option.map ~f:(List.map ~f:ast_to_label)) x3 in
     Ptyp_variant (x1, x2, x3)
   | Ptyp_poly (x1, x2) ->
     let x1 = (List.map ~f:Astlib.Loc.to_loc) x1 in
@@ -569,7 +551,7 @@ and ast_of_row_field x =
 and concrete_of_row_field x : Versions.V4_07.Row_field.concrete =
   match (x : Compiler_types.row_field) with
   | Rtag (x1, x2, x3, x4) ->
-    let x1 = (Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_label) Astlib.Loc.of_loc) x1 in
+    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = ast_of_attributes x2 in
     let x4 = (List.map ~f:ast_of_core_type) x4 in
     Rtag (x1, x2, x3, x4)
@@ -588,7 +570,7 @@ and ast_to_row_field x =
 and concrete_to_row_field x : Compiler_types.row_field =
   match (x : Versions.V4_07.Row_field.concrete) with
   | Rtag (x1, x2, x3, x4) ->
-    let x1 = (Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_label)) x1 in
+    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = ast_to_attributes x2 in
     let x4 = (List.map ~f:ast_to_core_type) x4 in
     Rtag (x1, x2, x3, x4)
@@ -602,7 +584,7 @@ and ast_of_object_field x =
 and concrete_of_object_field x : Versions.V4_07.Object_field.concrete =
   match (x : Compiler_types.object_field) with
   | Otag (x1, x2, x3) ->
-    let x1 = (Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_label) Astlib.Loc.of_loc) x1 in
+    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = ast_of_attributes x2 in
     let x3 = ast_of_core_type x3 in
     Otag (x1, x2, x3)
@@ -621,7 +603,7 @@ and ast_to_object_field x =
 and concrete_to_object_field x : Compiler_types.object_field =
   match (x : Versions.V4_07.Object_field.concrete) with
   | Otag (x1, x2, x3) ->
-    let x1 = (Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_label)) x1 in
+    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = ast_to_attributes x2 in
     let x3 = ast_to_core_type x3 in
     Otag (x1, x2, x3)
@@ -684,7 +666,6 @@ and concrete_of_pattern_desc x : Versions.V4_07.Pattern_desc.concrete =
     let x2 = (Helpers.Option.map ~f:ast_of_pattern) x2 in
     Ppat_construct (x1, x2)
   | Ppat_variant (x1, x2) ->
-    let x1 = ast_of_label x1 in
     let x2 = (Helpers.Option.map ~f:ast_of_pattern) x2 in
     Ppat_variant (x1, x2)
   | Ppat_record (x1, x2) ->
@@ -755,7 +736,6 @@ and concrete_to_pattern_desc x : Compiler_types.pattern_desc =
     let x2 = (Helpers.Option.map ~f:ast_to_pattern) x2 in
     Ppat_construct (x1, x2)
   | Ppat_variant (x1, x2) ->
-    let x1 = ast_to_label x1 in
     let x2 = (Helpers.Option.map ~f:ast_to_pattern) x2 in
     Ppat_variant (x1, x2)
   | Ppat_record (x1, x2) ->
@@ -865,7 +845,6 @@ and concrete_of_expression_desc x : Versions.V4_07.Expression_desc.concrete =
     let x2 = (Helpers.Option.map ~f:ast_of_expression) x2 in
     Pexp_construct (x1, x2)
   | Pexp_variant (x1, x2) ->
-    let x1 = ast_of_label x1 in
     let x2 = (Helpers.Option.map ~f:ast_of_expression) x2 in
     Pexp_variant (x1, x2)
   | Pexp_record (x1, x2) ->
@@ -915,17 +894,17 @@ and concrete_of_expression_desc x : Versions.V4_07.Expression_desc.concrete =
     Pexp_coerce (x1, x2, x3)
   | Pexp_send (x1, x2) ->
     let x1 = ast_of_expression x1 in
-    let x2 = (Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_label) Astlib.Loc.of_loc) x2 in
+    let x2 = Astlib.Loc.of_loc x2 in
     Pexp_send (x1, x2)
   | Pexp_new (x1) ->
     let x1 = ast_of_longident_loc x1 in
     Pexp_new (x1)
   | Pexp_setinstvar (x1, x2) ->
-    let x1 = (Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_label) Astlib.Loc.of_loc) x1 in
+    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = ast_of_expression x2 in
     Pexp_setinstvar (x1, x2)
   | Pexp_override (x1) ->
-    let x1 = (List.map ~f:(Helpers.Tuple.map2 ~f1:(Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_label) Astlib.Loc.of_loc) ~f2:ast_of_expression)) x1 in
+    let x1 = (List.map ~f:(Helpers.Tuple.map2 ~f1:Astlib.Loc.of_loc ~f2:ast_of_expression)) x1 in
     Pexp_override (x1)
   | Pexp_letmodule (x1, x2, x3) ->
     let x1 = Astlib.Loc.of_loc x1 in
@@ -1016,7 +995,6 @@ and concrete_to_expression_desc x : Compiler_types.expression_desc =
     let x2 = (Helpers.Option.map ~f:ast_to_expression) x2 in
     Pexp_construct (x1, x2)
   | Pexp_variant (x1, x2) ->
-    let x1 = ast_to_label x1 in
     let x2 = (Helpers.Option.map ~f:ast_to_expression) x2 in
     Pexp_variant (x1, x2)
   | Pexp_record (x1, x2) ->
@@ -1066,17 +1044,17 @@ and concrete_to_expression_desc x : Compiler_types.expression_desc =
     Pexp_coerce (x1, x2, x3)
   | Pexp_send (x1, x2) ->
     let x1 = ast_to_expression x1 in
-    let x2 = (Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_label)) x2 in
+    let x2 = Astlib.Loc.to_loc x2 in
     Pexp_send (x1, x2)
   | Pexp_new (x1) ->
     let x1 = ast_to_longident_loc x1 in
     Pexp_new (x1)
   | Pexp_setinstvar (x1, x2) ->
-    let x1 = (Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_label)) x1 in
+    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = ast_to_expression x2 in
     Pexp_setinstvar (x1, x2)
   | Pexp_override (x1) ->
-    let x1 = (List.map ~f:(Helpers.Tuple.map2 ~f1:(Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_label)) ~f2:ast_to_expression)) x1 in
+    let x1 = (List.map ~f:(Helpers.Tuple.map2 ~f1:Astlib.Loc.to_loc ~f2:ast_to_expression)) x1 in
     Pexp_override (x1)
   | Pexp_letmodule (x1, x2, x3) ->
     let x1 = Astlib.Loc.to_loc x1 in
@@ -1570,10 +1548,10 @@ and concrete_of_class_type_field_desc x : Versions.V4_07.Class_type_field_desc.c
     let x1 = ast_of_class_type x1 in
     Pctf_inherit (x1)
   | Pctf_val (x1) ->
-    let x1 = (Helpers.Tuple.map4 ~f1:(Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_label) Astlib.Loc.of_loc) ~f2:ast_of_mutable_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
+    let x1 = (Helpers.Tuple.map4 ~f1:Astlib.Loc.of_loc ~f2:ast_of_mutable_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
     Pctf_val (x1)
   | Pctf_method (x1) ->
-    let x1 = (Helpers.Tuple.map4 ~f1:(Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_label) Astlib.Loc.of_loc) ~f2:ast_of_private_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
+    let x1 = (Helpers.Tuple.map4 ~f1:Astlib.Loc.of_loc ~f2:ast_of_private_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
     Pctf_method (x1)
   | Pctf_constraint (x1) ->
     let x1 = (Helpers.Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_core_type) x1 in
@@ -1599,10 +1577,10 @@ and concrete_to_class_type_field_desc x : Compiler_types.class_type_field_desc =
     let x1 = ast_to_class_type x1 in
     Pctf_inherit (x1)
   | Pctf_val (x1) ->
-    let x1 = (Helpers.Tuple.map4 ~f1:(Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_label)) ~f2:ast_to_mutable_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
+    let x1 = (Helpers.Tuple.map4 ~f1:Astlib.Loc.to_loc ~f2:ast_to_mutable_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
     Pctf_val (x1)
   | Pctf_method (x1) ->
-    let x1 = (Helpers.Tuple.map4 ~f1:(Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_label)) ~f2:ast_to_private_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
+    let x1 = (Helpers.Tuple.map4 ~f1:Astlib.Loc.to_loc ~f2:ast_to_private_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
     Pctf_method (x1)
   | Pctf_constraint (x1) ->
     let x1 = (Helpers.Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_core_type) x1 in
@@ -1889,10 +1867,10 @@ and concrete_of_class_field_desc x : Versions.V4_07.Class_field_desc.concrete =
     let x3 = (Helpers.Option.map ~f:Astlib.Loc.of_loc) x3 in
     Pcf_inherit (x1, x2, x3)
   | Pcf_val (x1) ->
-    let x1 = (Helpers.Tuple.map3 ~f1:(Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_label) Astlib.Loc.of_loc) ~f2:ast_of_mutable_flag ~f3:ast_of_class_field_kind) x1 in
+    let x1 = (Helpers.Tuple.map3 ~f1:Astlib.Loc.of_loc ~f2:ast_of_mutable_flag ~f3:ast_of_class_field_kind) x1 in
     Pcf_val (x1)
   | Pcf_method (x1) ->
-    let x1 = (Helpers.Tuple.map3 ~f1:(Helpers.Fn.compose (Astlib.Loc.map ~f:ast_of_label) Astlib.Loc.of_loc) ~f2:ast_of_private_flag ~f3:ast_of_class_field_kind) x1 in
+    let x1 = (Helpers.Tuple.map3 ~f1:Astlib.Loc.of_loc ~f2:ast_of_private_flag ~f3:ast_of_class_field_kind) x1 in
     Pcf_method (x1)
   | Pcf_constraint (x1) ->
     let x1 = (Helpers.Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_core_type) x1 in
@@ -1923,10 +1901,10 @@ and concrete_to_class_field_desc x : Compiler_types.class_field_desc =
     let x3 = (Helpers.Option.map ~f:Astlib.Loc.to_loc) x3 in
     Pcf_inherit (x1, x2, x3)
   | Pcf_val (x1) ->
-    let x1 = (Helpers.Tuple.map3 ~f1:(Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_label)) ~f2:ast_to_mutable_flag ~f3:ast_to_class_field_kind) x1 in
+    let x1 = (Helpers.Tuple.map3 ~f1:Astlib.Loc.to_loc ~f2:ast_to_mutable_flag ~f3:ast_to_class_field_kind) x1 in
     Pcf_val (x1)
   | Pcf_method (x1) ->
-    let x1 = (Helpers.Tuple.map3 ~f1:(Helpers.Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_label)) ~f2:ast_to_private_flag ~f3:ast_to_class_field_kind) x1 in
+    let x1 = (Helpers.Tuple.map3 ~f1:Astlib.Loc.to_loc ~f2:ast_to_private_flag ~f3:ast_to_class_field_kind) x1 in
     Pcf_method (x1)
   | Pcf_constraint (x1) ->
     let x1 = (Helpers.Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_core_type) x1 in

--- a/ast/conversion.mli
+++ b/ast/conversion.mli
@@ -71,14 +71,6 @@ val ast_to_closed_flag :
   Versions.V4_07.Closed_flag.t
   -> Compiler_types.closed_flag
 
-val ast_of_label :
-  Compiler_types.label
-  -> Versions.V4_07.Label.t
-
-val ast_to_label :
-  Versions.V4_07.Label.t
-  -> Compiler_types.label
-
 val ast_of_arg_label :
   Compiler_types.arg_label
   -> Versions.V4_07.Arg_label.t

--- a/ast/test/cinaps/ppx_ast_tests_cinaps.ml
+++ b/ast/test/cinaps/ppx_ast_tests_cinaps.ml
@@ -46,11 +46,11 @@ let print_deriving_type decl ~index ~name ~tvars =
     (Ml.poly_type name ~tvars);
   Print.indented (fun () ->
     match (decl : Astlib.Grammar.decl) with
-    | Unversioned ty | Versioned (Wrapper ty) -> Print.println "%s" (string_of_ty ty)
-    | Versioned (Record record) ->
+    | Wrapper ty -> Print.println "%s" (string_of_ty ty)
+    | Record record ->
       Print.println "%s =" (Ml.poly_type ("Compiler_types." ^ name) ~tvars);
       Ml.print_record_type record ~f:string_of_ty
-    | Versioned (Variant variant) ->
+    | Variant variant ->
       Print.println "%s =" (Ml.poly_type ("Compiler_types." ^ name) ~tvars);
       Ml.print_variant_type variant ~f:(fun clause ->
         match (clause : Astlib.Grammar.clause) with
@@ -135,10 +135,10 @@ let print_quickcheck_generator decl ~index ~name ~tvars =
   Print.indented (fun () ->
     let gen_id name = Ml.id ("gen_" ^ name) in
     match (decl : Astlib.Grammar.decl) with
-    | Unversioned ty | Versioned (Wrapper ty) ->
+    | Wrapper ty ->
       Print.println "let gen = %s in" (generator_string ty);
       Print.println "Generator.generate gen ~size ~random"
-    | Versioned (Record record) ->
+    | Record record ->
       List.iteri record ~f:(fun index (field, ty) ->
         Print.println "%s %s = %s"
           (if index = 0 then "let" else "and")
@@ -151,7 +151,7 @@ let print_quickcheck_generator decl ~index ~name ~tvars =
           (Ml.id field)
           (Ml.id field));
       Print.println "}"
-    | Versioned (Variant variant) ->
+    | Variant variant ->
       List.iteri variant ~f:(fun index (tag, clause) ->
         Print.println "%s %s =" (if index = 0 then "let" else "and") (gen_id tag);
         Print.indented (fun () ->

--- a/ast/test/deriving.mli
+++ b/ast/test/deriving.mli
@@ -46,11 +46,6 @@ module Closed_flag : sig
   [@@deriving equal, quickcheck, sexp_of]
 end
 
-module Label : sig
-  type t = Compiler_types.label
-  [@@deriving equal, quickcheck, sexp_of]
-end
-
 module Arg_label : sig
   type t = Compiler_types.arg_label
   [@@deriving equal, quickcheck, sexp_of]

--- a/ast/unversioned.ml
+++ b/ast/unversioned.ml
@@ -37,7 +37,6 @@ module Types = struct
   type include_declaration_
   type include_description_
   type 'a include_infos_
-  type label_
   type label_declaration_
   type longident_
   type longident_loc_
@@ -110,7 +109,6 @@ module Types = struct
   type include_declaration = include_declaration_ node
   type include_description = include_description_ node
   type 'a include_infos = 'a include_infos_ node
-  type label = label_ node
   type label_declaration = label_declaration_ node
   type longident = longident_ node
   type longident_loc = longident_loc_ node

--- a/ast/unversioned.ml
+++ b/ast/unversioned.ml
@@ -6,6 +6,8 @@ module Types = struct
   type attribute_
   type attributes_
   type case_
+  type class_declaration_
+  type class_description_
   type class_expr_
   type class_expr_desc_
   type class_field_
@@ -15,6 +17,7 @@ module Types = struct
   type class_signature_
   type class_structure_
   type class_type_
+  type class_type_declaration_
   type class_type_desc_
   type class_type_field_
   type class_type_field_desc_
@@ -31,9 +34,13 @@ module Types = struct
   type extension_
   type extension_constructor_
   type extension_constructor_kind_
+  type include_declaration_
+  type include_description_
   type 'a include_infos_
+  type label_
   type label_declaration_
   type longident_
+  type longident_loc_
   type module_binding_
   type module_declaration_
   type module_expr_
@@ -72,6 +79,8 @@ module Types = struct
   type attribute = attribute_ node
   type attributes = attributes_ node
   type case = case_ node
+  type class_declaration = class_declaration_ node
+  type class_description = class_description_ node
   type class_expr = class_expr_ node
   type class_expr_desc = class_expr_desc_ node
   type class_field = class_field_ node
@@ -81,6 +90,7 @@ module Types = struct
   type class_signature = class_signature_ node
   type class_structure = class_structure_ node
   type class_type = class_type_ node
+  type class_type_declaration = class_type_declaration_ node
   type class_type_desc = class_type_desc_ node
   type class_type_field = class_type_field_ node
   type class_type_field_desc = class_type_field_desc_ node
@@ -97,9 +107,13 @@ module Types = struct
   type extension = extension_ node
   type extension_constructor = extension_constructor_ node
   type extension_constructor_kind = extension_constructor_kind_ node
+  type include_declaration = include_declaration_ node
+  type include_description = include_description_ node
   type 'a include_infos = 'a include_infos_ node
+  type label = label_ node
   type label_declaration = label_declaration_ node
   type longident = longident_ node
+  type longident_loc = longident_loc_ node
   type module_binding = module_binding_ node
   type module_declaration = module_declaration_ node
   type module_expr = module_expr_ node
@@ -133,14 +147,6 @@ module Types = struct
   type variance = variance_ node
   type virtual_flag = virtual_flag_ node
   type with_constraint = with_constraint_ node
-
-  type class_declaration = class_expr class_infos
-  type class_description = class_type class_infos
-  type class_type_declaration = class_type class_infos
-  type include_declaration = module_expr include_infos
-  type include_description = module_type include_infos
-  type label = string
-  type longident_loc = longident Astlib.Loc.t
 (*$*)
 end
 

--- a/ast/unversioned.mli
+++ b/ast/unversioned.mli
@@ -6,6 +6,8 @@ module Types : sig
   type attribute_
   type attributes_
   type case_
+  type class_declaration_
+  type class_description_
   type class_expr_
   type class_expr_desc_
   type class_field_
@@ -15,6 +17,7 @@ module Types : sig
   type class_signature_
   type class_structure_
   type class_type_
+  type class_type_declaration_
   type class_type_desc_
   type class_type_field_
   type class_type_field_desc_
@@ -31,9 +34,13 @@ module Types : sig
   type extension_
   type extension_constructor_
   type extension_constructor_kind_
+  type include_declaration_
+  type include_description_
   type 'a include_infos_
+  type label_
   type label_declaration_
   type longident_
+  type longident_loc_
   type module_binding_
   type module_declaration_
   type module_expr_
@@ -72,6 +79,8 @@ module Types : sig
   type attribute = attribute_ node
   type attributes = attributes_ node
   type case = case_ node
+  type class_declaration = class_declaration_ node
+  type class_description = class_description_ node
   type class_expr = class_expr_ node
   type class_expr_desc = class_expr_desc_ node
   type class_field = class_field_ node
@@ -81,6 +90,7 @@ module Types : sig
   type class_signature = class_signature_ node
   type class_structure = class_structure_ node
   type class_type = class_type_ node
+  type class_type_declaration = class_type_declaration_ node
   type class_type_desc = class_type_desc_ node
   type class_type_field = class_type_field_ node
   type class_type_field_desc = class_type_field_desc_ node
@@ -97,9 +107,13 @@ module Types : sig
   type extension = extension_ node
   type extension_constructor = extension_constructor_ node
   type extension_constructor_kind = extension_constructor_kind_ node
+  type include_declaration = include_declaration_ node
+  type include_description = include_description_ node
   type 'a include_infos = 'a include_infos_ node
+  type label = label_ node
   type label_declaration = label_declaration_ node
   type longident = longident_ node
+  type longident_loc = longident_loc_ node
   type module_binding = module_binding_ node
   type module_declaration = module_declaration_ node
   type module_expr = module_expr_ node
@@ -133,14 +147,6 @@ module Types : sig
   type variance = variance_ node
   type virtual_flag = virtual_flag_ node
   type with_constraint = with_constraint_ node
-
-  type class_declaration = class_expr class_infos
-  type class_description = class_type class_infos
-  type class_type_declaration = class_type class_infos
-  type include_declaration = module_expr include_infos
-  type include_description = module_type include_infos
-  type label = string
-  type longident_loc = longident Astlib.Loc.t
 (*$*)
 end
 

--- a/ast/unversioned.mli
+++ b/ast/unversioned.mli
@@ -37,7 +37,6 @@ module Types : sig
   type include_declaration_
   type include_description_
   type 'a include_infos_
-  type label_
   type label_declaration_
   type longident_
   type longident_loc_
@@ -110,7 +109,6 @@ module Types : sig
   type include_declaration = include_declaration_ node
   type include_description = include_description_ node
   type 'a include_infos = 'a include_infos_ node
-  type label = label_ node
   type label_declaration = label_declaration_ node
   type longident = longident_ node
   type longident_loc = longident_loc_ node

--- a/ast/version_unstable_for_testing.ml
+++ b/ast/version_unstable_for_testing.ml
@@ -1454,8 +1454,8 @@ module Class_field_desc = struct
     | Pcf_attribute of attribute
     | Pcf_initializer of expression
     | Pcf_constraint of (core_type * core_type)
-    | Pcf_method of (class_field_kind * private_flag * label Astlib.Loc.t)
-    | Pcf_val of (class_field_kind * mutable_flag * label Astlib.Loc.t)
+    | Pcf_method of (class_field_kind * private_flag * string Astlib.Loc.t)
+    | Pcf_val of (class_field_kind * mutable_flag * string Astlib.Loc.t)
     | Pcf_inherit of string Astlib.Loc.t option * class_expr * override_flag
 
   let pcf_extension x1 =
@@ -1495,7 +1495,7 @@ module Class_field_desc = struct
       (Variant
         { tag = "Pcf_method"
         ; args =
-          [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_node)) x1
+          [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_string)) x1
           |]
         })
   let pcf_val x1 =
@@ -1503,7 +1503,7 @@ module Class_field_desc = struct
       (Variant
         { tag = "Pcf_val"
         ; args =
-          [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_node)) x1
+          [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_string)) x1
           |]
         })
   let pcf_inherit x1 x2 x3 =
@@ -1556,11 +1556,11 @@ module Class_field_desc = struct
             Some (Pcf_constraint (x1))
           )
         | Variant { tag = "Pcf_method"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
             Some (Pcf_method (x1))
           )
         | Variant { tag = "Pcf_val"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
             Some (Pcf_val (x1))
           )
         | Variant { tag = "Pcf_inherit"; args = [| x1; x2; x3 |] } ->
@@ -1916,8 +1916,8 @@ module Class_type_field_desc = struct
     | Pctf_extension of extension
     | Pctf_attribute of attribute
     | Pctf_constraint of (core_type * core_type)
-    | Pctf_method of (core_type * virtual_flag * private_flag * label Astlib.Loc.t)
-    | Pctf_val of (core_type * virtual_flag * mutable_flag * label Astlib.Loc.t)
+    | Pctf_method of (core_type * virtual_flag * private_flag * string Astlib.Loc.t)
+    | Pctf_val of (core_type * virtual_flag * mutable_flag * string Astlib.Loc.t)
     | Pctf_inherit of class_type
 
   let pctf_extension x1 =
@@ -1949,7 +1949,7 @@ module Class_type_field_desc = struct
       (Variant
         { tag = "Pctf_method"
         ; args =
-          [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_node)) x1
+          [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_string)) x1
           |]
         })
   let pctf_val x1 =
@@ -1957,7 +1957,7 @@ module Class_type_field_desc = struct
       (Variant
         { tag = "Pctf_val"
         ; args =
-          [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_node)) x1
+          [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_string)) x1
           |]
         })
   let pctf_inherit x1 =
@@ -2002,11 +2002,11 @@ module Class_type_field_desc = struct
             Some (Pctf_constraint (x1))
           )
         | Variant { tag = "Pctf_method"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
             Some (Pctf_method (x1))
           )
         | Variant { tag = "Pctf_val"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
             Some (Pctf_val (x1))
           )
         | Variant { tag = "Pctf_inherit"; args = [| x1 |] } ->
@@ -2675,10 +2675,10 @@ module Expression_desc = struct
     | Pexp_assert of expression
     | Pexp_letexception of expression * extension_constructor
     | Pexp_letmodule of expression * module_expr * string Astlib.Loc.t
-    | Pexp_override of (expression * label Astlib.Loc.t) list
-    | Pexp_setinstvar of expression * label Astlib.Loc.t
+    | Pexp_override of (expression * string Astlib.Loc.t) list
+    | Pexp_setinstvar of expression * string Astlib.Loc.t
     | Pexp_new of longident_loc
-    | Pexp_send of label Astlib.Loc.t * expression
+    | Pexp_send of string Astlib.Loc.t * expression
     | Pexp_coerce of core_type * core_type option * expression
     | Pexp_constraint of core_type * expression
     | Pexp_for of expression * direction_flag * expression * expression * pattern
@@ -2689,7 +2689,7 @@ module Expression_desc = struct
     | Pexp_setfield of expression * longident_loc * expression
     | Pexp_field of longident_loc * expression
     | Pexp_record of expression option * (expression * longident_loc) list
-    | Pexp_variant of expression option * label
+    | Pexp_variant of expression option * string
     | Pexp_construct of expression option * longident_loc
     | Pexp_tuple of expression list
     | Pexp_try of case list * expression
@@ -2795,7 +2795,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_override"
         ; args =
-          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_node))) x1
+          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_string))) x1
           |]
         })
   let pexp_setinstvar x1 x2 =
@@ -2804,7 +2804,7 @@ module Expression_desc = struct
         { tag = "Pexp_setinstvar"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; (Data.of_loc ~f:Data.of_string) x2
           |]
         })
   let pexp_new x1 =
@@ -2820,7 +2820,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_send"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| (Data.of_loc ~f:Data.of_string) x1
            ; Data.of_node x2
           |]
         })
@@ -2925,7 +2925,7 @@ module Expression_desc = struct
         { tag = "Pexp_variant"
         ; args =
           [| (Data.of_option ~f:Data.of_node) x1
-           ; Data.of_node x2
+           ; Data.of_string x2
           |]
         })
   let pexp_construct x1 x2 =
@@ -3146,12 +3146,12 @@ module Expression_desc = struct
                 Some (Pexp_letmodule (x1, x2, x3))
           )))
         | Variant { tag = "Pexp_override"; args = [| x1 |] } ->
-          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_node))) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_string))) x1) ~f:(fun x1 ->
             Some (Pexp_override (x1))
           )
         | Variant { tag = "Pexp_setinstvar"; args = [| x1; x2 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind ((Data.to_loc ~f:Data.to_string) x2) ~f:(fun x2 ->
               Some (Pexp_setinstvar (x1, x2))
           ))
         | Variant { tag = "Pexp_new"; args = [| x1 |] } ->
@@ -3159,7 +3159,7 @@ module Expression_desc = struct
             Some (Pexp_new (x1))
           )
         | Variant { tag = "Pexp_send"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_loc ~f:Data.to_string) x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pexp_send (x1, x2))
           ))
@@ -3220,7 +3220,7 @@ module Expression_desc = struct
           ))
         | Variant { tag = "Pexp_variant"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind (Data.to_node x2) ~f:(fun x2 ->
+            Option.bind (Data.to_string x2) ~f:(fun x2 ->
               Some (Pexp_variant (x1, x2))
           ))
         | Variant { tag = "Pexp_construct"; args = [| x1; x2 |] } ->
@@ -3325,7 +3325,7 @@ module Pattern_desc = struct
     | Ppat_or of pattern * pattern
     | Ppat_array of pattern list
     | Ppat_record of closed_flag * (pattern * longident_loc) list
-    | Ppat_variant of pattern option * label
+    | Ppat_variant of pattern option * string
     | Ppat_construct of pattern option * longident_loc
     | Ppat_tuple of pattern list
     | Ppat_interval of constant * constant
@@ -3424,7 +3424,7 @@ module Pattern_desc = struct
         { tag = "Ppat_variant"
         ; args =
           [| (Data.of_option ~f:Data.of_node) x1
-           ; Data.of_node x2
+           ; Data.of_string x2
           |]
         })
   let ppat_construct x1 x2 =
@@ -3570,7 +3570,7 @@ module Pattern_desc = struct
           ))
         | Variant { tag = "Ppat_variant"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind (Data.to_node x2) ~f:(fun x2 ->
+            Option.bind (Data.to_string x2) ~f:(fun x2 ->
               Some (Ppat_variant (x1, x2))
           ))
         | Variant { tag = "Ppat_construct"; args = [| x1; x2 |] } ->
@@ -3645,7 +3645,7 @@ module Object_field = struct
 
   type concrete =
     | Oinherit of core_type
-    | Otag of core_type * attributes * label Astlib.Loc.t
+    | Otag of core_type * attributes * string Astlib.Loc.t
 
   let oinherit x1 =
     node "object_field"
@@ -3662,7 +3662,7 @@ module Object_field = struct
         ; args =
           [| Data.of_node x1
            ; Data.of_node x2
-           ; (Data.of_loc ~f:Data.of_node) x3
+           ; (Data.of_loc ~f:Data.of_string) x3
           |]
         })
 
@@ -3685,7 +3685,7 @@ module Object_field = struct
         | Variant { tag = "Otag"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
-              Option.bind ((Data.to_loc ~f:Data.to_node) x3) ~f:(fun x3 ->
+              Option.bind ((Data.to_loc ~f:Data.to_string) x3) ~f:(fun x3 ->
                 Some (Otag (x1, x2, x3))
           )))
       | _ -> None
@@ -3698,7 +3698,7 @@ module Row_field = struct
 
   type concrete =
     | Rinherit of core_type
-    | Rtag of core_type list * bool * attributes * label Astlib.Loc.t
+    | Rtag of core_type list * bool * attributes * string Astlib.Loc.t
 
   let rinherit x1 =
     node "row_field"
@@ -3716,7 +3716,7 @@ module Row_field = struct
           [| (Data.of_list ~f:Data.of_node) x1
            ; Data.of_bool x2
            ; Data.of_node x3
-           ; (Data.of_loc ~f:Data.of_node) x4
+           ; (Data.of_loc ~f:Data.of_string) x4
           |]
         })
 
@@ -3740,7 +3740,7 @@ module Row_field = struct
           Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
             Option.bind (Data.to_bool x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
-                Option.bind ((Data.to_loc ~f:Data.to_node) x4) ~f:(fun x4 ->
+                Option.bind ((Data.to_loc ~f:Data.to_string) x4) ~f:(fun x4 ->
                   Some (Rtag (x1, x2, x3, x4))
           ))))
       | _ -> None
@@ -3772,7 +3772,7 @@ module Core_type_desc = struct
     | Ptyp_extension of extension
     | Ptyp_package of package_type
     | Ptyp_poly of core_type * string Astlib.Loc.t list
-    | Ptyp_variant of label list option * closed_flag * row_field list
+    | Ptyp_variant of string list option * closed_flag * row_field list
     | Ptyp_alias of string * core_type
     | Ptyp_class of core_type list * longident_loc
     | Ptyp_object of closed_flag * object_field list
@@ -3812,7 +3812,7 @@ module Core_type_desc = struct
       (Variant
         { tag = "Ptyp_variant"
         ; args =
-          [| (Data.of_option ~f:(Data.of_list ~f:Data.of_node)) x1
+          [| (Data.of_option ~f:(Data.of_list ~f:Data.of_string)) x1
            ; Data.of_node x2
            ; (Data.of_list ~f:Data.of_node) x3
           |]
@@ -3927,7 +3927,7 @@ module Core_type_desc = struct
               Some (Ptyp_poly (x1, x2))
           ))
         | Variant { tag = "Ptyp_variant"; args = [| x1; x2; x3 |] } ->
-          Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_node)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_string)) x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind ((Data.to_list ~f:Data.to_node) x3) ~f:(fun x3 ->
                 Some (Ptyp_variant (x1, x2, x3))
@@ -4308,23 +4308,6 @@ module Arg_label = struct
         | Variant { tag = "Nolabel"; args = [||] } -> Some Nolabel
       | _ -> None
       end
-    | _ -> None
-end
-
-module Label = struct
-  type t = label
-
-  type concrete = string
-
-  let create =
-    let data = Data.of_string in
-    fun x -> node "label" (data x)
-
-  let of_concrete = create
-
-  let to_concrete t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
-    | { name = "label"; data } -> Data.to_string data
     | _ -> None
 end
 

--- a/ast/version_unstable_for_testing.ml
+++ b/ast/version_unstable_for_testing.ml
@@ -585,7 +585,7 @@ module Module_expr_desc = struct
       (Variant
         { tag = "Pmod_ident"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
 
@@ -640,7 +640,7 @@ module Module_expr_desc = struct
             Some (Pmod_structure (x1))
           )
         | Variant { tag = "Pmod_ident"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pmod_ident (x1))
           )
       | _ -> None
@@ -696,8 +696,8 @@ module With_constraint = struct
       (Variant
         { tag = "Pwith_modsubst"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+          [| Data.of_node x1
+           ; Data.of_node x2
           |]
         })
   let pwith_typesubst x1 x2 =
@@ -706,7 +706,7 @@ module With_constraint = struct
         { tag = "Pwith_typesubst"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
   let pwith_module x1 x2 =
@@ -714,8 +714,8 @@ module With_constraint = struct
       (Variant
         { tag = "Pwith_module"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+          [| Data.of_node x1
+           ; Data.of_node x2
           |]
         })
   let pwith_type x1 x2 =
@@ -724,7 +724,7 @@ module With_constraint = struct
         { tag = "Pwith_type"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
 
@@ -745,23 +745,23 @@ module With_constraint = struct
       begin
         match data with
         | Variant { tag = "Pwith_modsubst"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pwith_modsubst (x1, x2))
           ))
         | Variant { tag = "Pwith_typesubst"; args = [| x1; x2 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pwith_typesubst (x1, x2))
           ))
         | Variant { tag = "Pwith_module"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pwith_module (x1, x2))
           ))
         | Variant { tag = "Pwith_type"; args = [| x1; x2 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pwith_type (x1, x2))
           ))
       | _ -> None
@@ -770,11 +770,37 @@ module With_constraint = struct
 end
 
 module Include_declaration = struct
-  type t = module_expr include_infos
+  type t = include_declaration
+
+  type concrete = module_expr include_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "include_declaration" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "include_declaration"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module Include_description = struct
-  type t = module_type include_infos
+  type t = include_description
+
+  type concrete = module_type include_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "include_description" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "include_description"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module Include_infos = struct
@@ -826,7 +852,7 @@ module Open_description = struct
       [| Data.of_node popen_attributes
        ; Data.of_location popen_loc
        ; Data.of_node popen_override
-       ; (Data.of_loc ~f:Data.of_node) popen_lid
+       ; Data.of_node popen_lid
       |]
     in
     node "open_description" (Record fields)
@@ -842,7 +868,7 @@ module Open_description = struct
         Option.bind (Data.to_node popen_attributes) ~f:(fun popen_attributes ->
           Option.bind (Data.to_location popen_loc) ~f:(fun popen_loc ->
             Option.bind (Data.to_node popen_override) ~f:(fun popen_override ->
-              Option.bind ((Data.to_loc ~f:Data.to_node) popen_lid) ~f:(fun popen_lid ->
+              Option.bind (Data.to_node popen_lid) ~f:(fun popen_lid ->
                 Some { popen_attributes; popen_loc; popen_override; popen_lid }
         ))))
     | _ -> None
@@ -1205,7 +1231,7 @@ module Module_type_desc = struct
       (Variant
         { tag = "Pmty_alias"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
   let pmty_extension x1 =
@@ -1256,7 +1282,7 @@ module Module_type_desc = struct
       (Variant
         { tag = "Pmty_ident"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
 
@@ -1283,7 +1309,7 @@ module Module_type_desc = struct
       begin
         match data with
         | Variant { tag = "Pmty_alias"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pmty_alias (x1))
           )
         | Variant { tag = "Pmty_extension"; args = [| x1 |] } ->
@@ -1310,7 +1336,7 @@ module Module_type_desc = struct
             Some (Pmty_signature (x1))
           )
         | Variant { tag = "Pmty_ident"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pmty_ident (x1))
           )
       | _ -> None
@@ -1353,7 +1379,20 @@ module Module_type = struct
 end
 
 module Class_declaration = struct
-  type t = class_expr class_infos
+  type t = class_declaration
+
+  type concrete = class_expr class_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "class_declaration" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "class_declaration"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module Class_field_kind = struct
@@ -1456,7 +1495,7 @@ module Class_field_desc = struct
       (Variant
         { tag = "Pcf_method"
         ; args =
-          [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_string)) x1
+          [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_node)) x1
           |]
         })
   let pcf_val x1 =
@@ -1464,7 +1503,7 @@ module Class_field_desc = struct
       (Variant
         { tag = "Pcf_val"
         ; args =
-          [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_string)) x1
+          [| (Data.of_tuple3 ~f1:Data.of_node ~f2:Data.of_node ~f3:(Data.of_loc ~f:Data.of_node)) x1
           |]
         })
   let pcf_inherit x1 x2 x3 =
@@ -1517,11 +1556,11 @@ module Class_field_desc = struct
             Some (Pcf_constraint (x1))
           )
         | Variant { tag = "Pcf_method"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
             Some (Pcf_method (x1))
           )
         | Variant { tag = "Pcf_val"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple3 ~f1:Data.to_node ~f2:Data.to_node ~f3:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
             Some (Pcf_val (x1))
           )
         | Variant { tag = "Pcf_inherit"; args = [| x1; x2; x3 |] } ->
@@ -1619,7 +1658,7 @@ module Class_expr_desc = struct
         { tag = "Pcl_open"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
            ; Data.of_node x3
           |]
         })
@@ -1684,7 +1723,7 @@ module Class_expr_desc = struct
         { tag = "Pcl_constr"
         ; args =
           [| (Data.of_list ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
 
@@ -1714,7 +1753,7 @@ module Class_expr_desc = struct
         match data with
         | Variant { tag = "Pcl_open"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
                 Some (Pcl_open (x1, x2, x3))
           )))
@@ -1751,7 +1790,7 @@ module Class_expr_desc = struct
           )
         | Variant { tag = "Pcl_constr"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pcl_constr (x1, x2))
           ))
       | _ -> None
@@ -1794,11 +1833,37 @@ module Class_expr = struct
 end
 
 module Class_type_declaration = struct
-  type t = class_type class_infos
+  type t = class_type_declaration
+
+  type concrete = class_type class_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "class_type_declaration" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "class_type_declaration"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module Class_description = struct
-  type t = class_type class_infos
+  type t = class_description
+
+  type concrete = class_type class_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "class_description" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "class_description"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module Class_infos = struct
@@ -1884,7 +1949,7 @@ module Class_type_field_desc = struct
       (Variant
         { tag = "Pctf_method"
         ; args =
-          [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_string)) x1
+          [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_node)) x1
           |]
         })
   let pctf_val x1 =
@@ -1892,7 +1957,7 @@ module Class_type_field_desc = struct
       (Variant
         { tag = "Pctf_val"
         ; args =
-          [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_string)) x1
+          [| (Data.of_tuple4 ~f1:Data.of_node ~f2:Data.of_node ~f3:Data.of_node ~f4:(Data.of_loc ~f:Data.of_node)) x1
           |]
         })
   let pctf_inherit x1 =
@@ -1937,11 +2002,11 @@ module Class_type_field_desc = struct
             Some (Pctf_constraint (x1))
           )
         | Variant { tag = "Pctf_method"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
             Some (Pctf_method (x1))
           )
         | Variant { tag = "Pctf_val"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_string)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple4 ~f1:Data.to_node ~f2:Data.to_node ~f3:Data.to_node ~f4:(Data.to_loc ~f:Data.to_node)) x1) ~f:(fun x1 ->
             Some (Pctf_val (x1))
           )
         | Variant { tag = "Pctf_inherit"; args = [| x1 |] } ->
@@ -2034,7 +2099,7 @@ module Class_type_desc = struct
         { tag = "Pcty_open"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
            ; Data.of_node x3
           |]
         })
@@ -2070,7 +2135,7 @@ module Class_type_desc = struct
         { tag = "Pcty_constr"
         ; args =
           [| (Data.of_list ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
 
@@ -2094,7 +2159,7 @@ module Class_type_desc = struct
         match data with
         | Variant { tag = "Pcty_open"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
                 Some (Pcty_open (x1, x2, x3))
           )))
@@ -2114,7 +2179,7 @@ module Class_type_desc = struct
           )
         | Variant { tag = "Pcty_constr"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pcty_constr (x1, x2))
           ))
       | _ -> None
@@ -2168,7 +2233,7 @@ module Extension_constructor_kind = struct
       (Variant
         { tag = "Pext_rebind"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
   let pext_decl x1 x2 =
@@ -2194,7 +2259,7 @@ module Extension_constructor_kind = struct
       begin
         match data with
         | Variant { tag = "Pext_rebind"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pext_rebind (x1))
           )
         | Variant { tag = "Pext_decl"; args = [| x1; x2 |] } ->
@@ -2261,7 +2326,7 @@ module Type_extension = struct
        ; Data.of_node ptyext_private
        ; (Data.of_list ~f:Data.of_node) ptyext_constructors
        ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) ptyext_params
-       ; (Data.of_loc ~f:Data.of_node) ptyext_path
+       ; Data.of_node ptyext_path
       |]
     in
     node "type_extension" (Record fields)
@@ -2278,7 +2343,7 @@ module Type_extension = struct
           Option.bind (Data.to_node ptyext_private) ~f:(fun ptyext_private ->
             Option.bind ((Data.to_list ~f:Data.to_node) ptyext_constructors) ~f:(fun ptyext_constructors ->
               Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) ptyext_params) ~f:(fun ptyext_params ->
-                Option.bind ((Data.to_loc ~f:Data.to_node) ptyext_path) ~f:(fun ptyext_path ->
+                Option.bind (Data.to_node ptyext_path) ~f:(fun ptyext_path ->
                   Some { ptyext_attributes; ptyext_private; ptyext_constructors; ptyext_params; ptyext_path }
         )))))
     | _ -> None
@@ -2652,7 +2717,7 @@ module Expression_desc = struct
         { tag = "Pexp_open"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
            ; Data.of_node x3
           |]
         })
@@ -2730,7 +2795,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_override"
         ; args =
-          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_string))) x1
+          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_node))) x1
           |]
         })
   let pexp_setinstvar x1 x2 =
@@ -2739,7 +2804,7 @@ module Expression_desc = struct
         { tag = "Pexp_setinstvar"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_string) x2
+           ; (Data.of_loc ~f:Data.of_node) x2
           |]
         })
   let pexp_new x1 =
@@ -2747,7 +2812,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_new"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
   let pexp_send x1 x2 =
@@ -2755,7 +2820,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_send"
         ; args =
-          [| (Data.of_loc ~f:Data.of_string) x1
+          [| (Data.of_loc ~f:Data.of_node) x1
            ; Data.of_node x2
           |]
         })
@@ -2832,7 +2897,7 @@ module Expression_desc = struct
         { tag = "Pexp_setfield"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
            ; Data.of_node x3
           |]
         })
@@ -2841,7 +2906,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_field"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; Data.of_node x2
           |]
         })
@@ -2851,7 +2916,7 @@ module Expression_desc = struct
         { tag = "Pexp_record"
         ; args =
           [| (Data.of_option ~f:Data.of_node) x1
-           ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_node))) x2
+           ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) x2
           |]
         })
   let pexp_variant x1 x2 =
@@ -2860,7 +2925,7 @@ module Expression_desc = struct
         { tag = "Pexp_variant"
         ; args =
           [| (Data.of_option ~f:Data.of_node) x1
-           ; Data.of_string x2
+           ; Data.of_node x2
           |]
         })
   let pexp_construct x1 x2 =
@@ -2869,7 +2934,7 @@ module Expression_desc = struct
         { tag = "Pexp_construct"
         ; args =
           [| (Data.of_option ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
   let pexp_tuple x1 =
@@ -2949,7 +3014,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_ident"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
 
@@ -3039,7 +3104,7 @@ module Expression_desc = struct
           )
         | Variant { tag = "Pexp_open"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
                 Some (Pexp_open (x1, x2, x3))
           )))
@@ -3081,20 +3146,20 @@ module Expression_desc = struct
                 Some (Pexp_letmodule (x1, x2, x3))
           )))
         | Variant { tag = "Pexp_override"; args = [| x1 |] } ->
-          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_string))) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_node))) x1) ~f:(fun x1 ->
             Some (Pexp_override (x1))
           )
         | Variant { tag = "Pexp_setinstvar"; args = [| x1; x2 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_string) x2) ~f:(fun x2 ->
+            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Pexp_setinstvar (x1, x2))
           ))
         | Variant { tag = "Pexp_new"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pexp_new (x1))
           )
         | Variant { tag = "Pexp_send"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_string) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pexp_send (x1, x2))
           ))
@@ -3139,28 +3204,28 @@ module Expression_desc = struct
           )
         | Variant { tag = "Pexp_setfield"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
                 Some (Pexp_setfield (x1, x2, x3))
           )))
         | Variant { tag = "Pexp_field"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pexp_field (x1, x2))
           ))
         | Variant { tag = "Pexp_record"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_node))) x2) ~f:(fun x2 ->
+            Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) x2) ~f:(fun x2 ->
               Some (Pexp_record (x1, x2))
           ))
         | Variant { tag = "Pexp_variant"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind (Data.to_string x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pexp_variant (x1, x2))
           ))
         | Variant { tag = "Pexp_construct"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pexp_construct (x1, x2))
           ))
         | Variant { tag = "Pexp_tuple"; args = [| x1 |] } ->
@@ -3204,7 +3269,7 @@ module Expression_desc = struct
             Some (Pexp_constant (x1))
           )
         | Variant { tag = "Pexp_ident"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pexp_ident (x1))
           )
       | _ -> None
@@ -3275,7 +3340,7 @@ module Pattern_desc = struct
         { tag = "Ppat_open"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
   let ppat_extension x1 =
@@ -3315,7 +3380,7 @@ module Pattern_desc = struct
       (Variant
         { tag = "Ppat_type"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
   let ppat_constraint x1 x2 =
@@ -3350,7 +3415,7 @@ module Pattern_desc = struct
         { tag = "Ppat_record"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_node))) x2
+           ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) x2
           |]
         })
   let ppat_variant x1 x2 =
@@ -3359,7 +3424,7 @@ module Pattern_desc = struct
         { tag = "Ppat_variant"
         ; args =
           [| (Data.of_option ~f:Data.of_node) x1
-           ; Data.of_string x2
+           ; Data.of_node x2
           |]
         })
   let ppat_construct x1 x2 =
@@ -3368,7 +3433,7 @@ module Pattern_desc = struct
         { tag = "Ppat_construct"
         ; args =
           [| (Data.of_option ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
   let ppat_tuple x1 =
@@ -3461,7 +3526,7 @@ module Pattern_desc = struct
         match data with
         | Variant { tag = "Ppat_open"; args = [| x1; x2 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Ppat_open (x1, x2))
           ))
         | Variant { tag = "Ppat_extension"; args = [| x1 |] } ->
@@ -3481,7 +3546,7 @@ module Pattern_desc = struct
             Some (Ppat_lazy (x1))
           )
         | Variant { tag = "Ppat_type"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Ppat_type (x1))
           )
         | Variant { tag = "Ppat_constraint"; args = [| x1; x2 |] } ->
@@ -3500,17 +3565,17 @@ module Pattern_desc = struct
           )
         | Variant { tag = "Ppat_record"; args = [| x1; x2 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_node))) x2) ~f:(fun x2 ->
+            Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) x2) ~f:(fun x2 ->
               Some (Ppat_record (x1, x2))
           ))
         | Variant { tag = "Ppat_variant"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind (Data.to_string x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Ppat_variant (x1, x2))
           ))
         | Variant { tag = "Ppat_construct"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_option ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Ppat_construct (x1, x2))
           ))
         | Variant { tag = "Ppat_tuple"; args = [| x1 |] } ->
@@ -3597,7 +3662,7 @@ module Object_field = struct
         ; args =
           [| Data.of_node x1
            ; Data.of_node x2
-           ; (Data.of_loc ~f:Data.of_string) x3
+           ; (Data.of_loc ~f:Data.of_node) x3
           |]
         })
 
@@ -3620,7 +3685,7 @@ module Object_field = struct
         | Variant { tag = "Otag"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
-              Option.bind ((Data.to_loc ~f:Data.to_string) x3) ~f:(fun x3 ->
+              Option.bind ((Data.to_loc ~f:Data.to_node) x3) ~f:(fun x3 ->
                 Some (Otag (x1, x2, x3))
           )))
       | _ -> None
@@ -3651,7 +3716,7 @@ module Row_field = struct
           [| (Data.of_list ~f:Data.of_node) x1
            ; Data.of_bool x2
            ; Data.of_node x3
-           ; (Data.of_loc ~f:Data.of_string) x4
+           ; (Data.of_loc ~f:Data.of_node) x4
           |]
         })
 
@@ -3675,7 +3740,7 @@ module Row_field = struct
           Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
             Option.bind (Data.to_bool x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
-                Option.bind ((Data.to_loc ~f:Data.to_string) x4) ~f:(fun x4 ->
+                Option.bind ((Data.to_loc ~f:Data.to_node) x4) ~f:(fun x4 ->
                   Some (Rtag (x1, x2, x3, x4))
           ))))
       | _ -> None
@@ -3689,14 +3754,14 @@ module Package_type = struct
   type concrete = ((core_type * longident_loc) list * longident_loc)
 
   let create =
-    let data = (Data.of_tuple2 ~f1:(Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_loc ~f:Data.of_node))) ~f2:(Data.of_loc ~f:Data.of_node)) in
+    let data = (Data.of_tuple2 ~f1:(Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) ~f2:Data.of_node) in
     fun x -> node "package_type" (data x)
 
   let of_concrete = create
 
   let to_concrete t =
     match Node.to_node (Unversioned.Private.transparent t) ~version with
-    | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_node))) ~f2:(Data.to_loc ~f:Data.to_node)) data
+    | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) ~f2:Data.to_node) data
     | _ -> None
 end
 
@@ -3747,7 +3812,7 @@ module Core_type_desc = struct
       (Variant
         { tag = "Ptyp_variant"
         ; args =
-          [| (Data.of_option ~f:(Data.of_list ~f:Data.of_string)) x1
+          [| (Data.of_option ~f:(Data.of_list ~f:Data.of_node)) x1
            ; Data.of_node x2
            ; (Data.of_list ~f:Data.of_node) x3
           |]
@@ -3767,7 +3832,7 @@ module Core_type_desc = struct
         { tag = "Ptyp_class"
         ; args =
           [| (Data.of_list ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
   let ptyp_object x1 x2 =
@@ -3785,7 +3850,7 @@ module Core_type_desc = struct
         { tag = "Ptyp_constr"
         ; args =
           [| (Data.of_list ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
   let ptyp_tuple x1 =
@@ -3862,7 +3927,7 @@ module Core_type_desc = struct
               Some (Ptyp_poly (x1, x2))
           ))
         | Variant { tag = "Ptyp_variant"; args = [| x1; x2; x3 |] } ->
-          Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_string)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_node)) x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind ((Data.to_list ~f:Data.to_node) x3) ~f:(fun x3 ->
                 Some (Ptyp_variant (x1, x2, x3))
@@ -3874,7 +3939,7 @@ module Core_type_desc = struct
           ))
         | Variant { tag = "Ptyp_class"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Ptyp_class (x1, x2))
           ))
         | Variant { tag = "Ptyp_object"; args = [| x1; x2 |] } ->
@@ -3884,7 +3949,7 @@ module Core_type_desc = struct
           ))
         | Variant { tag = "Ptyp_constr"; args = [| x1; x2 |] } ->
           Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Ptyp_constr (x1, x2))
           ))
         | Variant { tag = "Ptyp_tuple"; args = [| x1 |] } ->
@@ -4247,7 +4312,20 @@ module Arg_label = struct
 end
 
 module Label = struct
-  type t = string
+  type t = label
+
+  type concrete = string
+
+  let create =
+    let data = Data.of_string in
+    fun x -> node "label" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "label"; data } -> Data.to_string data
+    | _ -> None
 end
 
 module Closed_flag = struct
@@ -4454,7 +4532,20 @@ module Rec_flag = struct
 end
 
 module Longident_loc = struct
-  type t = longident Astlib.Loc.t
+  type t = longident_loc
+
+  type concrete = longident Astlib.Loc.t
+
+  let create =
+    let data = (Data.of_loc ~f:Data.of_node) in
+    fun x -> node "longident_loc" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
+    | _ -> None
 end
 
 module Longident = struct

--- a/ast/version_unstable_for_testing.mli
+++ b/ast/version_unstable_for_testing.mli
@@ -285,11 +285,25 @@ and With_constraint : sig
 end
 
 and Include_declaration : sig
-  type t = Module_expr.t Include_infos.t
+  type t = include_declaration
+
+  type concrete = Module_expr.t Include_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Module_expr.t Include_infos.t -> t
 end
 
 and Include_description : sig
-  type t = Module_type.t Include_infos.t
+  type t = include_description
+
+  type concrete = Module_type.t Include_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Module_type.t Include_infos.t -> t
 end
 
 and Include_infos : sig
@@ -527,7 +541,14 @@ and Module_type : sig
 end
 
 and Class_declaration : sig
-  type t = Class_expr.t Class_infos.t
+  type t = class_declaration
+
+  type concrete = Class_expr.t Class_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Class_expr.t Class_infos.t -> t
 end
 
 and Class_field_kind : sig
@@ -697,11 +718,25 @@ and Class_expr : sig
 end
 
 and Class_type_declaration : sig
-  type t = Class_type.t Class_infos.t
+  type t = class_type_declaration
+
+  type concrete = Class_type.t Class_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Class_type.t Class_infos.t -> t
 end
 
 and Class_description : sig
-  type t = Class_type.t Class_infos.t
+  type t = class_description
+
+  type concrete = Class_type.t Class_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Class_type.t Class_infos.t -> t
 end
 
 and Class_infos : sig
@@ -1647,7 +1682,14 @@ and Arg_label : sig
 end
 
 and Label : sig
-  type t = string
+  type t = label
+
+  type concrete = string
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : string -> t
 end
 
 and Closed_flag : sig
@@ -1749,7 +1791,14 @@ and Rec_flag : sig
 end
 
 and Longident_loc : sig
-  type t = Longident.t Astlib.Loc.t
+  type t = longident_loc
+
+  type concrete = Longident.t Astlib.Loc.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Longident.t Astlib.Loc.t -> t
 end
 
 and Longident : sig

--- a/ast/version_unstable_for_testing.mli
+++ b/ast/version_unstable_for_testing.mli
@@ -578,8 +578,8 @@ and Class_field_desc : sig
     | Pcf_attribute of Attribute.t
     | Pcf_initializer of Expression.t
     | Pcf_constraint of (Core_type.t * Core_type.t)
-    | Pcf_method of (Class_field_kind.t * Private_flag.t * Label.t Astlib.Loc.t)
-    | Pcf_val of (Class_field_kind.t * Mutable_flag.t * Label.t Astlib.Loc.t)
+    | Pcf_method of (Class_field_kind.t * Private_flag.t * string Astlib.Loc.t)
+    | Pcf_val of (Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t)
     | Pcf_inherit of string Astlib.Loc.t option * Class_expr.t * Override_flag.t
 
   val of_concrete : concrete -> t
@@ -598,10 +598,10 @@ and Class_field_desc : sig
     (Core_type.t * Core_type.t)
     -> t
   val pcf_method :
-    (Class_field_kind.t * Private_flag.t * Label.t Astlib.Loc.t)
+    (Class_field_kind.t * Private_flag.t * string Astlib.Loc.t)
     -> t
   val pcf_val :
-    (Class_field_kind.t * Mutable_flag.t * Label.t Astlib.Loc.t)
+    (Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t)
     -> t
   val pcf_inherit :
     string Astlib.Loc.t option
@@ -771,8 +771,8 @@ and Class_type_field_desc : sig
     | Pctf_extension of Extension.t
     | Pctf_attribute of Attribute.t
     | Pctf_constraint of (Core_type.t * Core_type.t)
-    | Pctf_method of (Core_type.t * Virtual_flag.t * Private_flag.t * Label.t Astlib.Loc.t)
-    | Pctf_val of (Core_type.t * Virtual_flag.t * Mutable_flag.t * Label.t Astlib.Loc.t)
+    | Pctf_method of (Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t)
+    | Pctf_val of (Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t)
     | Pctf_inherit of Class_type.t
 
   val of_concrete : concrete -> t
@@ -788,10 +788,10 @@ and Class_type_field_desc : sig
     (Core_type.t * Core_type.t)
     -> t
   val pctf_method :
-    (Core_type.t * Virtual_flag.t * Private_flag.t * Label.t Astlib.Loc.t)
+    (Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t)
     -> t
   val pctf_val :
-    (Core_type.t * Virtual_flag.t * Mutable_flag.t * Label.t Astlib.Loc.t)
+    (Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t)
     -> t
   val pctf_inherit :
     Class_type.t
@@ -1123,10 +1123,10 @@ and Expression_desc : sig
     | Pexp_assert of Expression.t
     | Pexp_letexception of Expression.t * Extension_constructor.t
     | Pexp_letmodule of Expression.t * Module_expr.t * string Astlib.Loc.t
-    | Pexp_override of (Expression.t * Label.t Astlib.Loc.t) list
-    | Pexp_setinstvar of Expression.t * Label.t Astlib.Loc.t
+    | Pexp_override of (Expression.t * string Astlib.Loc.t) list
+    | Pexp_setinstvar of Expression.t * string Astlib.Loc.t
     | Pexp_new of Longident_loc.t
-    | Pexp_send of Label.t Astlib.Loc.t * Expression.t
+    | Pexp_send of string Astlib.Loc.t * Expression.t
     | Pexp_coerce of Core_type.t * Core_type.t option * Expression.t
     | Pexp_constraint of Core_type.t * Expression.t
     | Pexp_for of Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t
@@ -1137,7 +1137,7 @@ and Expression_desc : sig
     | Pexp_setfield of Expression.t * Longident_loc.t * Expression.t
     | Pexp_field of Longident_loc.t * Expression.t
     | Pexp_record of Expression.t option * (Expression.t * Longident_loc.t) list
-    | Pexp_variant of Expression.t option * Label.t
+    | Pexp_variant of Expression.t option * string
     | Pexp_construct of Expression.t option * Longident_loc.t
     | Pexp_tuple of Expression.t list
     | Pexp_try of Case.t list * Expression.t
@@ -1191,17 +1191,17 @@ and Expression_desc : sig
     -> string Astlib.Loc.t
     -> t
   val pexp_override :
-    (Expression.t * Label.t Astlib.Loc.t) list
+    (Expression.t * string Astlib.Loc.t) list
     -> t
   val pexp_setinstvar :
     Expression.t
-    -> Label.t Astlib.Loc.t
+    -> string Astlib.Loc.t
     -> t
   val pexp_new :
     Longident_loc.t
     -> t
   val pexp_send :
-    Label.t Astlib.Loc.t
+    string Astlib.Loc.t
     -> Expression.t
     -> t
   val pexp_coerce :
@@ -1251,7 +1251,7 @@ and Expression_desc : sig
     -> t
   val pexp_variant :
     Expression.t option
-    -> Label.t
+    -> string
     -> t
   val pexp_construct :
     Expression.t option
@@ -1327,7 +1327,7 @@ and Pattern_desc : sig
     | Ppat_or of Pattern.t * Pattern.t
     | Ppat_array of Pattern.t list
     | Ppat_record of Closed_flag.t * (Pattern.t * Longident_loc.t) list
-    | Ppat_variant of Pattern.t option * Label.t
+    | Ppat_variant of Pattern.t option * string
     | Ppat_construct of Pattern.t option * Longident_loc.t
     | Ppat_tuple of Pattern.t list
     | Ppat_interval of Constant.t * Constant.t
@@ -1375,7 +1375,7 @@ and Pattern_desc : sig
     -> t
   val ppat_variant :
     Pattern.t option
-    -> Label.t
+    -> string
     -> t
   val ppat_construct :
     Pattern.t option
@@ -1425,7 +1425,7 @@ and Object_field : sig
 
   type concrete =
     | Oinherit of Core_type.t
-    | Otag of Core_type.t * Attributes.t * Label.t Astlib.Loc.t
+    | Otag of Core_type.t * Attributes.t * string Astlib.Loc.t
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete option
@@ -1436,7 +1436,7 @@ and Object_field : sig
   val otag :
     Core_type.t
     -> Attributes.t
-    -> Label.t Astlib.Loc.t
+    -> string Astlib.Loc.t
     -> t
 end
 
@@ -1445,7 +1445,7 @@ and Row_field : sig
 
   type concrete =
     | Rinherit of Core_type.t
-    | Rtag of Core_type.t list * bool * Attributes.t * Label.t Astlib.Loc.t
+    | Rtag of Core_type.t list * bool * Attributes.t * string Astlib.Loc.t
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete option
@@ -1457,7 +1457,7 @@ and Row_field : sig
     Core_type.t list
     -> bool
     -> Attributes.t
-    -> Label.t Astlib.Loc.t
+    -> string Astlib.Loc.t
     -> t
 end
 
@@ -1479,7 +1479,7 @@ and Core_type_desc : sig
     | Ptyp_extension of Extension.t
     | Ptyp_package of Package_type.t
     | Ptyp_poly of Core_type.t * string Astlib.Loc.t list
-    | Ptyp_variant of Label.t list option * Closed_flag.t * Row_field.t list
+    | Ptyp_variant of string list option * Closed_flag.t * Row_field.t list
     | Ptyp_alias of string * Core_type.t
     | Ptyp_class of Core_type.t list * Longident_loc.t
     | Ptyp_object of Closed_flag.t * Object_field.t list
@@ -1503,7 +1503,7 @@ and Core_type_desc : sig
     -> string Astlib.Loc.t list
     -> t
   val ptyp_variant :
-    Label.t list option
+    string list option
     -> Closed_flag.t
     -> Row_field.t list
     -> t
@@ -1679,17 +1679,6 @@ and Arg_label : sig
     string
     -> t
   val nolabel : t
-end
-
-and Label : sig
-  type t = label
-
-  type concrete = string
-
-  val of_concrete : concrete -> t
-  val to_concrete : t -> concrete option
-
-  val create : string -> t
 end
 
 and Closed_flag : sig

--- a/ast/version_v4_07.ml
+++ b/ast/version_v4_07.ml
@@ -74,7 +74,20 @@ module Longident = struct
 end
 
 module Longident_loc = struct
-  type t = longident Astlib.Loc.t
+  type t = longident_loc
+
+  type concrete = longident Astlib.Loc.t
+
+  let create =
+    let data = (Data.of_loc ~f:Data.of_node) in
+    fun x -> node "longident_loc" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
+    | _ -> None
 end
 
 module Rec_flag = struct
@@ -281,7 +294,20 @@ module Closed_flag = struct
 end
 
 module Label = struct
-  type t = string
+  type t = label
+
+  type concrete = string
+
+  let create =
+    let data = Data.of_string in
+    fun x -> node "label" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "label"; data } -> Data.to_string data
+    | _ -> None
 end
 
 module Arg_label = struct
@@ -673,7 +699,7 @@ module Core_type_desc = struct
       (Variant
         { tag = "Ptyp_constr"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; (Data.of_list ~f:Data.of_node) x2
           |]
         })
@@ -691,7 +717,7 @@ module Core_type_desc = struct
       (Variant
         { tag = "Ptyp_class"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; (Data.of_list ~f:Data.of_node) x2
           |]
         })
@@ -711,7 +737,7 @@ module Core_type_desc = struct
         ; args =
           [| (Data.of_list ~f:Data.of_node) x1
            ; Data.of_node x2
-           ; (Data.of_option ~f:(Data.of_list ~f:Data.of_string)) x3
+           ; (Data.of_option ~f:(Data.of_list ~f:Data.of_node)) x3
           |]
         })
   let ptyp_poly x1 x2 =
@@ -787,7 +813,7 @@ module Core_type_desc = struct
             Some (Ptyp_tuple (x1))
           )
         | Variant { tag = "Ptyp_constr"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind ((Data.to_list ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Ptyp_constr (x1, x2))
           ))
@@ -797,7 +823,7 @@ module Core_type_desc = struct
               Some (Ptyp_object (x1, x2))
           ))
         | Variant { tag = "Ptyp_class"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind ((Data.to_list ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Ptyp_class (x1, x2))
           ))
@@ -809,7 +835,7 @@ module Core_type_desc = struct
         | Variant { tag = "Ptyp_variant"; args = [| x1; x2; x3 |] } ->
           Option.bind ((Data.to_list ~f:Data.to_node) x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
-              Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_string)) x3) ~f:(fun x3 ->
+              Option.bind ((Data.to_option ~f:(Data.to_list ~f:Data.to_node)) x3) ~f:(fun x3 ->
                 Some (Ptyp_variant (x1, x2, x3))
           )))
         | Variant { tag = "Ptyp_poly"; args = [| x1; x2 |] } ->
@@ -836,14 +862,14 @@ module Package_type = struct
   type concrete = (longident_loc * (longident_loc * core_type) list)
 
   let create =
-    let data = (Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:(Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node))) in
+    let data = (Data.of_tuple2 ~f1:Data.of_node ~f2:(Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node))) in
     fun x -> node "package_type" (data x)
 
   let of_concrete = create
 
   let to_concrete t =
     match Node.to_node (Unversioned.Private.transparent t) ~version with
-    | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:(Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node))) data
+    | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node))) data
     | _ -> None
 end
 
@@ -859,7 +885,7 @@ module Row_field = struct
       (Variant
         { tag = "Rtag"
         ; args =
-          [| (Data.of_loc ~f:Data.of_string) x1
+          [| (Data.of_loc ~f:Data.of_node) x1
            ; Data.of_node x2
            ; Data.of_bool x3
            ; (Data.of_list ~f:Data.of_node) x4
@@ -887,7 +913,7 @@ module Row_field = struct
       begin
         match data with
         | Variant { tag = "Rtag"; args = [| x1; x2; x3; x4 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_string) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_bool x3) ~f:(fun x3 ->
                 Option.bind ((Data.to_list ~f:Data.to_node) x4) ~f:(fun x4 ->
@@ -914,7 +940,7 @@ module Object_field = struct
       (Variant
         { tag = "Otag"
         ; args =
-          [| (Data.of_loc ~f:Data.of_string) x1
+          [| (Data.of_loc ~f:Data.of_node) x1
            ; Data.of_node x2
            ; Data.of_node x3
           |]
@@ -941,7 +967,7 @@ module Object_field = struct
       begin
         match data with
         | Variant { tag = "Otag"; args = [| x1; x2; x3 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_string) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
                 Some (Otag (x1, x2, x3))
@@ -1061,7 +1087,7 @@ module Pattern_desc = struct
       (Variant
         { tag = "Ppat_construct"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; (Data.of_option ~f:Data.of_node) x2
           |]
         })
@@ -1070,7 +1096,7 @@ module Pattern_desc = struct
       (Variant
         { tag = "Ppat_variant"
         ; args =
-          [| Data.of_string x1
+          [| Data.of_node x1
            ; (Data.of_option ~f:Data.of_node) x2
           |]
         })
@@ -1079,7 +1105,7 @@ module Pattern_desc = struct
       (Variant
         { tag = "Ppat_record"
         ; args =
-          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node)) x1
+          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) x1
            ; Data.of_node x2
           |]
         })
@@ -1114,7 +1140,7 @@ module Pattern_desc = struct
       (Variant
         { tag = "Ppat_type"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
   let ppat_lazy x1 =
@@ -1154,7 +1180,7 @@ module Pattern_desc = struct
       (Variant
         { tag = "Ppat_open"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; Data.of_node x2
           |]
         })
@@ -1226,17 +1252,17 @@ module Pattern_desc = struct
             Some (Ppat_tuple (x1))
           )
         | Variant { tag = "Ppat_construct"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Ppat_construct (x1, x2))
           ))
         | Variant { tag = "Ppat_variant"; args = [| x1; x2 |] } ->
-          Option.bind (Data.to_string x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Ppat_variant (x1, x2))
           ))
         | Variant { tag = "Ppat_record"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Ppat_record (x1, x2))
           ))
@@ -1255,7 +1281,7 @@ module Pattern_desc = struct
               Some (Ppat_constraint (x1, x2))
           ))
         | Variant { tag = "Ppat_type"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Ppat_type (x1))
           )
         | Variant { tag = "Ppat_lazy"; args = [| x1 |] } ->
@@ -1275,7 +1301,7 @@ module Pattern_desc = struct
             Some (Ppat_extension (x1))
           )
         | Variant { tag = "Ppat_open"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Ppat_open (x1, x2))
           ))
@@ -1364,7 +1390,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_ident"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
   let pexp_constant x1 =
@@ -1444,7 +1470,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_construct"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; (Data.of_option ~f:Data.of_node) x2
           |]
         })
@@ -1453,7 +1479,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_variant"
         ; args =
-          [| Data.of_string x1
+          [| Data.of_node x1
            ; (Data.of_option ~f:Data.of_node) x2
           |]
         })
@@ -1462,7 +1488,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_record"
         ; args =
-          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node)) x1
+          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) x1
            ; (Data.of_option ~f:Data.of_node) x2
           |]
         })
@@ -1472,7 +1498,7 @@ module Expression_desc = struct
         { tag = "Pexp_field"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
           |]
         })
   let pexp_setfield x1 x2 x3 =
@@ -1481,7 +1507,7 @@ module Expression_desc = struct
         { tag = "Pexp_setfield"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
            ; Data.of_node x3
           |]
         })
@@ -1558,7 +1584,7 @@ module Expression_desc = struct
         { tag = "Pexp_send"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_string) x2
+           ; (Data.of_loc ~f:Data.of_node) x2
           |]
         })
   let pexp_new x1 =
@@ -1566,7 +1592,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_new"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
   let pexp_setinstvar x1 x2 =
@@ -1574,7 +1600,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_setinstvar"
         ; args =
-          [| (Data.of_loc ~f:Data.of_string) x1
+          [| (Data.of_loc ~f:Data.of_node) x1
            ; Data.of_node x2
           |]
         })
@@ -1583,7 +1609,7 @@ module Expression_desc = struct
       (Variant
         { tag = "Pexp_override"
         ; args =
-          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node)) x1
+          [| (Data.of_list ~f:(Data.of_tuple2 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node)) x1
           |]
         })
   let pexp_letmodule x1 x2 x3 =
@@ -1661,7 +1687,7 @@ module Expression_desc = struct
         { tag = "Pexp_open"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
            ; Data.of_node x3
           |]
         })
@@ -1756,7 +1782,7 @@ module Expression_desc = struct
       begin
         match data with
         | Variant { tag = "Pexp_ident"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pexp_ident (x1))
           )
         | Variant { tag = "Pexp_constant"; args = [| x1 |] } ->
@@ -1800,28 +1826,28 @@ module Expression_desc = struct
             Some (Pexp_tuple (x1))
           )
         | Variant { tag = "Pexp_construct"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Pexp_construct (x1, x2))
           ))
         | Variant { tag = "Pexp_variant"; args = [| x1; x2 |] } ->
-          Option.bind (Data.to_string x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Pexp_variant (x1, x2))
           ))
         | Variant { tag = "Pexp_record"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) x1) ~f:(fun x1 ->
             Option.bind ((Data.to_option ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Pexp_record (x1, x2))
           ))
         | Variant { tag = "Pexp_field"; args = [| x1; x2 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pexp_field (x1, x2))
           ))
         | Variant { tag = "Pexp_setfield"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
                 Some (Pexp_setfield (x1, x2, x3))
           )))
@@ -1866,20 +1892,20 @@ module Expression_desc = struct
           )))
         | Variant { tag = "Pexp_send"; args = [| x1; x2 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_string) x2) ~f:(fun x2 ->
+            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Pexp_send (x1, x2))
           ))
         | Variant { tag = "Pexp_new"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pexp_new (x1))
           )
         | Variant { tag = "Pexp_setinstvar"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_string) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pexp_setinstvar (x1, x2))
           ))
         | Variant { tag = "Pexp_override"; args = [| x1 |] } ->
-          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node)) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node)) x1) ~f:(fun x1 ->
             Some (Pexp_override (x1))
           )
         | Variant { tag = "Pexp_letmodule"; args = [| x1; x2; x3 |] } ->
@@ -1921,7 +1947,7 @@ module Expression_desc = struct
           )
         | Variant { tag = "Pexp_open"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
                 Some (Pexp_open (x1, x2, x3))
           )))
@@ -2259,7 +2285,7 @@ module Type_extension = struct
 
   let create ~ptyext_path ~ptyext_params ~ptyext_constructors ~ptyext_private ~ptyext_attributes =
     let fields =
-      [| (Data.of_loc ~f:Data.of_node) ptyext_path
+      [| Data.of_node ptyext_path
        ; (Data.of_list ~f:(Data.of_tuple2 ~f1:Data.of_node ~f2:Data.of_node)) ptyext_params
        ; (Data.of_list ~f:Data.of_node) ptyext_constructors
        ; Data.of_node ptyext_private
@@ -2276,7 +2302,7 @@ module Type_extension = struct
     | { name = "type_extension"
       ; data = Record [| ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes |]
       } ->
-        Option.bind ((Data.to_loc ~f:Data.to_node) ptyext_path) ~f:(fun ptyext_path ->
+        Option.bind (Data.to_node ptyext_path) ~f:(fun ptyext_path ->
           Option.bind ((Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) ptyext_params) ~f:(fun ptyext_params ->
             Option.bind ((Data.to_list ~f:Data.to_node) ptyext_constructors) ~f:(fun ptyext_constructors ->
               Option.bind (Data.to_node ptyext_private) ~f:(fun ptyext_private ->
@@ -2344,7 +2370,7 @@ module Extension_constructor_kind = struct
       (Variant
         { tag = "Pext_rebind"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
 
@@ -2366,7 +2392,7 @@ module Extension_constructor_kind = struct
               Some (Pext_decl (x1, x2))
           ))
         | Variant { tag = "Pext_rebind"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pext_rebind (x1))
           )
       | _ -> None
@@ -2423,7 +2449,7 @@ module Class_type_desc = struct
       (Variant
         { tag = "Pcty_constr"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; (Data.of_list ~f:Data.of_node) x2
           |]
         })
@@ -2459,7 +2485,7 @@ module Class_type_desc = struct
         { tag = "Pcty_open"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
            ; Data.of_node x3
           |]
         })
@@ -2483,7 +2509,7 @@ module Class_type_desc = struct
       begin
         match data with
         | Variant { tag = "Pcty_constr"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind ((Data.to_list ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Pcty_constr (x1, x2))
           ))
@@ -2503,7 +2529,7 @@ module Class_type_desc = struct
           )
         | Variant { tag = "Pcty_open"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
                 Some (Pcty_open (x1, x2, x3))
           )))
@@ -2601,7 +2627,7 @@ module Class_type_field_desc = struct
       (Variant
         { tag = "Pctf_val"
         ; args =
-          [| (Data.of_tuple4 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node ~f3:Data.of_node ~f4:Data.of_node) x1
+          [| (Data.of_tuple4 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node ~f3:Data.of_node ~f4:Data.of_node) x1
           |]
         })
   let pctf_method x1 =
@@ -2609,7 +2635,7 @@ module Class_type_field_desc = struct
       (Variant
         { tag = "Pctf_method"
         ; args =
-          [| (Data.of_tuple4 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node ~f3:Data.of_node ~f4:Data.of_node) x1
+          [| (Data.of_tuple4 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node ~f3:Data.of_node ~f4:Data.of_node) x1
           |]
         })
   let pctf_constraint x1 =
@@ -2662,11 +2688,11 @@ module Class_type_field_desc = struct
             Some (Pctf_inherit (x1))
           )
         | Variant { tag = "Pctf_val"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple4 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node ~f3:Data.to_node ~f4:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple4 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node ~f3:Data.to_node ~f4:Data.to_node) x1) ~f:(fun x1 ->
             Some (Pctf_val (x1))
           )
         | Variant { tag = "Pctf_method"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple4 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node ~f3:Data.to_node ~f4:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple4 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node ~f3:Data.to_node ~f4:Data.to_node) x1) ~f:(fun x1 ->
             Some (Pctf_method (x1))
           )
         | Variant { tag = "Pctf_constraint"; args = [| x1 |] } ->
@@ -2730,11 +2756,37 @@ module Class_infos = struct
 end
 
 module Class_description = struct
-  type t = class_type class_infos
+  type t = class_description
+
+  type concrete = class_type class_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "class_description" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "class_description"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module Class_type_declaration = struct
-  type t = class_type class_infos
+  type t = class_type_declaration
+
+  type concrete = class_type class_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "class_type_declaration" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "class_type_declaration"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module Class_expr = struct
@@ -2789,7 +2841,7 @@ module Class_expr_desc = struct
       (Variant
         { tag = "Pcl_constr"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; (Data.of_list ~f:Data.of_node) x2
           |]
         })
@@ -2854,7 +2906,7 @@ module Class_expr_desc = struct
         { tag = "Pcl_open"
         ; args =
           [| Data.of_node x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+           ; Data.of_node x2
            ; Data.of_node x3
           |]
         })
@@ -2884,7 +2936,7 @@ module Class_expr_desc = struct
       begin
         match data with
         | Variant { tag = "Pcl_constr"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind ((Data.to_list ~f:Data.to_node) x2) ~f:(fun x2 ->
               Some (Pcl_constr (x1, x2))
           ))
@@ -2921,7 +2973,7 @@ module Class_expr_desc = struct
           )
         | Variant { tag = "Pcl_open"; args = [| x1; x2; x3 |] } ->
           Option.bind (Data.to_node x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Option.bind (Data.to_node x3) ~f:(fun x3 ->
                 Some (Pcl_open (x1, x2, x3))
           )))
@@ -3022,7 +3074,7 @@ module Class_field_desc = struct
       (Variant
         { tag = "Pcf_val"
         ; args =
-          [| (Data.of_tuple3 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node ~f3:Data.of_node) x1
+          [| (Data.of_tuple3 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node ~f3:Data.of_node) x1
           |]
         })
   let pcf_method x1 =
@@ -3030,7 +3082,7 @@ module Class_field_desc = struct
       (Variant
         { tag = "Pcf_method"
         ; args =
-          [| (Data.of_tuple3 ~f1:(Data.of_loc ~f:Data.of_string) ~f2:Data.of_node ~f3:Data.of_node) x1
+          [| (Data.of_tuple3 ~f1:(Data.of_loc ~f:Data.of_node) ~f2:Data.of_node ~f3:Data.of_node) x1
           |]
         })
   let pcf_constraint x1 =
@@ -3095,11 +3147,11 @@ module Class_field_desc = struct
                 Some (Pcf_inherit (x1, x2, x3))
           )))
         | Variant { tag = "Pcf_val"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple3 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node ~f3:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple3 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node ~f3:Data.to_node) x1) ~f:(fun x1 ->
             Some (Pcf_val (x1))
           )
         | Variant { tag = "Pcf_method"; args = [| x1 |] } ->
-          Option.bind ((Data.to_tuple3 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node ~f3:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind ((Data.to_tuple3 ~f1:(Data.to_loc ~f:Data.to_node) ~f2:Data.to_node ~f3:Data.to_node) x1) ~f:(fun x1 ->
             Some (Pcf_method (x1))
           )
         | Variant { tag = "Pcf_constraint"; args = [| x1 |] } ->
@@ -3175,7 +3227,20 @@ module Class_field_kind = struct
 end
 
 module Class_declaration = struct
-  type t = class_expr class_infos
+  type t = class_declaration
+
+  type concrete = class_expr class_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "class_declaration" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "class_declaration"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module Module_type = struct
@@ -3229,7 +3294,7 @@ module Module_type_desc = struct
       (Variant
         { tag = "Pmty_ident"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
   let pmty_signature x1 =
@@ -3280,7 +3345,7 @@ module Module_type_desc = struct
       (Variant
         { tag = "Pmty_alias"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
 
@@ -3307,7 +3372,7 @@ module Module_type_desc = struct
       begin
         match data with
         | Variant { tag = "Pmty_ident"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pmty_ident (x1))
           )
         | Variant { tag = "Pmty_signature"; args = [| x1 |] } ->
@@ -3334,7 +3399,7 @@ module Module_type_desc = struct
             Some (Pmty_extension (x1))
           )
         | Variant { tag = "Pmty_alias"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pmty_alias (x1))
           )
       | _ -> None
@@ -3694,7 +3759,7 @@ module Open_description = struct
 
   let create ~popen_lid ~popen_override ~popen_loc ~popen_attributes =
     let fields =
-      [| (Data.of_loc ~f:Data.of_node) popen_lid
+      [| Data.of_node popen_lid
        ; Data.of_node popen_override
        ; Data.of_location popen_loc
        ; Data.of_node popen_attributes
@@ -3710,7 +3775,7 @@ module Open_description = struct
     | { name = "open_description"
       ; data = Record [| popen_lid; popen_override; popen_loc; popen_attributes |]
       } ->
-        Option.bind ((Data.to_loc ~f:Data.to_node) popen_lid) ~f:(fun popen_lid ->
+        Option.bind (Data.to_node popen_lid) ~f:(fun popen_lid ->
           Option.bind (Data.to_node popen_override) ~f:(fun popen_override ->
             Option.bind (Data.to_location popen_loc) ~f:(fun popen_loc ->
               Option.bind (Data.to_node popen_attributes) ~f:(fun popen_attributes ->
@@ -3754,11 +3819,37 @@ module Include_infos = struct
 end
 
 module Include_description = struct
-  type t = module_type include_infos
+  type t = include_description
+
+  type concrete = module_type include_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "include_description" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "include_description"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module Include_declaration = struct
-  type t = module_expr include_infos
+  type t = include_declaration
+
+  type concrete = module_expr include_infos
+
+  let create =
+    let data = Data.of_node in
+    fun x -> node "include_declaration" (data x)
+
+  let of_concrete = create
+
+  let to_concrete t =
+    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    | { name = "include_declaration"; data } -> Data.to_node data
+    | _ -> None
 end
 
 module With_constraint = struct
@@ -3775,7 +3866,7 @@ module With_constraint = struct
       (Variant
         { tag = "Pwith_type"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; Data.of_node x2
           |]
         })
@@ -3784,8 +3875,8 @@ module With_constraint = struct
       (Variant
         { tag = "Pwith_module"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+          [| Data.of_node x1
+           ; Data.of_node x2
           |]
         })
   let pwith_typesubst x1 x2 =
@@ -3793,7 +3884,7 @@ module With_constraint = struct
       (Variant
         { tag = "Pwith_typesubst"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
            ; Data.of_node x2
           |]
         })
@@ -3802,8 +3893,8 @@ module With_constraint = struct
       (Variant
         { tag = "Pwith_modsubst"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
-           ; (Data.of_loc ~f:Data.of_node) x2
+          [| Data.of_node x1
+           ; Data.of_node x2
           |]
         })
 
@@ -3824,23 +3915,23 @@ module With_constraint = struct
       begin
         match data with
         | Variant { tag = "Pwith_type"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pwith_type (x1, x2))
           ))
         | Variant { tag = "Pwith_module"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pwith_module (x1, x2))
           ))
         | Variant { tag = "Pwith_typesubst"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pwith_typesubst (x1, x2))
           ))
         | Variant { tag = "Pwith_modsubst"; args = [| x1; x2 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
-            Option.bind ((Data.to_loc ~f:Data.to_node) x2) ~f:(fun x2 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
+            Option.bind (Data.to_node x2) ~f:(fun x2 ->
               Some (Pwith_modsubst (x1, x2))
           ))
       | _ -> None
@@ -3899,7 +3990,7 @@ module Module_expr_desc = struct
       (Variant
         { tag = "Pmod_ident"
         ; args =
-          [| (Data.of_loc ~f:Data.of_node) x1
+          [| Data.of_node x1
           |]
         })
   let pmod_structure x1 =
@@ -3978,7 +4069,7 @@ module Module_expr_desc = struct
       begin
         match data with
         | Variant { tag = "Pmod_ident"; args = [| x1 |] } ->
-          Option.bind ((Data.to_loc ~f:Data.to_node) x1) ~f:(fun x1 ->
+          Option.bind (Data.to_node x1) ~f:(fun x1 ->
             Some (Pmod_ident (x1))
           )
         | Variant { tag = "Pmod_structure"; args = [| x1 |] } ->

--- a/ast/version_v4_07.mli
+++ b/ast/version_v4_07.mli
@@ -134,17 +134,6 @@ and Closed_flag : sig
   val open_ : t
 end
 
-and Label : sig
-  type t = label
-
-  type concrete = string
-
-  val of_concrete : concrete -> t
-  val to_concrete : t -> concrete option
-
-  val create : string -> t
-end
-
 and Arg_label : sig
   type t = arg_label
 
@@ -301,7 +290,7 @@ and Core_type_desc : sig
     | Ptyp_object of Object_field.t list * Closed_flag.t
     | Ptyp_class of Longident_loc.t * Core_type.t list
     | Ptyp_alias of Core_type.t * string
-    | Ptyp_variant of Row_field.t list * Closed_flag.t * Label.t list option
+    | Ptyp_variant of Row_field.t list * Closed_flag.t * string list option
     | Ptyp_poly of string Astlib.Loc.t list * Core_type.t
     | Ptyp_package of Package_type.t
     | Ptyp_extension of Extension.t
@@ -340,7 +329,7 @@ and Core_type_desc : sig
   val ptyp_variant :
     Row_field.t list
     -> Closed_flag.t
-    -> Label.t list option
+    -> string list option
     -> t
   val ptyp_poly :
     string Astlib.Loc.t list
@@ -369,14 +358,14 @@ and Row_field : sig
   type t = row_field
 
   type concrete =
-    | Rtag of Label.t Astlib.Loc.t * Attributes.t * bool * Core_type.t list
+    | Rtag of string Astlib.Loc.t * Attributes.t * bool * Core_type.t list
     | Rinherit of Core_type.t
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete option
 
   val rtag :
-    Label.t Astlib.Loc.t
+    string Astlib.Loc.t
     -> Attributes.t
     -> bool
     -> Core_type.t list
@@ -390,14 +379,14 @@ and Object_field : sig
   type t = object_field
 
   type concrete =
-    | Otag of Label.t Astlib.Loc.t * Attributes.t * Core_type.t
+    | Otag of string Astlib.Loc.t * Attributes.t * Core_type.t
     | Oinherit of Core_type.t
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete option
 
   val otag :
-    Label.t Astlib.Loc.t
+    string Astlib.Loc.t
     -> Attributes.t
     -> Core_type.t
     -> t
@@ -436,7 +425,7 @@ and Pattern_desc : sig
     | Ppat_interval of Constant.t * Constant.t
     | Ppat_tuple of Pattern.t list
     | Ppat_construct of Longident_loc.t * Pattern.t option
-    | Ppat_variant of Label.t * Pattern.t option
+    | Ppat_variant of string * Pattern.t option
     | Ppat_record of (Longident_loc.t * Pattern.t) list * Closed_flag.t
     | Ppat_array of Pattern.t list
     | Ppat_or of Pattern.t * Pattern.t
@@ -474,7 +463,7 @@ and Pattern_desc : sig
     -> Pattern.t option
     -> t
   val ppat_variant :
-    Label.t
+    string
     -> Pattern.t option
     -> t
   val ppat_record :
@@ -546,7 +535,7 @@ and Expression_desc : sig
     | Pexp_try of Expression.t * Case.t list
     | Pexp_tuple of Expression.t list
     | Pexp_construct of Longident_loc.t * Expression.t option
-    | Pexp_variant of Label.t * Expression.t option
+    | Pexp_variant of string * Expression.t option
     | Pexp_record of (Longident_loc.t * Expression.t) list * Expression.t option
     | Pexp_field of Expression.t * Longident_loc.t
     | Pexp_setfield of Expression.t * Longident_loc.t * Expression.t
@@ -557,10 +546,10 @@ and Expression_desc : sig
     | Pexp_for of Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t
     | Pexp_constraint of Expression.t * Core_type.t
     | Pexp_coerce of Expression.t * Core_type.t option * Core_type.t
-    | Pexp_send of Expression.t * Label.t Astlib.Loc.t
+    | Pexp_send of Expression.t * string Astlib.Loc.t
     | Pexp_new of Longident_loc.t
-    | Pexp_setinstvar of Label.t Astlib.Loc.t * Expression.t
-    | Pexp_override of (Label.t Astlib.Loc.t * Expression.t) list
+    | Pexp_setinstvar of string Astlib.Loc.t * Expression.t
+    | Pexp_override of (string Astlib.Loc.t * Expression.t) list
     | Pexp_letmodule of string Astlib.Loc.t * Module_expr.t * Expression.t
     | Pexp_letexception of Extension_constructor.t * Expression.t
     | Pexp_assert of Expression.t
@@ -616,7 +605,7 @@ and Expression_desc : sig
     -> Expression.t option
     -> t
   val pexp_variant :
-    Label.t
+    string
     -> Expression.t option
     -> t
   val pexp_record :
@@ -666,17 +655,17 @@ and Expression_desc : sig
     -> t
   val pexp_send :
     Expression.t
-    -> Label.t Astlib.Loc.t
+    -> string Astlib.Loc.t
     -> t
   val pexp_new :
     Longident_loc.t
     -> t
   val pexp_setinstvar :
-    Label.t Astlib.Loc.t
+    string Astlib.Loc.t
     -> Expression.t
     -> t
   val pexp_override :
-    (Label.t Astlib.Loc.t * Expression.t) list
+    (string Astlib.Loc.t * Expression.t) list
     -> t
   val pexp_letmodule :
     string Astlib.Loc.t
@@ -1033,8 +1022,8 @@ and Class_type_field_desc : sig
 
   type concrete =
     | Pctf_inherit of Class_type.t
-    | Pctf_val of (Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
-    | Pctf_method of (Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
+    | Pctf_val of (string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
+    | Pctf_method of (string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
     | Pctf_constraint of (Core_type.t * Core_type.t)
     | Pctf_attribute of Attribute.t
     | Pctf_extension of Extension.t
@@ -1046,10 +1035,10 @@ and Class_type_field_desc : sig
     Class_type.t
     -> t
   val pctf_val :
-    (Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
+    (string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
     -> t
   val pctf_method :
-    (Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
+    (string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
     -> t
   val pctf_constraint :
     (Core_type.t * Core_type.t)
@@ -1221,8 +1210,8 @@ and Class_field_desc : sig
 
   type concrete =
     | Pcf_inherit of Override_flag.t * Class_expr.t * string Astlib.Loc.t option
-    | Pcf_val of (Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
-    | Pcf_method of (Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
+    | Pcf_val of (string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
+    | Pcf_method of (string Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
     | Pcf_constraint of (Core_type.t * Core_type.t)
     | Pcf_initializer of Expression.t
     | Pcf_attribute of Attribute.t
@@ -1237,10 +1226,10 @@ and Class_field_desc : sig
     -> string Astlib.Loc.t option
     -> t
   val pcf_val :
-    (Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
+    (string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
     -> t
   val pcf_method :
-    (Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
+    (string Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
     -> t
   val pcf_constraint :
     (Core_type.t * Core_type.t)

--- a/ast/version_v4_07.mli
+++ b/ast/version_v4_07.mli
@@ -26,7 +26,14 @@ module rec Longident : sig
 end
 
 and Longident_loc : sig
-  type t = Longident.t Astlib.Loc.t
+  type t = longident_loc
+
+  type concrete = Longident.t Astlib.Loc.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Longident.t Astlib.Loc.t -> t
 end
 
 and Rec_flag : sig
@@ -128,7 +135,14 @@ and Closed_flag : sig
 end
 
 and Label : sig
-  type t = string
+  type t = label
+
+  type concrete = string
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : string -> t
 end
 
 and Arg_label : sig
@@ -1074,11 +1088,25 @@ and Class_infos : sig
 end
 
 and Class_description : sig
-  type t = Class_type.t Class_infos.t
+  type t = class_description
+
+  type concrete = Class_type.t Class_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Class_type.t Class_infos.t -> t
 end
 
 and Class_type_declaration : sig
-  type t = Class_type.t Class_infos.t
+  type t = class_type_declaration
+
+  type concrete = Class_type.t Class_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Class_type.t Class_infos.t -> t
 end
 
 and Class_expr : sig
@@ -1248,7 +1276,14 @@ and Class_field_kind : sig
 end
 
 and Class_declaration : sig
-  type t = Class_expr.t Class_infos.t
+  type t = class_declaration
+
+  type concrete = Class_expr.t Class_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Class_expr.t Class_infos.t -> t
 end
 
 and Module_type : sig
@@ -1486,11 +1521,25 @@ and Include_infos : sig
 end
 
 and Include_description : sig
-  type t = Module_type.t Include_infos.t
+  type t = include_description
+
+  type concrete = Module_type.t Include_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Module_type.t Include_infos.t -> t
 end
 
 and Include_declaration : sig
-  type t = Module_expr.t Include_infos.t
+  type t = include_declaration
+
+  type concrete = Module_expr.t Include_infos.t
+
+  val of_concrete : concrete -> t
+  val to_concrete : t -> concrete option
+
+  val create : Module_expr.t Include_infos.t -> t
 end
 
 and With_constraint : sig

--- a/ast/viewer_unstable_for_testing.ml
+++ b/ast/viewer_unstable_for_testing.ml
@@ -396,6 +396,14 @@ let pstr_desc'match view value =
   in
   view concrete.Structure_item.pstr_desc
 
+let structure'const view value =
+  let concrete0 =
+    match Structure.to_concrete value with
+    | None -> conversion_failed "structure"
+    | Some n -> n
+  in
+  view concrete0
+
 let pmod_extension'const view value =
   let parent_concrete =
     match Module_expr.to_concrete value with
@@ -571,6 +579,22 @@ let pwith_type'const view value =
   match concrete with
   | With_constraint.Pwith_type (arg0, arg1) -> view (arg0, arg1)
   | _ -> View.error
+
+let include_declaration'const view value =
+  let concrete0 =
+    match Include_declaration.to_concrete value with
+    | None -> conversion_failed "include_declaration"
+    | Some n -> n
+  in
+  view concrete0
+
+let include_description'const view value =
+  let concrete0 =
+    match Include_description.to_concrete value with
+    | None -> conversion_failed "include_description"
+    | Some n -> n
+  in
+  view concrete0
 
 let pincl_attributes'match view value =
   let concrete =
@@ -916,6 +940,14 @@ let psig_desc'match view value =
   in
   view concrete.Signature_item.psig_desc
 
+let signature'const view value =
+  let concrete0 =
+    match Signature.to_concrete value with
+    | None -> conversion_failed "signature"
+    | Some n -> n
+  in
+  view concrete0
+
 let pmty_alias'const view value =
   let parent_concrete =
     match Module_type.to_concrete value with
@@ -1051,6 +1083,14 @@ let pmty_desc'match view value =
     | Some n -> n
   in
   view concrete.Module_type.pmty_desc
+
+let class_declaration'const view value =
+  let concrete0 =
+    match Class_declaration.to_concrete value with
+    | None -> conversion_failed "class_declaration"
+    | Some n -> n
+  in
+  view concrete0
 
 let cfk_concrete'const view value =
   let concrete =
@@ -1375,6 +1415,22 @@ let pcl_desc'match view value =
     | Some n -> n
   in
   view concrete.Class_expr.pcl_desc
+
+let class_type_declaration'const view value =
+  let concrete0 =
+    match Class_type_declaration.to_concrete value with
+    | None -> conversion_failed "class_type_declaration"
+    | Some n -> n
+  in
+  view concrete0
+
+let class_description'const view value =
+  let concrete0 =
+    match Class_description.to_concrete value with
+    | None -> conversion_failed "class_description"
+    | Some n -> n
+  in
+  view concrete0
 
 let pci_attributes'match view value =
   let concrete =
@@ -2976,6 +3032,14 @@ let rtag'const view value =
   | Row_field.Rtag (arg0, arg1, arg2, arg3) -> view (arg0, arg1, arg2, arg3)
   | _ -> View.error
 
+let package_type'const view value =
+  let concrete0 =
+    match Package_type.to_concrete value with
+    | None -> conversion_failed "package_type"
+    | Some n -> n
+  in
+  view concrete0
+
 let ptyp_extension'const view value =
   let parent_concrete =
     match Core_type.to_concrete value with
@@ -3232,6 +3296,30 @@ let pstr'const view value =
   | Payload.PStr arg -> view arg
   | _ -> View.error
 
+let attributes'const view value =
+  let concrete0 =
+    match Attributes.to_concrete value with
+    | None -> conversion_failed "attributes"
+    | Some n -> n
+  in
+  view concrete0
+
+let extension'const view value =
+  let concrete0 =
+    match Extension.to_concrete value with
+    | None -> conversion_failed "extension"
+    | Some n -> n
+  in
+  view concrete0
+
+let attribute'const view value =
+  let concrete0 =
+    match Attribute.to_concrete value with
+    | None -> conversion_failed "attribute"
+    | Some n -> n
+  in
+  view concrete0
+
 let pconst_float'const view value =
   let concrete =
     match Constant.to_concrete value with
@@ -3331,6 +3419,14 @@ let nolabel'const value =
   match concrete with
   | Arg_label.Nolabel -> View.ok
   | _ -> View.error
+
+let label'const view value =
+  let concrete0 =
+    match Label.to_concrete value with
+    | None -> conversion_failed "label"
+    | Some n -> n
+  in
+  view concrete0
 
 let open'const value =
   let concrete =
@@ -3471,6 +3567,14 @@ let nonrecursive'const value =
   match concrete with
   | Rec_flag.Nonrecursive -> View.ok
   | _ -> View.error
+
+let longident_loc'const view value =
+  let concrete0 =
+    match Longident_loc.to_concrete value with
+    | None -> conversion_failed "longident_loc"
+    | Some n -> n
+  in
+  view concrete0
 
 let lapply'const view value =
   let concrete =

--- a/ast/viewer_unstable_for_testing.ml
+++ b/ast/viewer_unstable_for_testing.ml
@@ -3420,14 +3420,6 @@ let nolabel'const value =
   | Arg_label.Nolabel -> View.ok
   | _ -> View.error
 
-let label'const view value =
-  let concrete0 =
-    match Label.to_concrete value with
-    | None -> conversion_failed "label"
-    | Some n -> n
-  in
-  view concrete0
-
 let open'const value =
   let concrete =
     match Closed_flag.to_concrete value with

--- a/ast/viewer_unstable_for_testing.mli
+++ b/ast/viewer_unstable_for_testing.mli
@@ -135,8 +135,8 @@ val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o
 val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_method'const : ((Class_field_kind.t * Private_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_val'const : ((Class_field_kind.t * Mutable_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_method'const : ((Class_field_kind.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_val'const : ((Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 val pcf_inherit'const : ((string Astlib.Loc.t option * Class_expr.t * Override_flag.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 
 val pcf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
@@ -179,8 +179,8 @@ val pci_virt'match : (Virtual_flag.t, 'i, 'o) View.t -> ('a node Class_infos.t, 
 val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_method'const : ((Core_type.t * Virtual_flag.t * Private_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_val'const : ((Core_type.t * Virtual_flag.t * Mutable_flag.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_method'const : ((Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_val'const : ((Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 
 val pctf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
@@ -295,10 +295,10 @@ val pexp_lazy'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) Vi
 val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_letexception'const : ((Expression.t * Extension_constructor.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_letmodule'const : ((Expression.t * Module_expr.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_override'const : ((Expression.t * Label.t Astlib.Loc.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_setinstvar'const : ((Expression.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_override'const : ((Expression.t * string Astlib.Loc.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_setinstvar'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_send'const : ((Label.t Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_send'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_coerce'const : ((Core_type.t * Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_constraint'const : ((Core_type.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_for'const : ((Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
@@ -309,7 +309,7 @@ val pexp_array'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 
 val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_field'const : ((Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_record'const : ((Expression.t option * (Expression.t * Longident_loc.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_variant'const : ((Expression.t option * Label.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_variant'const : ((Expression.t option * string), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_construct'const : ((Expression.t option * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_try'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
@@ -336,7 +336,7 @@ val ppat_constraint'const : ((Core_type.t * Pattern.t), 'i, 'o) View.t -> (Patte
 val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_record'const : ((Closed_flag.t * (Pattern.t * Longident_loc.t) list), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_variant'const : ((Pattern.t option * Label.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ppat_variant'const : ((Pattern.t option * string), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_construct'const : ((Pattern.t option * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
@@ -352,14 +352,14 @@ val ppat_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) V
 
 val ppat_desc'match : (Pattern_desc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val oinherit'const : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
-val otag'const : ((Core_type.t * Attributes.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+val otag'const : ((Core_type.t * Attributes.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
 val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
-val rtag'const : ((Core_type.t list * bool * Attributes.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+val rtag'const : ((Core_type.t list * bool * Attributes.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
 val package_type'const: (((Core_type.t * Longident_loc.t) list * Longident_loc.t), 'i, 'o) View.t -> (Package_type.t, 'i, 'o) View.t
 val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_poly'const : ((Core_type.t * string Astlib.Loc.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_variant'const : ((Label.t list option * Closed_flag.t * Row_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ptyp_variant'const : ((string list option * Closed_flag.t * Row_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_alias'const : ((string * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_class'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_object'const : ((Closed_flag.t * Object_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
@@ -396,7 +396,6 @@ val optional'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
 val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
 
 val nolabel'const : (Arg_label.t, 'a, 'a) View.t
-val label'const: (string, 'i, 'o) View.t -> (Label.t, 'i, 'o) View.t
 
 val open'const : (Closed_flag.t, 'a, 'a) View.t
 

--- a/ast/viewer_unstable_for_testing.mli
+++ b/ast/viewer_unstable_for_testing.mli
@@ -47,6 +47,7 @@ val pstr_eval'const : ((Attributes.t * Expression.t), 'i, 'o) View.t -> (Structu
 val pstr_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 
 val pstr_desc'match : (Structure_item_desc.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val structure'const: (Structure_item.t list, 'i, 'o) View.t -> (Structure.t, 'i, 'o) View.t
 val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 val pmod_constraint'const : ((Module_type.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
@@ -64,6 +65,8 @@ val pwith_modsubst'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t 
 val pwith_typesubst'const : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
 val pwith_module'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
 val pwith_type'const : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+val include_declaration'const: (Module_expr.t Include_infos.t, 'i, 'o) View.t -> (Include_declaration.t, 'i, 'o) View.t
+val include_description'const: (Module_type.t Include_infos.t, 'i, 'o) View.t -> (Include_description.t, 'i, 'o) View.t
 
 val pincl_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
 
@@ -111,6 +114,7 @@ val psig_value'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t
 val psig_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
 val psig_desc'match : (Signature_item_desc.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val signature'const: (Signature_item.t list, 'i, 'o) View.t -> (Signature.t, 'i, 'o) View.t
 val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
@@ -124,6 +128,7 @@ val pmty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_type.t, 'i,
 val pmty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
 val pmty_desc'match : (Module_type_desc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val class_declaration'const: (Class_expr.t Class_infos.t, 'i, 'o) View.t -> (Class_declaration.t, 'i, 'o) View.t
 val cfk_concrete'const : ((Expression.t * Override_flag.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
 val cfk_virtual'const : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
 val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
@@ -157,6 +162,8 @@ val pcl_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_expr.t, 'i, '
 val pcl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
 val pcl_desc'match : (Class_expr_desc.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val class_type_declaration'const: (Class_type.t Class_infos.t, 'i, 'o) View.t -> (Class_type_declaration.t, 'i, 'o) View.t
+val class_description'const: (Class_type.t Class_infos.t, 'i, 'o) View.t -> (Class_description.t, 'i, 'o) View.t
 
 val pci_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
 
@@ -348,6 +355,7 @@ val oinherit'const : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) Vi
 val otag'const : ((Core_type.t * Attributes.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
 val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
 val rtag'const : ((Core_type.t list * bool * Attributes.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+val package_type'const: (((Core_type.t * Longident_loc.t) list * Longident_loc.t), 'i, 'o) View.t -> (Package_type.t, 'i, 'o) View.t
 val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_poly'const : ((Core_type.t * string Astlib.Loc.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
@@ -371,6 +379,9 @@ val ppat'const : ((Expression.t option * Pattern.t), 'i, 'o) View.t -> (Payload.
 val ptyp'const : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
 val psig'const : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
 val pstr'const : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+val attributes'const: (Attribute.t list, 'i, 'o) View.t -> (Attributes.t, 'i, 'o) View.t
+val extension'const: ((Payload.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Extension.t, 'i, 'o) View.t
+val attribute'const: ((Payload.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Attribute.t, 'i, 'o) View.t
 val pconst_float'const : ((char option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
 val pconst_string'const : ((string option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
 val pconst_char'const : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
@@ -385,6 +396,7 @@ val optional'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
 val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
 
 val nolabel'const : (Arg_label.t, 'a, 'a) View.t
+val label'const: (string, 'i, 'o) View.t -> (Label.t, 'i, 'o) View.t
 
 val open'const : (Closed_flag.t, 'a, 'a) View.t
 
@@ -413,6 +425,7 @@ val upto'const : (Direction_flag.t, 'a, 'a) View.t
 val recursive'const : (Rec_flag.t, 'a, 'a) View.t
 
 val nonrecursive'const : (Rec_flag.t, 'a, 'a) View.t
+val longident_loc'const: (Longident.t Astlib.Loc.t, 'i, 'o) View.t -> (Longident_loc.t, 'i, 'o) View.t
 val lapply'const : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
 val ldot'const : ((string * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
 val lident'const : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t

--- a/ast/viewer_v4_07.ml
+++ b/ast/viewer_v4_07.ml
@@ -184,14 +184,6 @@ let open'const value =
   | Closed_flag.Open -> View.ok
   | _ -> View.error
 
-let label'const view value =
-  let concrete0 =
-    match Label.to_concrete value with
-    | None -> conversion_failed "label"
-    | Some n -> n
-  in
-  view concrete0
-
 let nolabel'const value =
   let concrete =
     match Arg_label.to_concrete value with

--- a/ast/viewer_v4_07.ml
+++ b/ast/viewer_v4_07.ml
@@ -36,6 +36,14 @@ let lapply'const view value =
   | Longident.Lapply (arg0, arg1) -> view (arg0, arg1)
   | _ -> View.error
 
+let longident_loc'const view value =
+  let concrete0 =
+    match Longident_loc.to_concrete value with
+    | None -> conversion_failed "longident_loc"
+    | Some n -> n
+  in
+  view concrete0
+
 let nonrecursive'const value =
   let concrete =
     match Rec_flag.to_concrete value with
@@ -176,6 +184,14 @@ let open'const value =
   | Closed_flag.Open -> View.ok
   | _ -> View.error
 
+let label'const view value =
+  let concrete0 =
+    match Label.to_concrete value with
+    | None -> conversion_failed "label"
+    | Some n -> n
+  in
+  view concrete0
+
 let nolabel'const value =
   let concrete =
     match Arg_label.to_concrete value with
@@ -275,6 +291,30 @@ let pconst_float'const view value =
   match concrete with
   | Constant.Pconst_float (arg0, arg1) -> view (arg0, arg1)
   | _ -> View.error
+
+let attribute'const view value =
+  let concrete0 =
+    match Attribute.to_concrete value with
+    | None -> conversion_failed "attribute"
+    | Some n -> n
+  in
+  view concrete0
+
+let extension'const view value =
+  let concrete0 =
+    match Extension.to_concrete value with
+    | None -> conversion_failed "extension"
+    | Some n -> n
+  in
+  view concrete0
+
+let attributes'const view value =
+  let concrete0 =
+    match Attributes.to_concrete value with
+    | None -> conversion_failed "attributes"
+    | Some n -> n
+  in
+  view concrete0
 
 let pstr'const view value =
   let concrete =
@@ -531,6 +571,14 @@ let ptyp_extension'const view value =
   match concrete with
   | Core_type_desc.Ptyp_extension arg -> view arg
   | _ -> View.error
+
+let package_type'const view value =
+  let concrete0 =
+    match Package_type.to_concrete value with
+    | None -> conversion_failed "package_type"
+    | Some n -> n
+  in
+  view concrete0
 
 let rtag'const view value =
   let concrete =
@@ -2132,6 +2180,22 @@ let pci_attributes'match view value =
   in
   view concrete.Class_infos.pci_attributes
 
+let class_description'const view value =
+  let concrete0 =
+    match Class_description.to_concrete value with
+    | None -> conversion_failed "class_description"
+    | Some n -> n
+  in
+  view concrete0
+
+let class_type_declaration'const view value =
+  let concrete0 =
+    match Class_type_declaration.to_concrete value with
+    | None -> conversion_failed "class_type_declaration"
+    | Some n -> n
+  in
+  view concrete0
+
 let pcl_desc'match view value =
   let concrete =
     match Class_expr.to_concrete value with
@@ -2456,6 +2520,14 @@ let cfk_concrete'const view value =
   | Class_field_kind.Cfk_concrete (arg0, arg1) -> view (arg0, arg1)
   | _ -> View.error
 
+let class_declaration'const view value =
+  let concrete0 =
+    match Class_declaration.to_concrete value with
+    | None -> conversion_failed "class_declaration"
+    | Some n -> n
+  in
+  view concrete0
+
 let pmty_desc'match view value =
   let concrete =
     match Module_type.to_concrete value with
@@ -2591,6 +2663,14 @@ let pmty_alias'const view value =
   match concrete with
   | Module_type_desc.Pmty_alias arg -> view arg
   | _ -> View.error
+
+let signature'const view value =
+  let concrete0 =
+    match Signature.to_concrete value with
+    | None -> conversion_failed "signature"
+    | Some n -> n
+  in
+  view concrete0
 
 let psig_desc'match view value =
   let concrete =
@@ -2936,6 +3016,22 @@ let pincl_attributes'match view value =
   in
   view concrete.Include_infos.pincl_attributes
 
+let include_description'const view value =
+  let concrete0 =
+    match Include_description.to_concrete value with
+    | None -> conversion_failed "include_description"
+    | Some n -> n
+  in
+  view concrete0
+
+let include_declaration'const view value =
+  let concrete0 =
+    match Include_declaration.to_concrete value with
+    | None -> conversion_failed "include_declaration"
+    | Some n -> n
+  in
+  view concrete0
+
 let pwith_type'const view value =
   let concrete =
     match With_constraint.to_concrete value with
@@ -3111,6 +3207,14 @@ let pmod_extension'const view value =
   match concrete with
   | Module_expr_desc.Pmod_extension arg -> view arg
   | _ -> View.error
+
+let structure'const view value =
+  let concrete0 =
+    match Structure.to_concrete value with
+    | None -> conversion_failed "structure"
+    | Some n -> n
+  in
+  view concrete0
 
 let pstr_desc'match view value =
   let concrete =

--- a/ast/viewer_v4_07.mli
+++ b/ast/viewer_v4_07.mli
@@ -36,7 +36,6 @@ val fresh'const : (Override_flag.t, 'a, 'a) View.t
 val closed'const : (Closed_flag.t, 'a, 'a) View.t
 
 val open'const : (Closed_flag.t, 'a, 'a) View.t
-val label'const: (string, 'i, 'o) View.t -> (Label.t, 'i, 'o) View.t
 
 val nolabel'const : (Arg_label.t, 'a, 'a) View.t
 val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
@@ -73,14 +72,14 @@ val ptyp_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t ->
 val ptyp_object'const : ((Object_field.t list * Closed_flag.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_class'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_alias'const : ((Core_type.t * string), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val ptyp_variant'const : ((Row_field.t list * Closed_flag.t * Label.t list option), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ptyp_variant'const : ((Row_field.t list * Closed_flag.t * string list option), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_poly'const : ((string Astlib.Loc.t list * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val package_type'const: ((Longident_loc.t * (Longident_loc.t * Core_type.t) list), 'i, 'o) View.t -> (Package_type.t, 'i, 'o) View.t
-val rtag'const : ((Label.t Astlib.Loc.t * Attributes.t * bool * Core_type.t list), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+val rtag'const : ((string Astlib.Loc.t * Attributes.t * bool * Core_type.t list), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
 val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
-val otag'const : ((Label.t Astlib.Loc.t * Attributes.t * Core_type.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+val otag'const : ((string Astlib.Loc.t * Attributes.t * Core_type.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
 val oinherit'const : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
 
 val ppat_desc'match : (Pattern_desc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
@@ -96,7 +95,7 @@ val ppat_constant'const : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) Vie
 val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_construct'const : ((Longident_loc.t * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
-val ppat_variant'const : ((Label.t * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ppat_variant'const : ((string * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_record'const : (((Longident_loc.t * Pattern.t) list * Closed_flag.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
 val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
@@ -123,7 +122,7 @@ val pexp_match'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Express
 val pexp_try'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_construct'const : ((Longident_loc.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_variant'const : ((Label.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_variant'const : ((string * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_record'const : (((Longident_loc.t * Expression.t) list * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_field'const : ((Expression.t * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
@@ -134,10 +133,10 @@ val pexp_while'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expres
 val pexp_for'const : ((Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_constraint'const : ((Expression.t * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_coerce'const : ((Expression.t * Core_type.t option * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_send'const : ((Expression.t * Label.t Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_send'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_setinstvar'const : ((Label.t Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
-val pexp_override'const : ((Label.t Astlib.Loc.t * Expression.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_setinstvar'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_override'const : ((string Astlib.Loc.t * Expression.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_letmodule'const : ((string Astlib.Loc.t * Module_expr.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_letexception'const : ((Extension_constructor.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
 val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
@@ -252,8 +251,8 @@ val pctf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type_field.t, 
 
 val pctf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_val'const : ((Label.t Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
-val pctf_method'const : ((Label.t Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_val'const : ((string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_method'const : ((string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
 val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
@@ -296,8 +295,8 @@ val pcf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o
 
 val pcf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 val pcf_inherit'const : ((Override_flag.t * Class_expr.t * string Astlib.Loc.t option), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_val'const : ((Label.t Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
-val pcf_method'const : ((Label.t Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_val'const : ((string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_method'const : ((string Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t

--- a/ast/viewer_v4_07.mli
+++ b/ast/viewer_v4_07.mli
@@ -7,6 +7,7 @@ include module type of Viewer_common
 val lident'const : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
 val ldot'const : ((Longident.t * string), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
 val lapply'const : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+val longident_loc'const: (Longident.t Astlib.Loc.t, 'i, 'o) View.t -> (Longident_loc.t, 'i, 'o) View.t
 
 val nonrecursive'const : (Rec_flag.t, 'a, 'a) View.t
 
@@ -35,6 +36,7 @@ val fresh'const : (Override_flag.t, 'a, 'a) View.t
 val closed'const : (Closed_flag.t, 'a, 'a) View.t
 
 val open'const : (Closed_flag.t, 'a, 'a) View.t
+val label'const: (string, 'i, 'o) View.t -> (Label.t, 'i, 'o) View.t
 
 val nolabel'const : (Arg_label.t, 'a, 'a) View.t
 val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
@@ -49,6 +51,9 @@ val pconst_integer'const : ((string * char option), 'i, 'o) View.t -> (Constant.
 val pconst_char'const : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
 val pconst_string'const : ((string * string option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
 val pconst_float'const : ((string * char option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+val attribute'const: ((string Astlib.Loc.t * Payload.t), 'i, 'o) View.t -> (Attribute.t, 'i, 'o) View.t
+val extension'const: ((string Astlib.Loc.t * Payload.t), 'i, 'o) View.t -> (Extension.t, 'i, 'o) View.t
+val attributes'const: (Attribute.t list, 'i, 'o) View.t -> (Attributes.t, 'i, 'o) View.t
 val pstr'const : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
 val psig'const : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
 val ptyp'const : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
@@ -72,6 +77,7 @@ val ptyp_variant'const : ((Row_field.t list * Closed_flag.t * Label.t list optio
 val ptyp_poly'const : ((string Astlib.Loc.t list * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
 val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val package_type'const: ((Longident_loc.t * (Longident_loc.t * Core_type.t) list), 'i, 'o) View.t -> (Package_type.t, 'i, 'o) View.t
 val rtag'const : ((Label.t Astlib.Loc.t * Attributes.t * bool * Core_type.t list), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
 val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
 val otag'const : ((Label.t Astlib.Loc.t * Attributes.t * Core_type.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
@@ -263,6 +269,8 @@ val pci_expr'match : ('a node, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o)
 val pci_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
 
 val pci_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val class_description'const: (Class_type.t Class_infos.t, 'i, 'o) View.t -> (Class_description.t, 'i, 'o) View.t
+val class_type_declaration'const: (Class_type.t Class_infos.t, 'i, 'o) View.t -> (Class_type_declaration.t, 'i, 'o) View.t
 
 val pcl_desc'match : (Class_expr_desc.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
 
@@ -296,6 +304,7 @@ val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o
 val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
 val cfk_virtual'const : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
 val cfk_concrete'const : ((Override_flag.t * Expression.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+val class_declaration'const: (Class_expr.t Class_infos.t, 'i, 'o) View.t -> (Class_declaration.t, 'i, 'o) View.t
 
 val pmty_desc'match : (Module_type_desc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 
@@ -309,6 +318,7 @@ val pmty_with'const : ((Module_type.t * With_constraint.t list), 'i, 'o) View.t 
 val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
 val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val signature'const: (Signature_item.t list, 'i, 'o) View.t -> (Signature.t, 'i, 'o) View.t
 
 val psig_desc'match : (Signature_item_desc.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
 
@@ -356,6 +366,8 @@ val pincl_mod'match : ('a node, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 
 val pincl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
 
 val pincl_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
+val include_description'const: (Module_type.t Include_infos.t, 'i, 'o) View.t -> (Include_description.t, 'i, 'o) View.t
+val include_declaration'const: (Module_expr.t Include_infos.t, 'i, 'o) View.t -> (Include_declaration.t, 'i, 'o) View.t
 val pwith_type'const : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
 val pwith_module'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
 val pwith_typesubst'const : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
@@ -373,6 +385,7 @@ val pmod_apply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Modu
 val pmod_constraint'const : ((Module_expr.t * Module_type.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
 val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val structure'const: (Structure_item.t list, 'i, 'o) View.t -> (Structure.t, 'i, 'o) View.t
 
 val pstr_desc'match : (Structure_item_desc.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
 

--- a/ast/virtual_traverse_unstable_for_testing.ml
+++ b/ast/virtual_traverse_unstable_for_testing.ml
@@ -225,12 +225,22 @@ class virtual map =
           With_constraint.of_concrete (Pwith_type (x0, x1))
     method include_declaration : Include_declaration.t -> Include_declaration.t  =
       fun include_declaration ->
-        let include_declaration = self#include_infos_module_expr include_declaration in
-        include_declaration
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_expr concrete in
+        Include_declaration.of_concrete concrete
     method include_description : Include_description.t -> Include_description.t  =
       fun include_description ->
-        let include_description = self#include_infos_module_type include_description in
-        include_description
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_type concrete in
+        Include_description.of_concrete concrete
     method include_infos_module_expr : Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t  =
       fun include_infos ->
         let concrete =
@@ -409,8 +419,13 @@ class virtual map =
         Module_type.of_concrete { pmty_attributes; pmty_loc; pmty_desc }
     method class_declaration : Class_declaration.t -> Class_declaration.t  =
       fun class_declaration ->
-        let class_declaration = self#class_infos_class_expr class_declaration in
-        class_declaration
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_expr concrete in
+        Class_declaration.of_concrete concrete
     method class_field_kind : Class_field_kind.t -> Class_field_kind.t  =
       fun class_field_kind ->
         let concrete =
@@ -536,12 +551,22 @@ class virtual map =
         Class_expr.of_concrete { pcl_attributes; pcl_loc; pcl_desc }
     method class_type_declaration : Class_type_declaration.t -> Class_type_declaration.t  =
       fun class_type_declaration ->
-        let class_type_declaration = self#class_infos_class_type class_type_declaration in
-        class_type_declaration
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type concrete in
+        Class_type_declaration.of_concrete concrete
     method class_description : Class_description.t -> Class_description.t  =
       fun class_description ->
-        let class_description = self#class_infos_class_type class_description in
-        class_description
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type concrete in
+        Class_description.of_concrete concrete
     method class_infos_class_expr : Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t  =
       fun class_infos ->
         let concrete =
@@ -1263,8 +1288,13 @@ class virtual map =
           Arg_label.of_concrete Nolabel
     method label : Label.t -> Label.t  =
       fun label ->
-        let label = self#string label in
-        label
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let concrete = self#string concrete in
+        Label.of_concrete concrete
     method closed_flag : Closed_flag.t -> Closed_flag.t  =
       fun closed_flag ->
         let concrete =
@@ -1351,8 +1381,13 @@ class virtual map =
           Rec_flag.of_concrete Nonrecursive
     method longident_loc : Longident_loc.t -> Longident_loc.t  =
       fun longident_loc ->
-        let longident_loc = self#loc self#longident longident_loc in
-        longident_loc
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let concrete = self#loc self#longident concrete in
+        Longident_loc.of_concrete concrete
     method longident : Longident.t -> Longident.t  =
       fun longident ->
         let concrete =
@@ -1559,10 +1594,20 @@ class virtual iter =
           self#longident_loc x1
     method include_declaration : Include_declaration.t -> unit  =
       fun include_declaration ->
-        self#include_infos_module_expr include_declaration
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        self#include_infos_module_expr concrete
     method include_description : Include_description.t -> unit  =
       fun include_description ->
-        self#include_infos_module_type include_description
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        self#include_infos_module_type concrete
     method include_infos_module_expr : Module_expr.t Include_infos.t -> unit  =
       fun include_infos ->
         let concrete =
@@ -1713,7 +1758,12 @@ class virtual iter =
         self#module_type_desc pmty_desc
     method class_declaration : Class_declaration.t -> unit  =
       fun class_declaration ->
-        self#class_infos_class_expr class_declaration
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        self#class_infos_class_expr concrete
     method class_field_kind : Class_field_kind.t -> unit  =
       fun class_field_kind ->
         let concrete =
@@ -1819,10 +1869,20 @@ class virtual iter =
         self#class_expr_desc pcl_desc
     method class_type_declaration : Class_type_declaration.t -> unit  =
       fun class_type_declaration ->
-        self#class_infos_class_type class_type_declaration
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        self#class_infos_class_type concrete
     method class_description : Class_description.t -> unit  =
       fun class_description ->
-        self#class_infos_class_type class_description
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        self#class_infos_class_type concrete
     method class_infos_class_expr : Class_expr.t Class_infos.t -> unit  =
       fun class_infos ->
         let concrete =
@@ -2431,7 +2491,12 @@ class virtual iter =
           ()
     method label : Label.t -> unit  =
       fun label ->
-        self#string label
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        self#string concrete
     method closed_flag : Closed_flag.t -> unit  =
       fun closed_flag ->
         let concrete =
@@ -2518,7 +2583,12 @@ class virtual iter =
           ()
     method longident_loc : Longident_loc.t -> unit  =
       fun longident_loc ->
-        self#loc self#longident longident_loc
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        self#loc self#longident concrete
     method longident : Longident.t -> unit  =
       fun longident ->
         let concrete =
@@ -2759,11 +2829,21 @@ class virtual ['acc] fold =
           acc
     method include_declaration : Include_declaration.t -> 'acc -> 'acc  =
       fun include_declaration acc ->
-        let acc = self#include_infos_module_expr include_declaration acc in
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let acc = self#include_infos_module_expr concrete acc in
         acc
     method include_description : Include_description.t -> 'acc -> 'acc  =
       fun include_description acc ->
-        let acc = self#include_infos_module_type include_description acc in
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let acc = self#include_infos_module_type concrete acc in
         acc
     method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> 'acc  =
       fun include_infos acc ->
@@ -2943,7 +3023,12 @@ class virtual ['acc] fold =
         acc
     method class_declaration : Class_declaration.t -> 'acc -> 'acc  =
       fun class_declaration acc ->
-        let acc = self#class_infos_class_expr class_declaration acc in
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let acc = self#class_infos_class_expr concrete acc in
         acc
     method class_field_kind : Class_field_kind.t -> 'acc -> 'acc  =
       fun class_field_kind acc ->
@@ -3070,11 +3155,21 @@ class virtual ['acc] fold =
         acc
     method class_type_declaration : Class_type_declaration.t -> 'acc -> 'acc  =
       fun class_type_declaration acc ->
-        let acc = self#class_infos_class_type class_type_declaration acc in
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let acc = self#class_infos_class_type concrete acc in
         acc
     method class_description : Class_description.t -> 'acc -> 'acc  =
       fun class_description acc ->
-        let acc = self#class_infos_class_type class_description acc in
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let acc = self#class_infos_class_type concrete acc in
         acc
     method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> 'acc  =
       fun class_infos acc ->
@@ -3797,7 +3892,12 @@ class virtual ['acc] fold =
           acc
     method label : Label.t -> 'acc -> 'acc  =
       fun label acc ->
-        let acc = self#string label acc in
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let acc = self#string concrete acc in
         acc
     method closed_flag : Closed_flag.t -> 'acc -> 'acc  =
       fun closed_flag acc ->
@@ -3885,7 +3985,12 @@ class virtual ['acc] fold =
           acc
     method longident_loc : Longident_loc.t -> 'acc -> 'acc  =
       fun longident_loc acc ->
-        let acc = self#loc self#longident longident_loc acc in
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let acc = self#loc self#longident concrete acc in
         acc
     method longident : Longident.t -> 'acc -> 'acc  =
       fun longident acc ->
@@ -4130,12 +4235,22 @@ class virtual ['acc] fold_map =
           (With_constraint.of_concrete (Pwith_type (x0, x1)), acc)
     method include_declaration : Include_declaration.t -> 'acc -> (Include_declaration.t * 'acc)  =
       fun include_declaration acc ->
-        let (include_declaration, acc) = self#include_infos_module_expr include_declaration acc in
-        (include_declaration, acc)
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#include_infos_module_expr concrete acc in
+        (Include_declaration.of_concrete concrete, acc)
     method include_description : Include_description.t -> 'acc -> (Include_description.t * 'acc)  =
       fun include_description acc ->
-        let (include_description, acc) = self#include_infos_module_type include_description acc in
-        (include_description, acc)
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#include_infos_module_type concrete acc in
+        (Include_description.of_concrete concrete, acc)
     method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> (Module_expr.t Include_infos.t * 'acc)  =
       fun include_infos acc ->
         let concrete =
@@ -4314,8 +4429,13 @@ class virtual ['acc] fold_map =
         (Module_type.of_concrete { pmty_attributes; pmty_loc; pmty_desc }, acc)
     method class_declaration : Class_declaration.t -> 'acc -> (Class_declaration.t * 'acc)  =
       fun class_declaration acc ->
-        let (class_declaration, acc) = self#class_infos_class_expr class_declaration acc in
-        (class_declaration, acc)
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#class_infos_class_expr concrete acc in
+        (Class_declaration.of_concrete concrete, acc)
     method class_field_kind : Class_field_kind.t -> 'acc -> (Class_field_kind.t * 'acc)  =
       fun class_field_kind acc ->
         let concrete =
@@ -4441,12 +4561,22 @@ class virtual ['acc] fold_map =
         (Class_expr.of_concrete { pcl_attributes; pcl_loc; pcl_desc }, acc)
     method class_type_declaration : Class_type_declaration.t -> 'acc -> (Class_type_declaration.t * 'acc)  =
       fun class_type_declaration acc ->
-        let (class_type_declaration, acc) = self#class_infos_class_type class_type_declaration acc in
-        (class_type_declaration, acc)
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#class_infos_class_type concrete acc in
+        (Class_type_declaration.of_concrete concrete, acc)
     method class_description : Class_description.t -> 'acc -> (Class_description.t * 'acc)  =
       fun class_description acc ->
-        let (class_description, acc) = self#class_infos_class_type class_description acc in
-        (class_description, acc)
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#class_infos_class_type concrete acc in
+        (Class_description.of_concrete concrete, acc)
     method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> (Class_expr.t Class_infos.t * 'acc)  =
       fun class_infos acc ->
         let concrete =
@@ -5168,8 +5298,13 @@ class virtual ['acc] fold_map =
           (Arg_label.of_concrete Nolabel, acc)
     method label : Label.t -> 'acc -> (Label.t * 'acc)  =
       fun label acc ->
-        let (label, acc) = self#string label acc in
-        (label, acc)
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#string concrete acc in
+        (Label.of_concrete concrete, acc)
     method closed_flag : Closed_flag.t -> 'acc -> (Closed_flag.t * 'acc)  =
       fun closed_flag acc ->
         let concrete =
@@ -5256,8 +5391,13 @@ class virtual ['acc] fold_map =
           (Rec_flag.of_concrete Nonrecursive, acc)
     method longident_loc : Longident_loc.t -> 'acc -> (Longident_loc.t * 'acc)  =
       fun longident_loc acc ->
-        let (longident_loc, acc) = self#loc self#longident longident_loc acc in
-        (longident_loc, acc)
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#loc self#longident concrete acc in
+        (Longident_loc.of_concrete concrete, acc)
     method longident : Longident.t -> 'acc -> (Longident.t * 'acc)  =
       fun longident acc ->
         let concrete =
@@ -5501,12 +5641,22 @@ class virtual ['ctx] map_with_context =
           With_constraint.of_concrete (Pwith_type (x0, x1))
     method include_declaration : 'ctx -> Include_declaration.t -> Include_declaration.t  =
       fun _ctx include_declaration ->
-        let include_declaration = self#include_infos_module_expr _ctx include_declaration in
-        include_declaration
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_expr _ctx concrete in
+        Include_declaration.of_concrete concrete
     method include_description : 'ctx -> Include_description.t -> Include_description.t  =
       fun _ctx include_description ->
-        let include_description = self#include_infos_module_type _ctx include_description in
-        include_description
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_type _ctx concrete in
+        Include_description.of_concrete concrete
     method include_infos_module_expr : 'ctx -> Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t  =
       fun _ctx include_infos ->
         let concrete =
@@ -5685,8 +5835,13 @@ class virtual ['ctx] map_with_context =
         Module_type.of_concrete { pmty_attributes; pmty_loc; pmty_desc }
     method class_declaration : 'ctx -> Class_declaration.t -> Class_declaration.t  =
       fun _ctx class_declaration ->
-        let class_declaration = self#class_infos_class_expr _ctx class_declaration in
-        class_declaration
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_expr _ctx concrete in
+        Class_declaration.of_concrete concrete
     method class_field_kind : 'ctx -> Class_field_kind.t -> Class_field_kind.t  =
       fun _ctx class_field_kind ->
         let concrete =
@@ -5812,12 +5967,22 @@ class virtual ['ctx] map_with_context =
         Class_expr.of_concrete { pcl_attributes; pcl_loc; pcl_desc }
     method class_type_declaration : 'ctx -> Class_type_declaration.t -> Class_type_declaration.t  =
       fun _ctx class_type_declaration ->
-        let class_type_declaration = self#class_infos_class_type _ctx class_type_declaration in
-        class_type_declaration
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type _ctx concrete in
+        Class_type_declaration.of_concrete concrete
     method class_description : 'ctx -> Class_description.t -> Class_description.t  =
       fun _ctx class_description ->
-        let class_description = self#class_infos_class_type _ctx class_description in
-        class_description
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type _ctx concrete in
+        Class_description.of_concrete concrete
     method class_infos_class_expr : 'ctx -> Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t  =
       fun _ctx class_infos ->
         let concrete =
@@ -6539,8 +6704,13 @@ class virtual ['ctx] map_with_context =
           Arg_label.of_concrete Nolabel
     method label : 'ctx -> Label.t -> Label.t  =
       fun _ctx label ->
-        let label = self#string _ctx label in
-        label
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let concrete = self#string _ctx concrete in
+        Label.of_concrete concrete
     method closed_flag : 'ctx -> Closed_flag.t -> Closed_flag.t  =
       fun _ctx closed_flag ->
         let concrete =
@@ -6627,8 +6797,13 @@ class virtual ['ctx] map_with_context =
           Rec_flag.of_concrete Nonrecursive
     method longident_loc : 'ctx -> Longident_loc.t -> Longident_loc.t  =
       fun _ctx longident_loc ->
-        let longident_loc = self#loc self#longident _ctx longident_loc in
-        longident_loc
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let concrete = self#loc self#longident _ctx concrete in
+        Longident_loc.of_concrete concrete
     method longident : 'ctx -> Longident.t -> Longident.t  =
       fun _ctx longident ->
         let concrete =
@@ -6876,12 +7051,22 @@ class virtual ['res] lift =
           self#constr (Some ("with_constraint", 0)) "Pwith_type" [x0; x1]
     method include_declaration : Include_declaration.t -> 'res  =
       fun include_declaration ->
-        let include_declaration = self#include_infos_module_expr include_declaration in
-        self#node None include_declaration
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_expr concrete in
+        self#node (Some ("include_declaration", 0)) concrete
     method include_description : Include_description.t -> 'res  =
       fun include_description ->
-        let include_description = self#include_infos_module_type include_description in
-        self#node None include_description
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_type concrete in
+        self#node (Some ("include_description", 0)) concrete
     method include_infos_module_expr : Module_expr.t Include_infos.t -> 'res  =
       fun include_infos ->
         let concrete =
@@ -7060,8 +7245,13 @@ class virtual ['res] lift =
         self#record (Some ("module_type", 0)) [("pmty_attributes", pmty_attributes); ("pmty_loc", pmty_loc); ("pmty_desc", pmty_desc)]
     method class_declaration : Class_declaration.t -> 'res  =
       fun class_declaration ->
-        let class_declaration = self#class_infos_class_expr class_declaration in
-        self#node None class_declaration
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_expr concrete in
+        self#node (Some ("class_declaration", 0)) concrete
     method class_field_kind : Class_field_kind.t -> 'res  =
       fun class_field_kind ->
         let concrete =
@@ -7187,12 +7377,22 @@ class virtual ['res] lift =
         self#record (Some ("class_expr", 0)) [("pcl_attributes", pcl_attributes); ("pcl_loc", pcl_loc); ("pcl_desc", pcl_desc)]
     method class_type_declaration : Class_type_declaration.t -> 'res  =
       fun class_type_declaration ->
-        let class_type_declaration = self#class_infos_class_type class_type_declaration in
-        self#node None class_type_declaration
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type concrete in
+        self#node (Some ("class_type_declaration", 0)) concrete
     method class_description : Class_description.t -> 'res  =
       fun class_description ->
-        let class_description = self#class_infos_class_type class_description in
-        self#node None class_description
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type concrete in
+        self#node (Some ("class_description", 0)) concrete
     method class_infos_class_expr : Class_expr.t Class_infos.t -> 'res  =
       fun class_infos ->
         let concrete =
@@ -7914,8 +8114,13 @@ class virtual ['res] lift =
           self#constr (Some ("arg_label", 0)) "Nolabel" []
     method label : Label.t -> 'res  =
       fun label ->
-        let label = self#string label in
-        self#node None label
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let concrete = self#string concrete in
+        self#node (Some ("label", 0)) concrete
     method closed_flag : Closed_flag.t -> 'res  =
       fun closed_flag ->
         let concrete =
@@ -8002,8 +8207,13 @@ class virtual ['res] lift =
           self#constr (Some ("rec_flag", 0)) "Nonrecursive" []
     method longident_loc : Longident_loc.t -> 'res  =
       fun longident_loc ->
-        let longident_loc = self#loc self#longident longident_loc in
-        self#node None longident_loc
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let concrete = self#loc self#longident concrete in
+        self#node (Some ("longident_loc", 0)) concrete
     method longident : Longident.t -> 'res  =
       fun longident ->
         let concrete =

--- a/ast/virtual_traverse_unstable_for_testing.ml
+++ b/ast/virtual_traverse_unstable_for_testing.ml
@@ -462,10 +462,10 @@ class virtual map =
           let x0 = (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#core_type x1 in (x0, x1)) x0 in
           Class_field_desc.of_concrete (Pcf_constraint x0)
         | Pcf_method x0 ->
-          let x0 = (fun (x0, x1, x2) -> let x0 = self#class_field_kind x0 in let x1 = self#private_flag x1 in let x2 = self#loc self#label x2 in (x0, x1, x2)) x0 in
+          let x0 = (fun (x0, x1, x2) -> let x0 = self#class_field_kind x0 in let x1 = self#private_flag x1 in let x2 = self#loc self#string x2 in (x0, x1, x2)) x0 in
           Class_field_desc.of_concrete (Pcf_method x0)
         | Pcf_val x0 ->
-          let x0 = (fun (x0, x1, x2) -> let x0 = self#class_field_kind x0 in let x1 = self#mutable_flag x1 in let x2 = self#loc self#label x2 in (x0, x1, x2)) x0 in
+          let x0 = (fun (x0, x1, x2) -> let x0 = self#class_field_kind x0 in let x1 = self#mutable_flag x1 in let x2 = self#loc self#string x2 in (x0, x1, x2)) x0 in
           Class_field_desc.of_concrete (Pcf_val x0)
         | Pcf_inherit (x0, x1, x2) ->
           let x0 = self#option (self#loc self#string) x0 in
@@ -615,10 +615,10 @@ class virtual map =
           let x0 = (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#core_type x1 in (x0, x1)) x0 in
           Class_type_field_desc.of_concrete (Pctf_constraint x0)
         | Pctf_method x0 ->
-          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#core_type x0 in let x1 = self#virtual_flag x1 in let x2 = self#private_flag x2 in let x3 = self#loc self#label x3 in (x0, x1, x2, x3)) x0 in
+          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#core_type x0 in let x1 = self#virtual_flag x1 in let x2 = self#private_flag x2 in let x3 = self#loc self#string x3 in (x0, x1, x2, x3)) x0 in
           Class_type_field_desc.of_concrete (Pctf_method x0)
         | Pctf_val x0 ->
-          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#core_type x0 in let x1 = self#virtual_flag x1 in let x2 = self#mutable_flag x2 in let x3 = self#loc self#label x3 in (x0, x1, x2, x3)) x0 in
+          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#core_type x0 in let x1 = self#virtual_flag x1 in let x2 = self#mutable_flag x2 in let x3 = self#loc self#string x3 in (x0, x1, x2, x3)) x0 in
           Class_type_field_desc.of_concrete (Pctf_val x0)
         | Pctf_inherit x0 ->
           let x0 = self#class_type x0 in
@@ -879,17 +879,17 @@ class virtual map =
           let x2 = self#loc self#string x2 in
           Expression_desc.of_concrete (Pexp_letmodule (x0, x1, x2))
         | Pexp_override x0 ->
-          let x0 = self#list (fun (x0, x1) -> let x0 = self#expression x0 in let x1 = self#loc self#label x1 in (x0, x1)) x0 in
+          let x0 = self#list (fun (x0, x1) -> let x0 = self#expression x0 in let x1 = self#loc self#string x1 in (x0, x1)) x0 in
           Expression_desc.of_concrete (Pexp_override x0)
         | Pexp_setinstvar (x0, x1) ->
           let x0 = self#expression x0 in
-          let x1 = self#loc self#label x1 in
+          let x1 = self#loc self#string x1 in
           Expression_desc.of_concrete (Pexp_setinstvar (x0, x1))
         | Pexp_new x0 ->
           let x0 = self#longident_loc x0 in
           Expression_desc.of_concrete (Pexp_new x0)
         | Pexp_send (x0, x1) ->
-          let x0 = self#loc self#label x0 in
+          let x0 = self#loc self#string x0 in
           let x1 = self#expression x1 in
           Expression_desc.of_concrete (Pexp_send (x0, x1))
         | Pexp_coerce (x0, x1, x2) ->
@@ -939,7 +939,7 @@ class virtual map =
           Expression_desc.of_concrete (Pexp_record (x0, x1))
         | Pexp_variant (x0, x1) ->
           let x0 = self#option self#expression x0 in
-          let x1 = self#label x1 in
+          let x1 = self#string x1 in
           Expression_desc.of_concrete (Pexp_variant (x0, x1))
         | Pexp_construct (x0, x1) ->
           let x0 = self#option self#expression x0 in
@@ -1036,7 +1036,7 @@ class virtual map =
           Pattern_desc.of_concrete (Ppat_record (x0, x1))
         | Ppat_variant (x0, x1) ->
           let x0 = self#option self#pattern x0 in
-          let x1 = self#label x1 in
+          let x1 = self#string x1 in
           Pattern_desc.of_concrete (Ppat_variant (x0, x1))
         | Ppat_construct (x0, x1) ->
           let x0 = self#option self#pattern x0 in
@@ -1087,7 +1087,7 @@ class virtual map =
         | Otag (x0, x1, x2) ->
           let x0 = self#core_type x0 in
           let x1 = self#attributes x1 in
-          let x2 = self#loc self#label x2 in
+          let x2 = self#loc self#string x2 in
           Object_field.of_concrete (Otag (x0, x1, x2))
     method row_field : Row_field.t -> Row_field.t  =
       fun row_field ->
@@ -1104,7 +1104,7 @@ class virtual map =
           let x0 = self#list self#core_type x0 in
           let x1 = self#bool x1 in
           let x2 = self#attributes x2 in
-          let x3 = self#loc self#label x3 in
+          let x3 = self#loc self#string x3 in
           Row_field.of_concrete (Rtag (x0, x1, x2, x3))
     method package_type : Package_type.t -> Package_type.t  =
       fun package_type ->
@@ -1136,7 +1136,7 @@ class virtual map =
           let x1 = self#list (self#loc self#string) x1 in
           Core_type_desc.of_concrete (Ptyp_poly (x0, x1))
         | Ptyp_variant (x0, x1, x2) ->
-          let x0 = self#option (self#list self#label) x0 in
+          let x0 = self#option (self#list self#string) x0 in
           let x1 = self#closed_flag x1 in
           let x2 = self#list self#row_field x2 in
           Core_type_desc.of_concrete (Ptyp_variant (x0, x1, x2))
@@ -1286,15 +1286,6 @@ class virtual map =
           Arg_label.of_concrete (Labelled x0)
         | Nolabel ->
           Arg_label.of_concrete Nolabel
-    method label : Label.t -> Label.t  =
-      fun label ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let concrete = self#string concrete in
-        Label.of_concrete concrete
     method closed_flag : Closed_flag.t -> Closed_flag.t  =
       fun closed_flag ->
         let concrete =
@@ -1794,9 +1785,9 @@ class virtual iter =
         | Pcf_constraint x0 ->
           (fun (x0, x1) -> self#core_type x0; self#core_type x1) x0
         | Pcf_method x0 ->
-          (fun (x0, x1, x2) -> self#class_field_kind x0; self#private_flag x1; self#loc self#label x2) x0
+          (fun (x0, x1, x2) -> self#class_field_kind x0; self#private_flag x1; self#loc self#string x2) x0
         | Pcf_val x0 ->
-          (fun (x0, x1, x2) -> self#class_field_kind x0; self#mutable_flag x1; self#loc self#label x2) x0
+          (fun (x0, x1, x2) -> self#class_field_kind x0; self#mutable_flag x1; self#loc self#string x2) x0
         | Pcf_inherit (x0, x1, x2) ->
           self#option (self#loc self#string) x0;
           self#class_expr x1;
@@ -1926,9 +1917,9 @@ class virtual iter =
         | Pctf_constraint x0 ->
           (fun (x0, x1) -> self#core_type x0; self#core_type x1) x0
         | Pctf_method x0 ->
-          (fun (x0, x1, x2, x3) -> self#core_type x0; self#virtual_flag x1; self#private_flag x2; self#loc self#label x3) x0
+          (fun (x0, x1, x2, x3) -> self#core_type x0; self#virtual_flag x1; self#private_flag x2; self#loc self#string x3) x0
         | Pctf_val x0 ->
-          (fun (x0, x1, x2, x3) -> self#core_type x0; self#virtual_flag x1; self#mutable_flag x2; self#loc self#label x3) x0
+          (fun (x0, x1, x2, x3) -> self#core_type x0; self#virtual_flag x1; self#mutable_flag x2; self#loc self#string x3) x0
         | Pctf_inherit x0 ->
           self#class_type x0
     method class_type_field : Class_type_field.t -> unit  =
@@ -2156,14 +2147,14 @@ class virtual iter =
           self#module_expr x1;
           self#loc self#string x2
         | Pexp_override x0 ->
-          self#list (fun (x0, x1) -> self#expression x0; self#loc self#label x1) x0
+          self#list (fun (x0, x1) -> self#expression x0; self#loc self#string x1) x0
         | Pexp_setinstvar (x0, x1) ->
           self#expression x0;
-          self#loc self#label x1
+          self#loc self#string x1
         | Pexp_new x0 ->
           self#longident_loc x0
         | Pexp_send (x0, x1) ->
-          self#loc self#label x0;
+          self#loc self#string x0;
           self#expression x1
         | Pexp_coerce (x0, x1, x2) ->
           self#core_type x0;
@@ -2202,7 +2193,7 @@ class virtual iter =
           self#list (fun (x0, x1) -> self#expression x0; self#longident_loc x1) x1
         | Pexp_variant (x0, x1) ->
           self#option self#expression x0;
-          self#label x1
+          self#string x1
         | Pexp_construct (x0, x1) ->
           self#option self#expression x0;
           self#longident_loc x1
@@ -2277,7 +2268,7 @@ class virtual iter =
           self#list (fun (x0, x1) -> self#pattern x0; self#longident_loc x1) x1
         | Ppat_variant (x0, x1) ->
           self#option self#pattern x0;
-          self#label x1
+          self#string x1
         | Ppat_construct (x0, x1) ->
           self#option self#pattern x0;
           self#longident_loc x1
@@ -2319,7 +2310,7 @@ class virtual iter =
         | Otag (x0, x1, x2) ->
           self#core_type x0;
           self#attributes x1;
-          self#loc self#label x2
+          self#loc self#string x2
     method row_field : Row_field.t -> unit  =
       fun row_field ->
         let concrete =
@@ -2334,7 +2325,7 @@ class virtual iter =
           self#list self#core_type x0;
           self#bool x1;
           self#attributes x2;
-          self#loc self#label x3
+          self#loc self#string x3
     method package_type : Package_type.t -> unit  =
       fun package_type ->
         let concrete =
@@ -2361,7 +2352,7 @@ class virtual iter =
           self#core_type x0;
           self#list (self#loc self#string) x1
         | Ptyp_variant (x0, x1, x2) ->
-          self#option (self#list self#label) x0;
+          self#option (self#list self#string) x0;
           self#closed_flag x1;
           self#list self#row_field x2
         | Ptyp_alias (x0, x1) ->
@@ -2489,14 +2480,6 @@ class virtual iter =
           self#string x0
         | Nolabel ->
           ()
-    method label : Label.t -> unit  =
-      fun label ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        self#string concrete
     method closed_flag : Closed_flag.t -> unit  =
       fun closed_flag ->
         let concrete =
@@ -3066,10 +3049,10 @@ class virtual ['acc] fold =
           let acc = (fun (x0, x1) acc -> let acc = self#core_type x0 acc in let acc = self#core_type x1 acc in acc) x0 acc in
           acc
         | Pcf_method x0 ->
-          let acc = (fun (x0, x1, x2) acc -> let acc = self#class_field_kind x0 acc in let acc = self#private_flag x1 acc in let acc = self#loc self#label x2 acc in acc) x0 acc in
+          let acc = (fun (x0, x1, x2) acc -> let acc = self#class_field_kind x0 acc in let acc = self#private_flag x1 acc in let acc = self#loc self#string x2 acc in acc) x0 acc in
           acc
         | Pcf_val x0 ->
-          let acc = (fun (x0, x1, x2) acc -> let acc = self#class_field_kind x0 acc in let acc = self#mutable_flag x1 acc in let acc = self#loc self#label x2 acc in acc) x0 acc in
+          let acc = (fun (x0, x1, x2) acc -> let acc = self#class_field_kind x0 acc in let acc = self#mutable_flag x1 acc in let acc = self#loc self#string x2 acc in acc) x0 acc in
           acc
         | Pcf_inherit (x0, x1, x2) ->
           let acc = self#option (self#loc self#string) x0 acc in
@@ -3219,10 +3202,10 @@ class virtual ['acc] fold =
           let acc = (fun (x0, x1) acc -> let acc = self#core_type x0 acc in let acc = self#core_type x1 acc in acc) x0 acc in
           acc
         | Pctf_method x0 ->
-          let acc = (fun (x0, x1, x2, x3) acc -> let acc = self#core_type x0 acc in let acc = self#virtual_flag x1 acc in let acc = self#private_flag x2 acc in let acc = self#loc self#label x3 acc in acc) x0 acc in
+          let acc = (fun (x0, x1, x2, x3) acc -> let acc = self#core_type x0 acc in let acc = self#virtual_flag x1 acc in let acc = self#private_flag x2 acc in let acc = self#loc self#string x3 acc in acc) x0 acc in
           acc
         | Pctf_val x0 ->
-          let acc = (fun (x0, x1, x2, x3) acc -> let acc = self#core_type x0 acc in let acc = self#virtual_flag x1 acc in let acc = self#mutable_flag x2 acc in let acc = self#loc self#label x3 acc in acc) x0 acc in
+          let acc = (fun (x0, x1, x2, x3) acc -> let acc = self#core_type x0 acc in let acc = self#virtual_flag x1 acc in let acc = self#mutable_flag x2 acc in let acc = self#loc self#string x3 acc in acc) x0 acc in
           acc
         | Pctf_inherit x0 ->
           let acc = self#class_type x0 acc in
@@ -3483,17 +3466,17 @@ class virtual ['acc] fold =
           let acc = self#loc self#string x2 acc in
           acc
         | Pexp_override x0 ->
-          let acc = self#list (fun (x0, x1) acc -> let acc = self#expression x0 acc in let acc = self#loc self#label x1 acc in acc) x0 acc in
+          let acc = self#list (fun (x0, x1) acc -> let acc = self#expression x0 acc in let acc = self#loc self#string x1 acc in acc) x0 acc in
           acc
         | Pexp_setinstvar (x0, x1) ->
           let acc = self#expression x0 acc in
-          let acc = self#loc self#label x1 acc in
+          let acc = self#loc self#string x1 acc in
           acc
         | Pexp_new x0 ->
           let acc = self#longident_loc x0 acc in
           acc
         | Pexp_send (x0, x1) ->
-          let acc = self#loc self#label x0 acc in
+          let acc = self#loc self#string x0 acc in
           let acc = self#expression x1 acc in
           acc
         | Pexp_coerce (x0, x1, x2) ->
@@ -3543,7 +3526,7 @@ class virtual ['acc] fold =
           acc
         | Pexp_variant (x0, x1) ->
           let acc = self#option self#expression x0 acc in
-          let acc = self#label x1 acc in
+          let acc = self#string x1 acc in
           acc
         | Pexp_construct (x0, x1) ->
           let acc = self#option self#expression x0 acc in
@@ -3640,7 +3623,7 @@ class virtual ['acc] fold =
           acc
         | Ppat_variant (x0, x1) ->
           let acc = self#option self#pattern x0 acc in
-          let acc = self#label x1 acc in
+          let acc = self#string x1 acc in
           acc
         | Ppat_construct (x0, x1) ->
           let acc = self#option self#pattern x0 acc in
@@ -3691,7 +3674,7 @@ class virtual ['acc] fold =
         | Otag (x0, x1, x2) ->
           let acc = self#core_type x0 acc in
           let acc = self#attributes x1 acc in
-          let acc = self#loc self#label x2 acc in
+          let acc = self#loc self#string x2 acc in
           acc
     method row_field : Row_field.t -> 'acc -> 'acc  =
       fun row_field acc ->
@@ -3708,7 +3691,7 @@ class virtual ['acc] fold =
           let acc = self#list self#core_type x0 acc in
           let acc = self#bool x1 acc in
           let acc = self#attributes x2 acc in
-          let acc = self#loc self#label x3 acc in
+          let acc = self#loc self#string x3 acc in
           acc
     method package_type : Package_type.t -> 'acc -> 'acc  =
       fun package_type acc ->
@@ -3740,7 +3723,7 @@ class virtual ['acc] fold =
           let acc = self#list (self#loc self#string) x1 acc in
           acc
         | Ptyp_variant (x0, x1, x2) ->
-          let acc = self#option (self#list self#label) x0 acc in
+          let acc = self#option (self#list self#string) x0 acc in
           let acc = self#closed_flag x1 acc in
           let acc = self#list self#row_field x2 acc in
           acc
@@ -3890,15 +3873,6 @@ class virtual ['acc] fold =
           acc
         | Nolabel ->
           acc
-    method label : Label.t -> 'acc -> 'acc  =
-      fun label acc ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let acc = self#string concrete acc in
-        acc
     method closed_flag : Closed_flag.t -> 'acc -> 'acc  =
       fun closed_flag acc ->
         let concrete =
@@ -4472,10 +4446,10 @@ class virtual ['acc] fold_map =
           let (x0, acc) = (fun (x0, x1) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#core_type x1 acc in ((x0, x1), acc)) x0 acc in
           (Class_field_desc.of_concrete (Pcf_constraint x0), acc)
         | Pcf_method x0 ->
-          let (x0, acc) = (fun (x0, x1, x2) acc -> let (x0, acc) = self#class_field_kind x0 acc in let (x1, acc) = self#private_flag x1 acc in let (x2, acc) = self#loc self#label x2 acc in ((x0, x1, x2), acc)) x0 acc in
+          let (x0, acc) = (fun (x0, x1, x2) acc -> let (x0, acc) = self#class_field_kind x0 acc in let (x1, acc) = self#private_flag x1 acc in let (x2, acc) = self#loc self#string x2 acc in ((x0, x1, x2), acc)) x0 acc in
           (Class_field_desc.of_concrete (Pcf_method x0), acc)
         | Pcf_val x0 ->
-          let (x0, acc) = (fun (x0, x1, x2) acc -> let (x0, acc) = self#class_field_kind x0 acc in let (x1, acc) = self#mutable_flag x1 acc in let (x2, acc) = self#loc self#label x2 acc in ((x0, x1, x2), acc)) x0 acc in
+          let (x0, acc) = (fun (x0, x1, x2) acc -> let (x0, acc) = self#class_field_kind x0 acc in let (x1, acc) = self#mutable_flag x1 acc in let (x2, acc) = self#loc self#string x2 acc in ((x0, x1, x2), acc)) x0 acc in
           (Class_field_desc.of_concrete (Pcf_val x0), acc)
         | Pcf_inherit (x0, x1, x2) ->
           let (x0, acc) = self#option (self#loc self#string) x0 acc in
@@ -4625,10 +4599,10 @@ class virtual ['acc] fold_map =
           let (x0, acc) = (fun (x0, x1) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#core_type x1 acc in ((x0, x1), acc)) x0 acc in
           (Class_type_field_desc.of_concrete (Pctf_constraint x0), acc)
         | Pctf_method x0 ->
-          let (x0, acc) = (fun (x0, x1, x2, x3) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#virtual_flag x1 acc in let (x2, acc) = self#private_flag x2 acc in let (x3, acc) = self#loc self#label x3 acc in ((x0, x1, x2, x3), acc)) x0 acc in
+          let (x0, acc) = (fun (x0, x1, x2, x3) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#virtual_flag x1 acc in let (x2, acc) = self#private_flag x2 acc in let (x3, acc) = self#loc self#string x3 acc in ((x0, x1, x2, x3), acc)) x0 acc in
           (Class_type_field_desc.of_concrete (Pctf_method x0), acc)
         | Pctf_val x0 ->
-          let (x0, acc) = (fun (x0, x1, x2, x3) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#virtual_flag x1 acc in let (x2, acc) = self#mutable_flag x2 acc in let (x3, acc) = self#loc self#label x3 acc in ((x0, x1, x2, x3), acc)) x0 acc in
+          let (x0, acc) = (fun (x0, x1, x2, x3) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#virtual_flag x1 acc in let (x2, acc) = self#mutable_flag x2 acc in let (x3, acc) = self#loc self#string x3 acc in ((x0, x1, x2, x3), acc)) x0 acc in
           (Class_type_field_desc.of_concrete (Pctf_val x0), acc)
         | Pctf_inherit x0 ->
           let (x0, acc) = self#class_type x0 acc in
@@ -4889,17 +4863,17 @@ class virtual ['acc] fold_map =
           let (x2, acc) = self#loc self#string x2 acc in
           (Expression_desc.of_concrete (Pexp_letmodule (x0, x1, x2)), acc)
         | Pexp_override x0 ->
-          let (x0, acc) = self#list (fun (x0, x1) acc -> let (x0, acc) = self#expression x0 acc in let (x1, acc) = self#loc self#label x1 acc in ((x0, x1), acc)) x0 acc in
+          let (x0, acc) = self#list (fun (x0, x1) acc -> let (x0, acc) = self#expression x0 acc in let (x1, acc) = self#loc self#string x1 acc in ((x0, x1), acc)) x0 acc in
           (Expression_desc.of_concrete (Pexp_override x0), acc)
         | Pexp_setinstvar (x0, x1) ->
           let (x0, acc) = self#expression x0 acc in
-          let (x1, acc) = self#loc self#label x1 acc in
+          let (x1, acc) = self#loc self#string x1 acc in
           (Expression_desc.of_concrete (Pexp_setinstvar (x0, x1)), acc)
         | Pexp_new x0 ->
           let (x0, acc) = self#longident_loc x0 acc in
           (Expression_desc.of_concrete (Pexp_new x0), acc)
         | Pexp_send (x0, x1) ->
-          let (x0, acc) = self#loc self#label x0 acc in
+          let (x0, acc) = self#loc self#string x0 acc in
           let (x1, acc) = self#expression x1 acc in
           (Expression_desc.of_concrete (Pexp_send (x0, x1)), acc)
         | Pexp_coerce (x0, x1, x2) ->
@@ -4949,7 +4923,7 @@ class virtual ['acc] fold_map =
           (Expression_desc.of_concrete (Pexp_record (x0, x1)), acc)
         | Pexp_variant (x0, x1) ->
           let (x0, acc) = self#option self#expression x0 acc in
-          let (x1, acc) = self#label x1 acc in
+          let (x1, acc) = self#string x1 acc in
           (Expression_desc.of_concrete (Pexp_variant (x0, x1)), acc)
         | Pexp_construct (x0, x1) ->
           let (x0, acc) = self#option self#expression x0 acc in
@@ -5046,7 +5020,7 @@ class virtual ['acc] fold_map =
           (Pattern_desc.of_concrete (Ppat_record (x0, x1)), acc)
         | Ppat_variant (x0, x1) ->
           let (x0, acc) = self#option self#pattern x0 acc in
-          let (x1, acc) = self#label x1 acc in
+          let (x1, acc) = self#string x1 acc in
           (Pattern_desc.of_concrete (Ppat_variant (x0, x1)), acc)
         | Ppat_construct (x0, x1) ->
           let (x0, acc) = self#option self#pattern x0 acc in
@@ -5097,7 +5071,7 @@ class virtual ['acc] fold_map =
         | Otag (x0, x1, x2) ->
           let (x0, acc) = self#core_type x0 acc in
           let (x1, acc) = self#attributes x1 acc in
-          let (x2, acc) = self#loc self#label x2 acc in
+          let (x2, acc) = self#loc self#string x2 acc in
           (Object_field.of_concrete (Otag (x0, x1, x2)), acc)
     method row_field : Row_field.t -> 'acc -> (Row_field.t * 'acc)  =
       fun row_field acc ->
@@ -5114,7 +5088,7 @@ class virtual ['acc] fold_map =
           let (x0, acc) = self#list self#core_type x0 acc in
           let (x1, acc) = self#bool x1 acc in
           let (x2, acc) = self#attributes x2 acc in
-          let (x3, acc) = self#loc self#label x3 acc in
+          let (x3, acc) = self#loc self#string x3 acc in
           (Row_field.of_concrete (Rtag (x0, x1, x2, x3)), acc)
     method package_type : Package_type.t -> 'acc -> (Package_type.t * 'acc)  =
       fun package_type acc ->
@@ -5146,7 +5120,7 @@ class virtual ['acc] fold_map =
           let (x1, acc) = self#list (self#loc self#string) x1 acc in
           (Core_type_desc.of_concrete (Ptyp_poly (x0, x1)), acc)
         | Ptyp_variant (x0, x1, x2) ->
-          let (x0, acc) = self#option (self#list self#label) x0 acc in
+          let (x0, acc) = self#option (self#list self#string) x0 acc in
           let (x1, acc) = self#closed_flag x1 acc in
           let (x2, acc) = self#list self#row_field x2 acc in
           (Core_type_desc.of_concrete (Ptyp_variant (x0, x1, x2)), acc)
@@ -5296,15 +5270,6 @@ class virtual ['acc] fold_map =
           (Arg_label.of_concrete (Labelled x0), acc)
         | Nolabel ->
           (Arg_label.of_concrete Nolabel, acc)
-    method label : Label.t -> 'acc -> (Label.t * 'acc)  =
-      fun label acc ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let (concrete, acc) = self#string concrete acc in
-        (Label.of_concrete concrete, acc)
     method closed_flag : Closed_flag.t -> 'acc -> (Closed_flag.t * 'acc)  =
       fun closed_flag acc ->
         let concrete =
@@ -5878,10 +5843,10 @@ class virtual ['ctx] map_with_context =
           let x0 = (fun _ctx (x0, x1) -> let x0 = self#core_type _ctx x0 in let x1 = self#core_type _ctx x1 in (x0, x1)) _ctx x0 in
           Class_field_desc.of_concrete (Pcf_constraint x0)
         | Pcf_method x0 ->
-          let x0 = (fun _ctx (x0, x1, x2) -> let x0 = self#class_field_kind _ctx x0 in let x1 = self#private_flag _ctx x1 in let x2 = self#loc self#label _ctx x2 in (x0, x1, x2)) _ctx x0 in
+          let x0 = (fun _ctx (x0, x1, x2) -> let x0 = self#class_field_kind _ctx x0 in let x1 = self#private_flag _ctx x1 in let x2 = self#loc self#string _ctx x2 in (x0, x1, x2)) _ctx x0 in
           Class_field_desc.of_concrete (Pcf_method x0)
         | Pcf_val x0 ->
-          let x0 = (fun _ctx (x0, x1, x2) -> let x0 = self#class_field_kind _ctx x0 in let x1 = self#mutable_flag _ctx x1 in let x2 = self#loc self#label _ctx x2 in (x0, x1, x2)) _ctx x0 in
+          let x0 = (fun _ctx (x0, x1, x2) -> let x0 = self#class_field_kind _ctx x0 in let x1 = self#mutable_flag _ctx x1 in let x2 = self#loc self#string _ctx x2 in (x0, x1, x2)) _ctx x0 in
           Class_field_desc.of_concrete (Pcf_val x0)
         | Pcf_inherit (x0, x1, x2) ->
           let x0 = self#option (self#loc self#string) _ctx x0 in
@@ -6031,10 +5996,10 @@ class virtual ['ctx] map_with_context =
           let x0 = (fun _ctx (x0, x1) -> let x0 = self#core_type _ctx x0 in let x1 = self#core_type _ctx x1 in (x0, x1)) _ctx x0 in
           Class_type_field_desc.of_concrete (Pctf_constraint x0)
         | Pctf_method x0 ->
-          let x0 = (fun _ctx (x0, x1, x2, x3) -> let x0 = self#core_type _ctx x0 in let x1 = self#virtual_flag _ctx x1 in let x2 = self#private_flag _ctx x2 in let x3 = self#loc self#label _ctx x3 in (x0, x1, x2, x3)) _ctx x0 in
+          let x0 = (fun _ctx (x0, x1, x2, x3) -> let x0 = self#core_type _ctx x0 in let x1 = self#virtual_flag _ctx x1 in let x2 = self#private_flag _ctx x2 in let x3 = self#loc self#string _ctx x3 in (x0, x1, x2, x3)) _ctx x0 in
           Class_type_field_desc.of_concrete (Pctf_method x0)
         | Pctf_val x0 ->
-          let x0 = (fun _ctx (x0, x1, x2, x3) -> let x0 = self#core_type _ctx x0 in let x1 = self#virtual_flag _ctx x1 in let x2 = self#mutable_flag _ctx x2 in let x3 = self#loc self#label _ctx x3 in (x0, x1, x2, x3)) _ctx x0 in
+          let x0 = (fun _ctx (x0, x1, x2, x3) -> let x0 = self#core_type _ctx x0 in let x1 = self#virtual_flag _ctx x1 in let x2 = self#mutable_flag _ctx x2 in let x3 = self#loc self#string _ctx x3 in (x0, x1, x2, x3)) _ctx x0 in
           Class_type_field_desc.of_concrete (Pctf_val x0)
         | Pctf_inherit x0 ->
           let x0 = self#class_type _ctx x0 in
@@ -6295,17 +6260,17 @@ class virtual ['ctx] map_with_context =
           let x2 = self#loc self#string _ctx x2 in
           Expression_desc.of_concrete (Pexp_letmodule (x0, x1, x2))
         | Pexp_override x0 ->
-          let x0 = self#list (fun _ctx (x0, x1) -> let x0 = self#expression _ctx x0 in let x1 = self#loc self#label _ctx x1 in (x0, x1)) _ctx x0 in
+          let x0 = self#list (fun _ctx (x0, x1) -> let x0 = self#expression _ctx x0 in let x1 = self#loc self#string _ctx x1 in (x0, x1)) _ctx x0 in
           Expression_desc.of_concrete (Pexp_override x0)
         | Pexp_setinstvar (x0, x1) ->
           let x0 = self#expression _ctx x0 in
-          let x1 = self#loc self#label _ctx x1 in
+          let x1 = self#loc self#string _ctx x1 in
           Expression_desc.of_concrete (Pexp_setinstvar (x0, x1))
         | Pexp_new x0 ->
           let x0 = self#longident_loc _ctx x0 in
           Expression_desc.of_concrete (Pexp_new x0)
         | Pexp_send (x0, x1) ->
-          let x0 = self#loc self#label _ctx x0 in
+          let x0 = self#loc self#string _ctx x0 in
           let x1 = self#expression _ctx x1 in
           Expression_desc.of_concrete (Pexp_send (x0, x1))
         | Pexp_coerce (x0, x1, x2) ->
@@ -6355,7 +6320,7 @@ class virtual ['ctx] map_with_context =
           Expression_desc.of_concrete (Pexp_record (x0, x1))
         | Pexp_variant (x0, x1) ->
           let x0 = self#option self#expression _ctx x0 in
-          let x1 = self#label _ctx x1 in
+          let x1 = self#string _ctx x1 in
           Expression_desc.of_concrete (Pexp_variant (x0, x1))
         | Pexp_construct (x0, x1) ->
           let x0 = self#option self#expression _ctx x0 in
@@ -6452,7 +6417,7 @@ class virtual ['ctx] map_with_context =
           Pattern_desc.of_concrete (Ppat_record (x0, x1))
         | Ppat_variant (x0, x1) ->
           let x0 = self#option self#pattern _ctx x0 in
-          let x1 = self#label _ctx x1 in
+          let x1 = self#string _ctx x1 in
           Pattern_desc.of_concrete (Ppat_variant (x0, x1))
         | Ppat_construct (x0, x1) ->
           let x0 = self#option self#pattern _ctx x0 in
@@ -6503,7 +6468,7 @@ class virtual ['ctx] map_with_context =
         | Otag (x0, x1, x2) ->
           let x0 = self#core_type _ctx x0 in
           let x1 = self#attributes _ctx x1 in
-          let x2 = self#loc self#label _ctx x2 in
+          let x2 = self#loc self#string _ctx x2 in
           Object_field.of_concrete (Otag (x0, x1, x2))
     method row_field : 'ctx -> Row_field.t -> Row_field.t  =
       fun _ctx row_field ->
@@ -6520,7 +6485,7 @@ class virtual ['ctx] map_with_context =
           let x0 = self#list self#core_type _ctx x0 in
           let x1 = self#bool _ctx x1 in
           let x2 = self#attributes _ctx x2 in
-          let x3 = self#loc self#label _ctx x3 in
+          let x3 = self#loc self#string _ctx x3 in
           Row_field.of_concrete (Rtag (x0, x1, x2, x3))
     method package_type : 'ctx -> Package_type.t -> Package_type.t  =
       fun _ctx package_type ->
@@ -6552,7 +6517,7 @@ class virtual ['ctx] map_with_context =
           let x1 = self#list (self#loc self#string) _ctx x1 in
           Core_type_desc.of_concrete (Ptyp_poly (x0, x1))
         | Ptyp_variant (x0, x1, x2) ->
-          let x0 = self#option (self#list self#label) _ctx x0 in
+          let x0 = self#option (self#list self#string) _ctx x0 in
           let x1 = self#closed_flag _ctx x1 in
           let x2 = self#list self#row_field _ctx x2 in
           Core_type_desc.of_concrete (Ptyp_variant (x0, x1, x2))
@@ -6702,15 +6667,6 @@ class virtual ['ctx] map_with_context =
           Arg_label.of_concrete (Labelled x0)
         | Nolabel ->
           Arg_label.of_concrete Nolabel
-    method label : 'ctx -> Label.t -> Label.t  =
-      fun _ctx label ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let concrete = self#string _ctx concrete in
-        Label.of_concrete concrete
     method closed_flag : 'ctx -> Closed_flag.t -> Closed_flag.t  =
       fun _ctx closed_flag ->
         let concrete =
@@ -7288,10 +7244,10 @@ class virtual ['res] lift =
           let x0 = (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#core_type x1 in self#node None (self#tuple [x0; x1])) x0 in
           self#constr (Some ("class_field_desc", 0)) "Pcf_constraint" [x0]
         | Pcf_method x0 ->
-          let x0 = (fun (x0, x1, x2) -> let x0 = self#class_field_kind x0 in let x1 = self#private_flag x1 in let x2 = self#loc self#label x2 in self#node None (self#tuple [x0; x1; x2])) x0 in
+          let x0 = (fun (x0, x1, x2) -> let x0 = self#class_field_kind x0 in let x1 = self#private_flag x1 in let x2 = self#loc self#string x2 in self#node None (self#tuple [x0; x1; x2])) x0 in
           self#constr (Some ("class_field_desc", 0)) "Pcf_method" [x0]
         | Pcf_val x0 ->
-          let x0 = (fun (x0, x1, x2) -> let x0 = self#class_field_kind x0 in let x1 = self#mutable_flag x1 in let x2 = self#loc self#label x2 in self#node None (self#tuple [x0; x1; x2])) x0 in
+          let x0 = (fun (x0, x1, x2) -> let x0 = self#class_field_kind x0 in let x1 = self#mutable_flag x1 in let x2 = self#loc self#string x2 in self#node None (self#tuple [x0; x1; x2])) x0 in
           self#constr (Some ("class_field_desc", 0)) "Pcf_val" [x0]
         | Pcf_inherit (x0, x1, x2) ->
           let x0 = self#option (self#loc self#string) x0 in
@@ -7441,10 +7397,10 @@ class virtual ['res] lift =
           let x0 = (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#core_type x1 in self#node None (self#tuple [x0; x1])) x0 in
           self#constr (Some ("class_type_field_desc", 0)) "Pctf_constraint" [x0]
         | Pctf_method x0 ->
-          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#core_type x0 in let x1 = self#virtual_flag x1 in let x2 = self#private_flag x2 in let x3 = self#loc self#label x3 in self#node None (self#tuple [x0; x1; x2; x3])) x0 in
+          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#core_type x0 in let x1 = self#virtual_flag x1 in let x2 = self#private_flag x2 in let x3 = self#loc self#string x3 in self#node None (self#tuple [x0; x1; x2; x3])) x0 in
           self#constr (Some ("class_type_field_desc", 0)) "Pctf_method" [x0]
         | Pctf_val x0 ->
-          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#core_type x0 in let x1 = self#virtual_flag x1 in let x2 = self#mutable_flag x2 in let x3 = self#loc self#label x3 in self#node None (self#tuple [x0; x1; x2; x3])) x0 in
+          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#core_type x0 in let x1 = self#virtual_flag x1 in let x2 = self#mutable_flag x2 in let x3 = self#loc self#string x3 in self#node None (self#tuple [x0; x1; x2; x3])) x0 in
           self#constr (Some ("class_type_field_desc", 0)) "Pctf_val" [x0]
         | Pctf_inherit x0 ->
           let x0 = self#class_type x0 in
@@ -7705,17 +7661,17 @@ class virtual ['res] lift =
           let x2 = self#loc self#string x2 in
           self#constr (Some ("expression_desc", 0)) "Pexp_letmodule" [x0; x1; x2]
         | Pexp_override x0 ->
-          let x0 = self#list (fun (x0, x1) -> let x0 = self#expression x0 in let x1 = self#loc self#label x1 in self#node None (self#tuple [x0; x1])) x0 in
+          let x0 = self#list (fun (x0, x1) -> let x0 = self#expression x0 in let x1 = self#loc self#string x1 in self#node None (self#tuple [x0; x1])) x0 in
           self#constr (Some ("expression_desc", 0)) "Pexp_override" [x0]
         | Pexp_setinstvar (x0, x1) ->
           let x0 = self#expression x0 in
-          let x1 = self#loc self#label x1 in
+          let x1 = self#loc self#string x1 in
           self#constr (Some ("expression_desc", 0)) "Pexp_setinstvar" [x0; x1]
         | Pexp_new x0 ->
           let x0 = self#longident_loc x0 in
           self#constr (Some ("expression_desc", 0)) "Pexp_new" [x0]
         | Pexp_send (x0, x1) ->
-          let x0 = self#loc self#label x0 in
+          let x0 = self#loc self#string x0 in
           let x1 = self#expression x1 in
           self#constr (Some ("expression_desc", 0)) "Pexp_send" [x0; x1]
         | Pexp_coerce (x0, x1, x2) ->
@@ -7765,7 +7721,7 @@ class virtual ['res] lift =
           self#constr (Some ("expression_desc", 0)) "Pexp_record" [x0; x1]
         | Pexp_variant (x0, x1) ->
           let x0 = self#option self#expression x0 in
-          let x1 = self#label x1 in
+          let x1 = self#string x1 in
           self#constr (Some ("expression_desc", 0)) "Pexp_variant" [x0; x1]
         | Pexp_construct (x0, x1) ->
           let x0 = self#option self#expression x0 in
@@ -7862,7 +7818,7 @@ class virtual ['res] lift =
           self#constr (Some ("pattern_desc", 0)) "Ppat_record" [x0; x1]
         | Ppat_variant (x0, x1) ->
           let x0 = self#option self#pattern x0 in
-          let x1 = self#label x1 in
+          let x1 = self#string x1 in
           self#constr (Some ("pattern_desc", 0)) "Ppat_variant" [x0; x1]
         | Ppat_construct (x0, x1) ->
           let x0 = self#option self#pattern x0 in
@@ -7913,7 +7869,7 @@ class virtual ['res] lift =
         | Otag (x0, x1, x2) ->
           let x0 = self#core_type x0 in
           let x1 = self#attributes x1 in
-          let x2 = self#loc self#label x2 in
+          let x2 = self#loc self#string x2 in
           self#constr (Some ("object_field", 0)) "Otag" [x0; x1; x2]
     method row_field : Row_field.t -> 'res  =
       fun row_field ->
@@ -7930,7 +7886,7 @@ class virtual ['res] lift =
           let x0 = self#list self#core_type x0 in
           let x1 = self#bool x1 in
           let x2 = self#attributes x2 in
-          let x3 = self#loc self#label x3 in
+          let x3 = self#loc self#string x3 in
           self#constr (Some ("row_field", 0)) "Rtag" [x0; x1; x2; x3]
     method package_type : Package_type.t -> 'res  =
       fun package_type ->
@@ -7962,7 +7918,7 @@ class virtual ['res] lift =
           let x1 = self#list (self#loc self#string) x1 in
           self#constr (Some ("core_type_desc", 0)) "Ptyp_poly" [x0; x1]
         | Ptyp_variant (x0, x1, x2) ->
-          let x0 = self#option (self#list self#label) x0 in
+          let x0 = self#option (self#list self#string) x0 in
           let x1 = self#closed_flag x1 in
           let x2 = self#list self#row_field x2 in
           self#constr (Some ("core_type_desc", 0)) "Ptyp_variant" [x0; x1; x2]
@@ -8112,15 +8068,6 @@ class virtual ['res] lift =
           self#constr (Some ("arg_label", 0)) "Labelled" [x0]
         | Nolabel ->
           self#constr (Some ("arg_label", 0)) "Nolabel" []
-    method label : Label.t -> 'res  =
-      fun label ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let concrete = self#string concrete in
-        self#node (Some ("label", 0)) concrete
     method closed_flag : Closed_flag.t -> 'res  =
       fun closed_flag ->
         let concrete =

--- a/ast/virtual_traverse_unstable_for_testing.mli
+++ b/ast/virtual_traverse_unstable_for_testing.mli
@@ -75,7 +75,6 @@ class virtual map :
     method constant : Constant.t -> Constant.t
     method variance : Variance.t -> Variance.t
     method arg_label : Arg_label.t -> Arg_label.t
-    method label : Label.t -> Label.t
     method closed_flag : Closed_flag.t -> Closed_flag.t
     method override_flag : Override_flag.t -> Override_flag.t
     method virtual_flag : Virtual_flag.t -> Virtual_flag.t
@@ -161,7 +160,6 @@ class virtual iter :
     method constant : Constant.t -> unit
     method variance : Variance.t -> unit
     method arg_label : Arg_label.t -> unit
-    method label : Label.t -> unit
     method closed_flag : Closed_flag.t -> unit
     method override_flag : Override_flag.t -> unit
     method virtual_flag : Virtual_flag.t -> unit
@@ -247,7 +245,6 @@ class virtual ['acc] fold :
     method constant : Constant.t -> 'acc -> 'acc
     method variance : Variance.t -> 'acc -> 'acc
     method arg_label : Arg_label.t -> 'acc -> 'acc
-    method label : Label.t -> 'acc -> 'acc
     method closed_flag : Closed_flag.t -> 'acc -> 'acc
     method override_flag : Override_flag.t -> 'acc -> 'acc
     method virtual_flag : Virtual_flag.t -> 'acc -> 'acc
@@ -333,7 +330,6 @@ class virtual ['acc] fold_map :
     method constant : Constant.t -> 'acc -> (Constant.t * 'acc)
     method variance : Variance.t -> 'acc -> (Variance.t * 'acc)
     method arg_label : Arg_label.t -> 'acc -> (Arg_label.t * 'acc)
-    method label : Label.t -> 'acc -> (Label.t * 'acc)
     method closed_flag : Closed_flag.t -> 'acc -> (Closed_flag.t * 'acc)
     method override_flag : Override_flag.t -> 'acc -> (Override_flag.t * 'acc)
     method virtual_flag : Virtual_flag.t -> 'acc -> (Virtual_flag.t * 'acc)
@@ -419,7 +415,6 @@ class virtual ['ctx] map_with_context :
     method constant : 'ctx -> Constant.t -> Constant.t
     method variance : 'ctx -> Variance.t -> Variance.t
     method arg_label : 'ctx -> Arg_label.t -> Arg_label.t
-    method label : 'ctx -> Label.t -> Label.t
     method closed_flag : 'ctx -> Closed_flag.t -> Closed_flag.t
     method override_flag : 'ctx -> Override_flag.t -> Override_flag.t
     method virtual_flag : 'ctx -> Virtual_flag.t -> Virtual_flag.t
@@ -509,7 +504,6 @@ class virtual ['res] lift :
     method constant : Constant.t -> 'res
     method variance : Variance.t -> 'res
     method arg_label : Arg_label.t -> 'res
-    method label : Label.t -> 'res
     method closed_flag : Closed_flag.t -> 'res
     method override_flag : Override_flag.t -> 'res
     method virtual_flag : Virtual_flag.t -> 'res

--- a/ast/virtual_traverse_v4_07.ml
+++ b/ast/virtual_traverse_v4_07.ml
@@ -125,15 +125,6 @@ class virtual map =
           Closed_flag.of_concrete Closed
         | Open ->
           Closed_flag.of_concrete Open
-    method label : Label.t -> Label.t  =
-      fun label ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let concrete = self#string concrete in
-        Label.of_concrete concrete
     method arg_label : Arg_label.t -> Arg_label.t  =
       fun arg_label ->
         let concrete =
@@ -291,7 +282,7 @@ class virtual map =
         | Ptyp_variant (x0, x1, x2) ->
           let x0 = self#list self#row_field x0 in
           let x1 = self#closed_flag x1 in
-          let x2 = self#option (self#list self#label) x2 in
+          let x2 = self#option (self#list self#string) x2 in
           Core_type_desc.of_concrete (Ptyp_variant (x0, x1, x2))
         | Ptyp_poly (x0, x1) ->
           let x0 = self#list (self#loc self#string) x0 in
@@ -323,7 +314,7 @@ class virtual map =
         in
         match (concrete : Row_field.concrete) with
         | Rtag (x0, x1, x2, x3) ->
-          let x0 = self#loc self#label x0 in
+          let x0 = self#loc self#string x0 in
           let x1 = self#attributes x1 in
           let x2 = self#bool x2 in
           let x3 = self#list self#core_type x3 in
@@ -340,7 +331,7 @@ class virtual map =
         in
         match (concrete : Object_field.concrete) with
         | Otag (x0, x1, x2) ->
-          let x0 = self#loc self#label x0 in
+          let x0 = self#loc self#string x0 in
           let x1 = self#attributes x1 in
           let x2 = self#core_type x2 in
           Object_field.of_concrete (Otag (x0, x1, x2))
@@ -391,7 +382,7 @@ class virtual map =
           let x1 = self#option self#pattern x1 in
           Pattern_desc.of_concrete (Ppat_construct (x0, x1))
         | Ppat_variant (x0, x1) ->
-          let x0 = self#label x0 in
+          let x0 = self#string x0 in
           let x1 = self#option self#pattern x1 in
           Pattern_desc.of_concrete (Ppat_variant (x0, x1))
         | Ppat_record (x0, x1) ->
@@ -488,7 +479,7 @@ class virtual map =
           let x1 = self#option self#expression x1 in
           Expression_desc.of_concrete (Pexp_construct (x0, x1))
         | Pexp_variant (x0, x1) ->
-          let x0 = self#label x0 in
+          let x0 = self#string x0 in
           let x1 = self#option self#expression x1 in
           Expression_desc.of_concrete (Pexp_variant (x0, x1))
         | Pexp_record (x0, x1) ->
@@ -538,17 +529,17 @@ class virtual map =
           Expression_desc.of_concrete (Pexp_coerce (x0, x1, x2))
         | Pexp_send (x0, x1) ->
           let x0 = self#expression x0 in
-          let x1 = self#loc self#label x1 in
+          let x1 = self#loc self#string x1 in
           Expression_desc.of_concrete (Pexp_send (x0, x1))
         | Pexp_new x0 ->
           let x0 = self#longident_loc x0 in
           Expression_desc.of_concrete (Pexp_new x0)
         | Pexp_setinstvar (x0, x1) ->
-          let x0 = self#loc self#label x0 in
+          let x0 = self#loc self#string x0 in
           let x1 = self#expression x1 in
           Expression_desc.of_concrete (Pexp_setinstvar (x0, x1))
         | Pexp_override x0 ->
-          let x0 = self#list (fun (x0, x1) -> let x0 = self#loc self#label x0 in let x1 = self#expression x1 in (x0, x1)) x0 in
+          let x0 = self#list (fun (x0, x1) -> let x0 = self#loc self#string x0 in let x1 = self#expression x1 in (x0, x1)) x0 in
           Expression_desc.of_concrete (Pexp_override x0)
         | Pexp_letmodule (x0, x1, x2) ->
           let x0 = self#loc self#string x0 in
@@ -809,10 +800,10 @@ class virtual map =
           let x0 = self#class_type x0 in
           Class_type_field_desc.of_concrete (Pctf_inherit x0)
         | Pctf_val x0 ->
-          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#loc self#label x0 in let x1 = self#mutable_flag x1 in let x2 = self#virtual_flag x2 in let x3 = self#core_type x3 in (x0, x1, x2, x3)) x0 in
+          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#loc self#string x0 in let x1 = self#mutable_flag x1 in let x2 = self#virtual_flag x2 in let x3 = self#core_type x3 in (x0, x1, x2, x3)) x0 in
           Class_type_field_desc.of_concrete (Pctf_val x0)
         | Pctf_method x0 ->
-          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#loc self#label x0 in let x1 = self#private_flag x1 in let x2 = self#virtual_flag x2 in let x3 = self#core_type x3 in (x0, x1, x2, x3)) x0 in
+          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#loc self#string x0 in let x1 = self#private_flag x1 in let x2 = self#virtual_flag x2 in let x3 = self#core_type x3 in (x0, x1, x2, x3)) x0 in
           Class_type_field_desc.of_concrete (Pctf_method x0)
         | Pctf_constraint x0 ->
           let x0 = (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#core_type x1 in (x0, x1)) x0 in
@@ -962,10 +953,10 @@ class virtual map =
           let x2 = self#option (self#loc self#string) x2 in
           Class_field_desc.of_concrete (Pcf_inherit (x0, x1, x2))
         | Pcf_val x0 ->
-          let x0 = (fun (x0, x1, x2) -> let x0 = self#loc self#label x0 in let x1 = self#mutable_flag x1 in let x2 = self#class_field_kind x2 in (x0, x1, x2)) x0 in
+          let x0 = (fun (x0, x1, x2) -> let x0 = self#loc self#string x0 in let x1 = self#mutable_flag x1 in let x2 = self#class_field_kind x2 in (x0, x1, x2)) x0 in
           Class_field_desc.of_concrete (Pcf_val x0)
         | Pcf_method x0 ->
-          let x0 = (fun (x0, x1, x2) -> let x0 = self#loc self#label x0 in let x1 = self#private_flag x1 in let x2 = self#class_field_kind x2 in (x0, x1, x2)) x0 in
+          let x0 = (fun (x0, x1, x2) -> let x0 = self#loc self#string x0 in let x1 = self#private_flag x1 in let x2 = self#class_field_kind x2 in (x0, x1, x2)) x0 in
           Class_field_desc.of_concrete (Pcf_method x0)
         | Pcf_constraint x0 ->
           let x0 = (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#core_type x1 in (x0, x1)) x0 in
@@ -1527,14 +1518,6 @@ class virtual iter =
           ()
         | Open ->
           ()
-    method label : Label.t -> unit  =
-      fun label ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        self#string concrete
     method arg_label : Arg_label.t -> unit  =
       fun arg_label ->
         let concrete =
@@ -1671,7 +1654,7 @@ class virtual iter =
         | Ptyp_variant (x0, x1, x2) ->
           self#list self#row_field x0;
           self#closed_flag x1;
-          self#option (self#list self#label) x2
+          self#option (self#list self#string) x2
         | Ptyp_poly (x0, x1) ->
           self#list (self#loc self#string) x0;
           self#core_type x1
@@ -1698,7 +1681,7 @@ class virtual iter =
         in
         match (concrete : Row_field.concrete) with
         | Rtag (x0, x1, x2, x3) ->
-          self#loc self#label x0;
+          self#loc self#string x0;
           self#attributes x1;
           self#bool x2;
           self#list self#core_type x3
@@ -1713,7 +1696,7 @@ class virtual iter =
         in
         match (concrete : Object_field.concrete) with
         | Otag (x0, x1, x2) ->
-          self#loc self#label x0;
+          self#loc self#string x0;
           self#attributes x1;
           self#core_type x2
         | Oinherit x0 ->
@@ -1755,7 +1738,7 @@ class virtual iter =
           self#longident_loc x0;
           self#option self#pattern x1
         | Ppat_variant (x0, x1) ->
-          self#label x0;
+          self#string x0;
           self#option self#pattern x1
         | Ppat_record (x0, x1) ->
           self#list (fun (x0, x1) -> self#longident_loc x0; self#pattern x1) x0;
@@ -1830,7 +1813,7 @@ class virtual iter =
           self#longident_loc x0;
           self#option self#expression x1
         | Pexp_variant (x0, x1) ->
-          self#label x0;
+          self#string x0;
           self#option self#expression x1
         | Pexp_record (x0, x1) ->
           self#list (fun (x0, x1) -> self#longident_loc x0; self#expression x1) x0;
@@ -1869,14 +1852,14 @@ class virtual iter =
           self#core_type x2
         | Pexp_send (x0, x1) ->
           self#expression x0;
-          self#loc self#label x1
+          self#loc self#string x1
         | Pexp_new x0 ->
           self#longident_loc x0
         | Pexp_setinstvar (x0, x1) ->
-          self#loc self#label x0;
+          self#loc self#string x0;
           self#expression x1
         | Pexp_override x0 ->
-          self#list (fun (x0, x1) -> self#loc self#label x0; self#expression x1) x0
+          self#list (fun (x0, x1) -> self#loc self#string x0; self#expression x1) x0
         | Pexp_letmodule (x0, x1, x2) ->
           self#loc self#string x0;
           self#module_expr x1;
@@ -2104,9 +2087,9 @@ class virtual iter =
         | Pctf_inherit x0 ->
           self#class_type x0
         | Pctf_val x0 ->
-          (fun (x0, x1, x2, x3) -> self#loc self#label x0; self#mutable_flag x1; self#virtual_flag x2; self#core_type x3) x0
+          (fun (x0, x1, x2, x3) -> self#loc self#string x0; self#mutable_flag x1; self#virtual_flag x2; self#core_type x3) x0
         | Pctf_method x0 ->
-          (fun (x0, x1, x2, x3) -> self#loc self#label x0; self#private_flag x1; self#virtual_flag x2; self#core_type x3) x0
+          (fun (x0, x1, x2, x3) -> self#loc self#string x0; self#private_flag x1; self#virtual_flag x2; self#core_type x3) x0
         | Pctf_constraint x0 ->
           (fun (x0, x1) -> self#core_type x0; self#core_type x1) x0
         | Pctf_attribute x0 ->
@@ -2236,9 +2219,9 @@ class virtual iter =
           self#class_expr x1;
           self#option (self#loc self#string) x2
         | Pcf_val x0 ->
-          (fun (x0, x1, x2) -> self#loc self#label x0; self#mutable_flag x1; self#class_field_kind x2) x0
+          (fun (x0, x1, x2) -> self#loc self#string x0; self#mutable_flag x1; self#class_field_kind x2) x0
         | Pcf_method x0 ->
-          (fun (x0, x1, x2) -> self#loc self#label x0; self#private_flag x1; self#class_field_kind x2) x0
+          (fun (x0, x1, x2) -> self#loc self#string x0; self#private_flag x1; self#class_field_kind x2) x0
         | Pcf_constraint x0 ->
           (fun (x0, x1) -> self#core_type x0; self#core_type x1) x0
         | Pcf_initializer x0 ->
@@ -2729,15 +2712,6 @@ class virtual ['acc] fold =
           acc
         | Open ->
           acc
-    method label : Label.t -> 'acc -> 'acc  =
-      fun label acc ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let acc = self#string concrete acc in
-        acc
     method arg_label : Arg_label.t -> 'acc -> 'acc  =
       fun arg_label acc ->
         let concrete =
@@ -2895,7 +2869,7 @@ class virtual ['acc] fold =
         | Ptyp_variant (x0, x1, x2) ->
           let acc = self#list self#row_field x0 acc in
           let acc = self#closed_flag x1 acc in
-          let acc = self#option (self#list self#label) x2 acc in
+          let acc = self#option (self#list self#string) x2 acc in
           acc
         | Ptyp_poly (x0, x1) ->
           let acc = self#list (self#loc self#string) x0 acc in
@@ -2927,7 +2901,7 @@ class virtual ['acc] fold =
         in
         match (concrete : Row_field.concrete) with
         | Rtag (x0, x1, x2, x3) ->
-          let acc = self#loc self#label x0 acc in
+          let acc = self#loc self#string x0 acc in
           let acc = self#attributes x1 acc in
           let acc = self#bool x2 acc in
           let acc = self#list self#core_type x3 acc in
@@ -2944,7 +2918,7 @@ class virtual ['acc] fold =
         in
         match (concrete : Object_field.concrete) with
         | Otag (x0, x1, x2) ->
-          let acc = self#loc self#label x0 acc in
+          let acc = self#loc self#string x0 acc in
           let acc = self#attributes x1 acc in
           let acc = self#core_type x2 acc in
           acc
@@ -2995,7 +2969,7 @@ class virtual ['acc] fold =
           let acc = self#option self#pattern x1 acc in
           acc
         | Ppat_variant (x0, x1) ->
-          let acc = self#label x0 acc in
+          let acc = self#string x0 acc in
           let acc = self#option self#pattern x1 acc in
           acc
         | Ppat_record (x0, x1) ->
@@ -3092,7 +3066,7 @@ class virtual ['acc] fold =
           let acc = self#option self#expression x1 acc in
           acc
         | Pexp_variant (x0, x1) ->
-          let acc = self#label x0 acc in
+          let acc = self#string x0 acc in
           let acc = self#option self#expression x1 acc in
           acc
         | Pexp_record (x0, x1) ->
@@ -3142,17 +3116,17 @@ class virtual ['acc] fold =
           acc
         | Pexp_send (x0, x1) ->
           let acc = self#expression x0 acc in
-          let acc = self#loc self#label x1 acc in
+          let acc = self#loc self#string x1 acc in
           acc
         | Pexp_new x0 ->
           let acc = self#longident_loc x0 acc in
           acc
         | Pexp_setinstvar (x0, x1) ->
-          let acc = self#loc self#label x0 acc in
+          let acc = self#loc self#string x0 acc in
           let acc = self#expression x1 acc in
           acc
         | Pexp_override x0 ->
-          let acc = self#list (fun (x0, x1) acc -> let acc = self#loc self#label x0 acc in let acc = self#expression x1 acc in acc) x0 acc in
+          let acc = self#list (fun (x0, x1) acc -> let acc = self#loc self#string x0 acc in let acc = self#expression x1 acc in acc) x0 acc in
           acc
         | Pexp_letmodule (x0, x1, x2) ->
           let acc = self#loc self#string x0 acc in
@@ -3413,10 +3387,10 @@ class virtual ['acc] fold =
           let acc = self#class_type x0 acc in
           acc
         | Pctf_val x0 ->
-          let acc = (fun (x0, x1, x2, x3) acc -> let acc = self#loc self#label x0 acc in let acc = self#mutable_flag x1 acc in let acc = self#virtual_flag x2 acc in let acc = self#core_type x3 acc in acc) x0 acc in
+          let acc = (fun (x0, x1, x2, x3) acc -> let acc = self#loc self#string x0 acc in let acc = self#mutable_flag x1 acc in let acc = self#virtual_flag x2 acc in let acc = self#core_type x3 acc in acc) x0 acc in
           acc
         | Pctf_method x0 ->
-          let acc = (fun (x0, x1, x2, x3) acc -> let acc = self#loc self#label x0 acc in let acc = self#private_flag x1 acc in let acc = self#virtual_flag x2 acc in let acc = self#core_type x3 acc in acc) x0 acc in
+          let acc = (fun (x0, x1, x2, x3) acc -> let acc = self#loc self#string x0 acc in let acc = self#private_flag x1 acc in let acc = self#virtual_flag x2 acc in let acc = self#core_type x3 acc in acc) x0 acc in
           acc
         | Pctf_constraint x0 ->
           let acc = (fun (x0, x1) acc -> let acc = self#core_type x0 acc in let acc = self#core_type x1 acc in acc) x0 acc in
@@ -3566,10 +3540,10 @@ class virtual ['acc] fold =
           let acc = self#option (self#loc self#string) x2 acc in
           acc
         | Pcf_val x0 ->
-          let acc = (fun (x0, x1, x2) acc -> let acc = self#loc self#label x0 acc in let acc = self#mutable_flag x1 acc in let acc = self#class_field_kind x2 acc in acc) x0 acc in
+          let acc = (fun (x0, x1, x2) acc -> let acc = self#loc self#string x0 acc in let acc = self#mutable_flag x1 acc in let acc = self#class_field_kind x2 acc in acc) x0 acc in
           acc
         | Pcf_method x0 ->
-          let acc = (fun (x0, x1, x2) acc -> let acc = self#loc self#label x0 acc in let acc = self#private_flag x1 acc in let acc = self#class_field_kind x2 acc in acc) x0 acc in
+          let acc = (fun (x0, x1, x2) acc -> let acc = self#loc self#string x0 acc in let acc = self#private_flag x1 acc in let acc = self#class_field_kind x2 acc in acc) x0 acc in
           acc
         | Pcf_constraint x0 ->
           let acc = (fun (x0, x1) acc -> let acc = self#core_type x0 acc in let acc = self#core_type x1 acc in acc) x0 acc in
@@ -4135,15 +4109,6 @@ class virtual ['acc] fold_map =
           (Closed_flag.of_concrete Closed, acc)
         | Open ->
           (Closed_flag.of_concrete Open, acc)
-    method label : Label.t -> 'acc -> (Label.t * 'acc)  =
-      fun label acc ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let (concrete, acc) = self#string concrete acc in
-        (Label.of_concrete concrete, acc)
     method arg_label : Arg_label.t -> 'acc -> (Arg_label.t * 'acc)  =
       fun arg_label acc ->
         let concrete =
@@ -4301,7 +4266,7 @@ class virtual ['acc] fold_map =
         | Ptyp_variant (x0, x1, x2) ->
           let (x0, acc) = self#list self#row_field x0 acc in
           let (x1, acc) = self#closed_flag x1 acc in
-          let (x2, acc) = self#option (self#list self#label) x2 acc in
+          let (x2, acc) = self#option (self#list self#string) x2 acc in
           (Core_type_desc.of_concrete (Ptyp_variant (x0, x1, x2)), acc)
         | Ptyp_poly (x0, x1) ->
           let (x0, acc) = self#list (self#loc self#string) x0 acc in
@@ -4333,7 +4298,7 @@ class virtual ['acc] fold_map =
         in
         match (concrete : Row_field.concrete) with
         | Rtag (x0, x1, x2, x3) ->
-          let (x0, acc) = self#loc self#label x0 acc in
+          let (x0, acc) = self#loc self#string x0 acc in
           let (x1, acc) = self#attributes x1 acc in
           let (x2, acc) = self#bool x2 acc in
           let (x3, acc) = self#list self#core_type x3 acc in
@@ -4350,7 +4315,7 @@ class virtual ['acc] fold_map =
         in
         match (concrete : Object_field.concrete) with
         | Otag (x0, x1, x2) ->
-          let (x0, acc) = self#loc self#label x0 acc in
+          let (x0, acc) = self#loc self#string x0 acc in
           let (x1, acc) = self#attributes x1 acc in
           let (x2, acc) = self#core_type x2 acc in
           (Object_field.of_concrete (Otag (x0, x1, x2)), acc)
@@ -4401,7 +4366,7 @@ class virtual ['acc] fold_map =
           let (x1, acc) = self#option self#pattern x1 acc in
           (Pattern_desc.of_concrete (Ppat_construct (x0, x1)), acc)
         | Ppat_variant (x0, x1) ->
-          let (x0, acc) = self#label x0 acc in
+          let (x0, acc) = self#string x0 acc in
           let (x1, acc) = self#option self#pattern x1 acc in
           (Pattern_desc.of_concrete (Ppat_variant (x0, x1)), acc)
         | Ppat_record (x0, x1) ->
@@ -4498,7 +4463,7 @@ class virtual ['acc] fold_map =
           let (x1, acc) = self#option self#expression x1 acc in
           (Expression_desc.of_concrete (Pexp_construct (x0, x1)), acc)
         | Pexp_variant (x0, x1) ->
-          let (x0, acc) = self#label x0 acc in
+          let (x0, acc) = self#string x0 acc in
           let (x1, acc) = self#option self#expression x1 acc in
           (Expression_desc.of_concrete (Pexp_variant (x0, x1)), acc)
         | Pexp_record (x0, x1) ->
@@ -4548,17 +4513,17 @@ class virtual ['acc] fold_map =
           (Expression_desc.of_concrete (Pexp_coerce (x0, x1, x2)), acc)
         | Pexp_send (x0, x1) ->
           let (x0, acc) = self#expression x0 acc in
-          let (x1, acc) = self#loc self#label x1 acc in
+          let (x1, acc) = self#loc self#string x1 acc in
           (Expression_desc.of_concrete (Pexp_send (x0, x1)), acc)
         | Pexp_new x0 ->
           let (x0, acc) = self#longident_loc x0 acc in
           (Expression_desc.of_concrete (Pexp_new x0), acc)
         | Pexp_setinstvar (x0, x1) ->
-          let (x0, acc) = self#loc self#label x0 acc in
+          let (x0, acc) = self#loc self#string x0 acc in
           let (x1, acc) = self#expression x1 acc in
           (Expression_desc.of_concrete (Pexp_setinstvar (x0, x1)), acc)
         | Pexp_override x0 ->
-          let (x0, acc) = self#list (fun (x0, x1) acc -> let (x0, acc) = self#loc self#label x0 acc in let (x1, acc) = self#expression x1 acc in ((x0, x1), acc)) x0 acc in
+          let (x0, acc) = self#list (fun (x0, x1) acc -> let (x0, acc) = self#loc self#string x0 acc in let (x1, acc) = self#expression x1 acc in ((x0, x1), acc)) x0 acc in
           (Expression_desc.of_concrete (Pexp_override x0), acc)
         | Pexp_letmodule (x0, x1, x2) ->
           let (x0, acc) = self#loc self#string x0 acc in
@@ -4819,10 +4784,10 @@ class virtual ['acc] fold_map =
           let (x0, acc) = self#class_type x0 acc in
           (Class_type_field_desc.of_concrete (Pctf_inherit x0), acc)
         | Pctf_val x0 ->
-          let (x0, acc) = (fun (x0, x1, x2, x3) acc -> let (x0, acc) = self#loc self#label x0 acc in let (x1, acc) = self#mutable_flag x1 acc in let (x2, acc) = self#virtual_flag x2 acc in let (x3, acc) = self#core_type x3 acc in ((x0, x1, x2, x3), acc)) x0 acc in
+          let (x0, acc) = (fun (x0, x1, x2, x3) acc -> let (x0, acc) = self#loc self#string x0 acc in let (x1, acc) = self#mutable_flag x1 acc in let (x2, acc) = self#virtual_flag x2 acc in let (x3, acc) = self#core_type x3 acc in ((x0, x1, x2, x3), acc)) x0 acc in
           (Class_type_field_desc.of_concrete (Pctf_val x0), acc)
         | Pctf_method x0 ->
-          let (x0, acc) = (fun (x0, x1, x2, x3) acc -> let (x0, acc) = self#loc self#label x0 acc in let (x1, acc) = self#private_flag x1 acc in let (x2, acc) = self#virtual_flag x2 acc in let (x3, acc) = self#core_type x3 acc in ((x0, x1, x2, x3), acc)) x0 acc in
+          let (x0, acc) = (fun (x0, x1, x2, x3) acc -> let (x0, acc) = self#loc self#string x0 acc in let (x1, acc) = self#private_flag x1 acc in let (x2, acc) = self#virtual_flag x2 acc in let (x3, acc) = self#core_type x3 acc in ((x0, x1, x2, x3), acc)) x0 acc in
           (Class_type_field_desc.of_concrete (Pctf_method x0), acc)
         | Pctf_constraint x0 ->
           let (x0, acc) = (fun (x0, x1) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#core_type x1 acc in ((x0, x1), acc)) x0 acc in
@@ -4972,10 +4937,10 @@ class virtual ['acc] fold_map =
           let (x2, acc) = self#option (self#loc self#string) x2 acc in
           (Class_field_desc.of_concrete (Pcf_inherit (x0, x1, x2)), acc)
         | Pcf_val x0 ->
-          let (x0, acc) = (fun (x0, x1, x2) acc -> let (x0, acc) = self#loc self#label x0 acc in let (x1, acc) = self#mutable_flag x1 acc in let (x2, acc) = self#class_field_kind x2 acc in ((x0, x1, x2), acc)) x0 acc in
+          let (x0, acc) = (fun (x0, x1, x2) acc -> let (x0, acc) = self#loc self#string x0 acc in let (x1, acc) = self#mutable_flag x1 acc in let (x2, acc) = self#class_field_kind x2 acc in ((x0, x1, x2), acc)) x0 acc in
           (Class_field_desc.of_concrete (Pcf_val x0), acc)
         | Pcf_method x0 ->
-          let (x0, acc) = (fun (x0, x1, x2) acc -> let (x0, acc) = self#loc self#label x0 acc in let (x1, acc) = self#private_flag x1 acc in let (x2, acc) = self#class_field_kind x2 acc in ((x0, x1, x2), acc)) x0 acc in
+          let (x0, acc) = (fun (x0, x1, x2) acc -> let (x0, acc) = self#loc self#string x0 acc in let (x1, acc) = self#private_flag x1 acc in let (x2, acc) = self#class_field_kind x2 acc in ((x0, x1, x2), acc)) x0 acc in
           (Class_field_desc.of_concrete (Pcf_method x0), acc)
         | Pcf_constraint x0 ->
           let (x0, acc) = (fun (x0, x1) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#core_type x1 acc in ((x0, x1), acc)) x0 acc in
@@ -5541,15 +5506,6 @@ class virtual ['ctx] map_with_context =
           Closed_flag.of_concrete Closed
         | Open ->
           Closed_flag.of_concrete Open
-    method label : 'ctx -> Label.t -> Label.t  =
-      fun _ctx label ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let concrete = self#string _ctx concrete in
-        Label.of_concrete concrete
     method arg_label : 'ctx -> Arg_label.t -> Arg_label.t  =
       fun _ctx arg_label ->
         let concrete =
@@ -5707,7 +5663,7 @@ class virtual ['ctx] map_with_context =
         | Ptyp_variant (x0, x1, x2) ->
           let x0 = self#list self#row_field _ctx x0 in
           let x1 = self#closed_flag _ctx x1 in
-          let x2 = self#option (self#list self#label) _ctx x2 in
+          let x2 = self#option (self#list self#string) _ctx x2 in
           Core_type_desc.of_concrete (Ptyp_variant (x0, x1, x2))
         | Ptyp_poly (x0, x1) ->
           let x0 = self#list (self#loc self#string) _ctx x0 in
@@ -5739,7 +5695,7 @@ class virtual ['ctx] map_with_context =
         in
         match (concrete : Row_field.concrete) with
         | Rtag (x0, x1, x2, x3) ->
-          let x0 = self#loc self#label _ctx x0 in
+          let x0 = self#loc self#string _ctx x0 in
           let x1 = self#attributes _ctx x1 in
           let x2 = self#bool _ctx x2 in
           let x3 = self#list self#core_type _ctx x3 in
@@ -5756,7 +5712,7 @@ class virtual ['ctx] map_with_context =
         in
         match (concrete : Object_field.concrete) with
         | Otag (x0, x1, x2) ->
-          let x0 = self#loc self#label _ctx x0 in
+          let x0 = self#loc self#string _ctx x0 in
           let x1 = self#attributes _ctx x1 in
           let x2 = self#core_type _ctx x2 in
           Object_field.of_concrete (Otag (x0, x1, x2))
@@ -5807,7 +5763,7 @@ class virtual ['ctx] map_with_context =
           let x1 = self#option self#pattern _ctx x1 in
           Pattern_desc.of_concrete (Ppat_construct (x0, x1))
         | Ppat_variant (x0, x1) ->
-          let x0 = self#label _ctx x0 in
+          let x0 = self#string _ctx x0 in
           let x1 = self#option self#pattern _ctx x1 in
           Pattern_desc.of_concrete (Ppat_variant (x0, x1))
         | Ppat_record (x0, x1) ->
@@ -5904,7 +5860,7 @@ class virtual ['ctx] map_with_context =
           let x1 = self#option self#expression _ctx x1 in
           Expression_desc.of_concrete (Pexp_construct (x0, x1))
         | Pexp_variant (x0, x1) ->
-          let x0 = self#label _ctx x0 in
+          let x0 = self#string _ctx x0 in
           let x1 = self#option self#expression _ctx x1 in
           Expression_desc.of_concrete (Pexp_variant (x0, x1))
         | Pexp_record (x0, x1) ->
@@ -5954,17 +5910,17 @@ class virtual ['ctx] map_with_context =
           Expression_desc.of_concrete (Pexp_coerce (x0, x1, x2))
         | Pexp_send (x0, x1) ->
           let x0 = self#expression _ctx x0 in
-          let x1 = self#loc self#label _ctx x1 in
+          let x1 = self#loc self#string _ctx x1 in
           Expression_desc.of_concrete (Pexp_send (x0, x1))
         | Pexp_new x0 ->
           let x0 = self#longident_loc _ctx x0 in
           Expression_desc.of_concrete (Pexp_new x0)
         | Pexp_setinstvar (x0, x1) ->
-          let x0 = self#loc self#label _ctx x0 in
+          let x0 = self#loc self#string _ctx x0 in
           let x1 = self#expression _ctx x1 in
           Expression_desc.of_concrete (Pexp_setinstvar (x0, x1))
         | Pexp_override x0 ->
-          let x0 = self#list (fun _ctx (x0, x1) -> let x0 = self#loc self#label _ctx x0 in let x1 = self#expression _ctx x1 in (x0, x1)) _ctx x0 in
+          let x0 = self#list (fun _ctx (x0, x1) -> let x0 = self#loc self#string _ctx x0 in let x1 = self#expression _ctx x1 in (x0, x1)) _ctx x0 in
           Expression_desc.of_concrete (Pexp_override x0)
         | Pexp_letmodule (x0, x1, x2) ->
           let x0 = self#loc self#string _ctx x0 in
@@ -6225,10 +6181,10 @@ class virtual ['ctx] map_with_context =
           let x0 = self#class_type _ctx x0 in
           Class_type_field_desc.of_concrete (Pctf_inherit x0)
         | Pctf_val x0 ->
-          let x0 = (fun _ctx (x0, x1, x2, x3) -> let x0 = self#loc self#label _ctx x0 in let x1 = self#mutable_flag _ctx x1 in let x2 = self#virtual_flag _ctx x2 in let x3 = self#core_type _ctx x3 in (x0, x1, x2, x3)) _ctx x0 in
+          let x0 = (fun _ctx (x0, x1, x2, x3) -> let x0 = self#loc self#string _ctx x0 in let x1 = self#mutable_flag _ctx x1 in let x2 = self#virtual_flag _ctx x2 in let x3 = self#core_type _ctx x3 in (x0, x1, x2, x3)) _ctx x0 in
           Class_type_field_desc.of_concrete (Pctf_val x0)
         | Pctf_method x0 ->
-          let x0 = (fun _ctx (x0, x1, x2, x3) -> let x0 = self#loc self#label _ctx x0 in let x1 = self#private_flag _ctx x1 in let x2 = self#virtual_flag _ctx x2 in let x3 = self#core_type _ctx x3 in (x0, x1, x2, x3)) _ctx x0 in
+          let x0 = (fun _ctx (x0, x1, x2, x3) -> let x0 = self#loc self#string _ctx x0 in let x1 = self#private_flag _ctx x1 in let x2 = self#virtual_flag _ctx x2 in let x3 = self#core_type _ctx x3 in (x0, x1, x2, x3)) _ctx x0 in
           Class_type_field_desc.of_concrete (Pctf_method x0)
         | Pctf_constraint x0 ->
           let x0 = (fun _ctx (x0, x1) -> let x0 = self#core_type _ctx x0 in let x1 = self#core_type _ctx x1 in (x0, x1)) _ctx x0 in
@@ -6378,10 +6334,10 @@ class virtual ['ctx] map_with_context =
           let x2 = self#option (self#loc self#string) _ctx x2 in
           Class_field_desc.of_concrete (Pcf_inherit (x0, x1, x2))
         | Pcf_val x0 ->
-          let x0 = (fun _ctx (x0, x1, x2) -> let x0 = self#loc self#label _ctx x0 in let x1 = self#mutable_flag _ctx x1 in let x2 = self#class_field_kind _ctx x2 in (x0, x1, x2)) _ctx x0 in
+          let x0 = (fun _ctx (x0, x1, x2) -> let x0 = self#loc self#string _ctx x0 in let x1 = self#mutable_flag _ctx x1 in let x2 = self#class_field_kind _ctx x2 in (x0, x1, x2)) _ctx x0 in
           Class_field_desc.of_concrete (Pcf_val x0)
         | Pcf_method x0 ->
-          let x0 = (fun _ctx (x0, x1, x2) -> let x0 = self#loc self#label _ctx x0 in let x1 = self#private_flag _ctx x1 in let x2 = self#class_field_kind _ctx x2 in (x0, x1, x2)) _ctx x0 in
+          let x0 = (fun _ctx (x0, x1, x2) -> let x0 = self#loc self#string _ctx x0 in let x1 = self#private_flag _ctx x1 in let x2 = self#class_field_kind _ctx x2 in (x0, x1, x2)) _ctx x0 in
           Class_field_desc.of_concrete (Pcf_method x0)
         | Pcf_constraint x0 ->
           let x0 = (fun _ctx (x0, x1) -> let x0 = self#core_type _ctx x0 in let x1 = self#core_type _ctx x1 in (x0, x1)) _ctx x0 in
@@ -6951,15 +6907,6 @@ class virtual ['res] lift =
           self#constr (Some ("closed_flag", 0)) "Closed" []
         | Open ->
           self#constr (Some ("closed_flag", 0)) "Open" []
-    method label : Label.t -> 'res  =
-      fun label ->
-        let concrete =
-          match Label.to_concrete label with
-          | None -> conversion_failed "label"
-          | Some n -> n
-        in
-        let concrete = self#string concrete in
-        self#node (Some ("label", 0)) concrete
     method arg_label : Arg_label.t -> 'res  =
       fun arg_label ->
         let concrete =
@@ -7117,7 +7064,7 @@ class virtual ['res] lift =
         | Ptyp_variant (x0, x1, x2) ->
           let x0 = self#list self#row_field x0 in
           let x1 = self#closed_flag x1 in
-          let x2 = self#option (self#list self#label) x2 in
+          let x2 = self#option (self#list self#string) x2 in
           self#constr (Some ("core_type_desc", 0)) "Ptyp_variant" [x0; x1; x2]
         | Ptyp_poly (x0, x1) ->
           let x0 = self#list (self#loc self#string) x0 in
@@ -7149,7 +7096,7 @@ class virtual ['res] lift =
         in
         match (concrete : Row_field.concrete) with
         | Rtag (x0, x1, x2, x3) ->
-          let x0 = self#loc self#label x0 in
+          let x0 = self#loc self#string x0 in
           let x1 = self#attributes x1 in
           let x2 = self#bool x2 in
           let x3 = self#list self#core_type x3 in
@@ -7166,7 +7113,7 @@ class virtual ['res] lift =
         in
         match (concrete : Object_field.concrete) with
         | Otag (x0, x1, x2) ->
-          let x0 = self#loc self#label x0 in
+          let x0 = self#loc self#string x0 in
           let x1 = self#attributes x1 in
           let x2 = self#core_type x2 in
           self#constr (Some ("object_field", 0)) "Otag" [x0; x1; x2]
@@ -7217,7 +7164,7 @@ class virtual ['res] lift =
           let x1 = self#option self#pattern x1 in
           self#constr (Some ("pattern_desc", 0)) "Ppat_construct" [x0; x1]
         | Ppat_variant (x0, x1) ->
-          let x0 = self#label x0 in
+          let x0 = self#string x0 in
           let x1 = self#option self#pattern x1 in
           self#constr (Some ("pattern_desc", 0)) "Ppat_variant" [x0; x1]
         | Ppat_record (x0, x1) ->
@@ -7314,7 +7261,7 @@ class virtual ['res] lift =
           let x1 = self#option self#expression x1 in
           self#constr (Some ("expression_desc", 0)) "Pexp_construct" [x0; x1]
         | Pexp_variant (x0, x1) ->
-          let x0 = self#label x0 in
+          let x0 = self#string x0 in
           let x1 = self#option self#expression x1 in
           self#constr (Some ("expression_desc", 0)) "Pexp_variant" [x0; x1]
         | Pexp_record (x0, x1) ->
@@ -7364,17 +7311,17 @@ class virtual ['res] lift =
           self#constr (Some ("expression_desc", 0)) "Pexp_coerce" [x0; x1; x2]
         | Pexp_send (x0, x1) ->
           let x0 = self#expression x0 in
-          let x1 = self#loc self#label x1 in
+          let x1 = self#loc self#string x1 in
           self#constr (Some ("expression_desc", 0)) "Pexp_send" [x0; x1]
         | Pexp_new x0 ->
           let x0 = self#longident_loc x0 in
           self#constr (Some ("expression_desc", 0)) "Pexp_new" [x0]
         | Pexp_setinstvar (x0, x1) ->
-          let x0 = self#loc self#label x0 in
+          let x0 = self#loc self#string x0 in
           let x1 = self#expression x1 in
           self#constr (Some ("expression_desc", 0)) "Pexp_setinstvar" [x0; x1]
         | Pexp_override x0 ->
-          let x0 = self#list (fun (x0, x1) -> let x0 = self#loc self#label x0 in let x1 = self#expression x1 in self#node None (self#tuple [x0; x1])) x0 in
+          let x0 = self#list (fun (x0, x1) -> let x0 = self#loc self#string x0 in let x1 = self#expression x1 in self#node None (self#tuple [x0; x1])) x0 in
           self#constr (Some ("expression_desc", 0)) "Pexp_override" [x0]
         | Pexp_letmodule (x0, x1, x2) ->
           let x0 = self#loc self#string x0 in
@@ -7635,10 +7582,10 @@ class virtual ['res] lift =
           let x0 = self#class_type x0 in
           self#constr (Some ("class_type_field_desc", 0)) "Pctf_inherit" [x0]
         | Pctf_val x0 ->
-          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#loc self#label x0 in let x1 = self#mutable_flag x1 in let x2 = self#virtual_flag x2 in let x3 = self#core_type x3 in self#node None (self#tuple [x0; x1; x2; x3])) x0 in
+          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#loc self#string x0 in let x1 = self#mutable_flag x1 in let x2 = self#virtual_flag x2 in let x3 = self#core_type x3 in self#node None (self#tuple [x0; x1; x2; x3])) x0 in
           self#constr (Some ("class_type_field_desc", 0)) "Pctf_val" [x0]
         | Pctf_method x0 ->
-          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#loc self#label x0 in let x1 = self#private_flag x1 in let x2 = self#virtual_flag x2 in let x3 = self#core_type x3 in self#node None (self#tuple [x0; x1; x2; x3])) x0 in
+          let x0 = (fun (x0, x1, x2, x3) -> let x0 = self#loc self#string x0 in let x1 = self#private_flag x1 in let x2 = self#virtual_flag x2 in let x3 = self#core_type x3 in self#node None (self#tuple [x0; x1; x2; x3])) x0 in
           self#constr (Some ("class_type_field_desc", 0)) "Pctf_method" [x0]
         | Pctf_constraint x0 ->
           let x0 = (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#core_type x1 in self#node None (self#tuple [x0; x1])) x0 in
@@ -7788,10 +7735,10 @@ class virtual ['res] lift =
           let x2 = self#option (self#loc self#string) x2 in
           self#constr (Some ("class_field_desc", 0)) "Pcf_inherit" [x0; x1; x2]
         | Pcf_val x0 ->
-          let x0 = (fun (x0, x1, x2) -> let x0 = self#loc self#label x0 in let x1 = self#mutable_flag x1 in let x2 = self#class_field_kind x2 in self#node None (self#tuple [x0; x1; x2])) x0 in
+          let x0 = (fun (x0, x1, x2) -> let x0 = self#loc self#string x0 in let x1 = self#mutable_flag x1 in let x2 = self#class_field_kind x2 in self#node None (self#tuple [x0; x1; x2])) x0 in
           self#constr (Some ("class_field_desc", 0)) "Pcf_val" [x0]
         | Pcf_method x0 ->
-          let x0 = (fun (x0, x1, x2) -> let x0 = self#loc self#label x0 in let x1 = self#private_flag x1 in let x2 = self#class_field_kind x2 in self#node None (self#tuple [x0; x1; x2])) x0 in
+          let x0 = (fun (x0, x1, x2) -> let x0 = self#loc self#string x0 in let x1 = self#private_flag x1 in let x2 = self#class_field_kind x2 in self#node None (self#tuple [x0; x1; x2])) x0 in
           self#constr (Some ("class_field_desc", 0)) "Pcf_method" [x0]
         | Pcf_constraint x0 ->
           let x0 = (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#core_type x1 in self#node None (self#tuple [x0; x1])) x0 in

--- a/ast/virtual_traverse_v4_07.ml
+++ b/ast/virtual_traverse_v4_07.ml
@@ -34,8 +34,13 @@ class virtual map =
           Longident.of_concrete (Lapply (x0, x1))
     method longident_loc : Longident_loc.t -> Longident_loc.t  =
       fun longident_loc ->
-        let longident_loc = self#loc self#longident longident_loc in
-        longident_loc
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let concrete = self#loc self#longident concrete in
+        Longident_loc.of_concrete concrete
     method rec_flag : Rec_flag.t -> Rec_flag.t  =
       fun rec_flag ->
         let concrete =
@@ -122,8 +127,13 @@ class virtual map =
           Closed_flag.of_concrete Open
     method label : Label.t -> Label.t  =
       fun label ->
-        let label = self#string label in
-        label
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let concrete = self#string concrete in
+        Label.of_concrete concrete
     method arg_label : Arg_label.t -> Arg_label.t  =
       fun arg_label ->
         let concrete =
@@ -845,12 +855,22 @@ class virtual map =
         Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
     method class_description : Class_description.t -> Class_description.t  =
       fun class_description ->
-        let class_description = self#class_infos_class_type class_description in
-        class_description
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type concrete in
+        Class_description.of_concrete concrete
     method class_type_declaration : Class_type_declaration.t -> Class_type_declaration.t  =
       fun class_type_declaration ->
-        let class_type_declaration = self#class_infos_class_type class_type_declaration in
-        class_type_declaration
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type concrete in
+        Class_type_declaration.of_concrete concrete
     method class_expr : Class_expr.t -> Class_expr.t  =
       fun class_expr ->
         let concrete =
@@ -976,8 +996,13 @@ class virtual map =
           Class_field_kind.of_concrete (Cfk_concrete (x0, x1))
     method class_declaration : Class_declaration.t -> Class_declaration.t  =
       fun class_declaration ->
-        let class_declaration = self#class_infos_class_expr class_declaration in
-        class_declaration
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_expr concrete in
+        Class_declaration.of_concrete concrete
     method module_type : Module_type.t -> Module_type.t  =
       fun module_type ->
         let concrete =
@@ -1156,12 +1181,22 @@ class virtual map =
         Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }
     method include_description : Include_description.t -> Include_description.t  =
       fun include_description ->
-        let include_description = self#include_infos_module_type include_description in
-        include_description
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_type concrete in
+        Include_description.of_concrete concrete
     method include_declaration : Include_declaration.t -> Include_declaration.t  =
       fun include_declaration ->
-        let include_declaration = self#include_infos_module_expr include_declaration in
-        include_declaration
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_expr concrete in
+        Include_declaration.of_concrete concrete
     method with_constraint : With_constraint.t -> With_constraint.t  =
       fun with_constraint ->
         let concrete =
@@ -1402,7 +1437,12 @@ class virtual iter =
           self#longident x1
     method longident_loc : Longident_loc.t -> unit  =
       fun longident_loc ->
-        self#loc self#longident longident_loc
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        self#loc self#longident concrete
     method rec_flag : Rec_flag.t -> unit  =
       fun rec_flag ->
         let concrete =
@@ -1489,7 +1529,12 @@ class virtual iter =
           ()
     method label : Label.t -> unit  =
       fun label ->
-        self#string label
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        self#string concrete
     method arg_label : Arg_label.t -> unit  =
       fun arg_label ->
         let concrete =
@@ -2098,10 +2143,20 @@ class virtual iter =
         self#attributes pci_attributes
     method class_description : Class_description.t -> unit  =
       fun class_description ->
-        self#class_infos_class_type class_description
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        self#class_infos_class_type concrete
     method class_type_declaration : Class_type_declaration.t -> unit  =
       fun class_type_declaration ->
-        self#class_infos_class_type class_type_declaration
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        self#class_infos_class_type concrete
     method class_expr : Class_expr.t -> unit  =
       fun class_expr ->
         let concrete =
@@ -2207,7 +2262,12 @@ class virtual iter =
           self#expression x1
     method class_declaration : Class_declaration.t -> unit  =
       fun class_declaration ->
-        self#class_infos_class_expr class_declaration
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        self#class_infos_class_expr concrete
     method module_type : Module_type.t -> unit  =
       fun module_type ->
         let concrete =
@@ -2358,10 +2418,20 @@ class virtual iter =
         self#attributes pincl_attributes
     method include_description : Include_description.t -> unit  =
       fun include_description ->
-        self#include_infos_module_type include_description
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        self#include_infos_module_type concrete
     method include_declaration : Include_declaration.t -> unit  =
       fun include_declaration ->
-        self#include_infos_module_expr include_declaration
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        self#include_infos_module_expr concrete
     method with_constraint : With_constraint.t -> unit  =
       fun with_constraint ->
         let concrete =
@@ -2568,7 +2638,12 @@ class virtual ['acc] fold =
           acc
     method longident_loc : Longident_loc.t -> 'acc -> 'acc  =
       fun longident_loc acc ->
-        let acc = self#loc self#longident longident_loc acc in
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let acc = self#loc self#longident concrete acc in
         acc
     method rec_flag : Rec_flag.t -> 'acc -> 'acc  =
       fun rec_flag acc ->
@@ -2656,7 +2731,12 @@ class virtual ['acc] fold =
           acc
     method label : Label.t -> 'acc -> 'acc  =
       fun label acc ->
-        let acc = self#string label acc in
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let acc = self#string concrete acc in
         acc
     method arg_label : Arg_label.t -> 'acc -> 'acc  =
       fun arg_label acc ->
@@ -3379,11 +3459,21 @@ class virtual ['acc] fold =
         acc
     method class_description : Class_description.t -> 'acc -> 'acc  =
       fun class_description acc ->
-        let acc = self#class_infos_class_type class_description acc in
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let acc = self#class_infos_class_type concrete acc in
         acc
     method class_type_declaration : Class_type_declaration.t -> 'acc -> 'acc  =
       fun class_type_declaration acc ->
-        let acc = self#class_infos_class_type class_type_declaration acc in
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let acc = self#class_infos_class_type concrete acc in
         acc
     method class_expr : Class_expr.t -> 'acc -> 'acc  =
       fun class_expr acc ->
@@ -3510,7 +3600,12 @@ class virtual ['acc] fold =
           acc
     method class_declaration : Class_declaration.t -> 'acc -> 'acc  =
       fun class_declaration acc ->
-        let acc = self#class_infos_class_expr class_declaration acc in
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let acc = self#class_infos_class_expr concrete acc in
         acc
     method module_type : Module_type.t -> 'acc -> 'acc  =
       fun module_type acc ->
@@ -3690,11 +3785,21 @@ class virtual ['acc] fold =
         acc
     method include_description : Include_description.t -> 'acc -> 'acc  =
       fun include_description acc ->
-        let acc = self#include_infos_module_type include_description acc in
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let acc = self#include_infos_module_type concrete acc in
         acc
     method include_declaration : Include_declaration.t -> 'acc -> 'acc  =
       fun include_declaration acc ->
-        let acc = self#include_infos_module_expr include_declaration acc in
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let acc = self#include_infos_module_expr concrete acc in
         acc
     method with_constraint : With_constraint.t -> 'acc -> 'acc  =
       fun with_constraint acc ->
@@ -3939,8 +4044,13 @@ class virtual ['acc] fold_map =
           (Longident.of_concrete (Lapply (x0, x1)), acc)
     method longident_loc : Longident_loc.t -> 'acc -> (Longident_loc.t * 'acc)  =
       fun longident_loc acc ->
-        let (longident_loc, acc) = self#loc self#longident longident_loc acc in
-        (longident_loc, acc)
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#loc self#longident concrete acc in
+        (Longident_loc.of_concrete concrete, acc)
     method rec_flag : Rec_flag.t -> 'acc -> (Rec_flag.t * 'acc)  =
       fun rec_flag acc ->
         let concrete =
@@ -4027,8 +4137,13 @@ class virtual ['acc] fold_map =
           (Closed_flag.of_concrete Open, acc)
     method label : Label.t -> 'acc -> (Label.t * 'acc)  =
       fun label acc ->
-        let (label, acc) = self#string label acc in
-        (label, acc)
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#string concrete acc in
+        (Label.of_concrete concrete, acc)
     method arg_label : Arg_label.t -> 'acc -> (Arg_label.t * 'acc)  =
       fun arg_label acc ->
         let concrete =
@@ -4750,12 +4865,22 @@ class virtual ['acc] fold_map =
         (Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }, acc)
     method class_description : Class_description.t -> 'acc -> (Class_description.t * 'acc)  =
       fun class_description acc ->
-        let (class_description, acc) = self#class_infos_class_type class_description acc in
-        (class_description, acc)
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#class_infos_class_type concrete acc in
+        (Class_description.of_concrete concrete, acc)
     method class_type_declaration : Class_type_declaration.t -> 'acc -> (Class_type_declaration.t * 'acc)  =
       fun class_type_declaration acc ->
-        let (class_type_declaration, acc) = self#class_infos_class_type class_type_declaration acc in
-        (class_type_declaration, acc)
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#class_infos_class_type concrete acc in
+        (Class_type_declaration.of_concrete concrete, acc)
     method class_expr : Class_expr.t -> 'acc -> (Class_expr.t * 'acc)  =
       fun class_expr acc ->
         let concrete =
@@ -4881,8 +5006,13 @@ class virtual ['acc] fold_map =
           (Class_field_kind.of_concrete (Cfk_concrete (x0, x1)), acc)
     method class_declaration : Class_declaration.t -> 'acc -> (Class_declaration.t * 'acc)  =
       fun class_declaration acc ->
-        let (class_declaration, acc) = self#class_infos_class_expr class_declaration acc in
-        (class_declaration, acc)
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#class_infos_class_expr concrete acc in
+        (Class_declaration.of_concrete concrete, acc)
     method module_type : Module_type.t -> 'acc -> (Module_type.t * 'acc)  =
       fun module_type acc ->
         let concrete =
@@ -5061,12 +5191,22 @@ class virtual ['acc] fold_map =
         (Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }, acc)
     method include_description : Include_description.t -> 'acc -> (Include_description.t * 'acc)  =
       fun include_description acc ->
-        let (include_description, acc) = self#include_infos_module_type include_description acc in
-        (include_description, acc)
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#include_infos_module_type concrete acc in
+        (Include_description.of_concrete concrete, acc)
     method include_declaration : Include_declaration.t -> 'acc -> (Include_declaration.t * 'acc)  =
       fun include_declaration acc ->
-        let (include_declaration, acc) = self#include_infos_module_expr include_declaration acc in
-        (include_declaration, acc)
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let (concrete, acc) = self#include_infos_module_expr concrete acc in
+        (Include_declaration.of_concrete concrete, acc)
     method with_constraint : With_constraint.t -> 'acc -> (With_constraint.t * 'acc)  =
       fun with_constraint acc ->
         let concrete =
@@ -5310,8 +5450,13 @@ class virtual ['ctx] map_with_context =
           Longident.of_concrete (Lapply (x0, x1))
     method longident_loc : 'ctx -> Longident_loc.t -> Longident_loc.t  =
       fun _ctx longident_loc ->
-        let longident_loc = self#loc self#longident _ctx longident_loc in
-        longident_loc
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let concrete = self#loc self#longident _ctx concrete in
+        Longident_loc.of_concrete concrete
     method rec_flag : 'ctx -> Rec_flag.t -> Rec_flag.t  =
       fun _ctx rec_flag ->
         let concrete =
@@ -5398,8 +5543,13 @@ class virtual ['ctx] map_with_context =
           Closed_flag.of_concrete Open
     method label : 'ctx -> Label.t -> Label.t  =
       fun _ctx label ->
-        let label = self#string _ctx label in
-        label
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let concrete = self#string _ctx concrete in
+        Label.of_concrete concrete
     method arg_label : 'ctx -> Arg_label.t -> Arg_label.t  =
       fun _ctx arg_label ->
         let concrete =
@@ -6121,12 +6271,22 @@ class virtual ['ctx] map_with_context =
         Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
     method class_description : 'ctx -> Class_description.t -> Class_description.t  =
       fun _ctx class_description ->
-        let class_description = self#class_infos_class_type _ctx class_description in
-        class_description
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type _ctx concrete in
+        Class_description.of_concrete concrete
     method class_type_declaration : 'ctx -> Class_type_declaration.t -> Class_type_declaration.t  =
       fun _ctx class_type_declaration ->
-        let class_type_declaration = self#class_infos_class_type _ctx class_type_declaration in
-        class_type_declaration
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type _ctx concrete in
+        Class_type_declaration.of_concrete concrete
     method class_expr : 'ctx -> Class_expr.t -> Class_expr.t  =
       fun _ctx class_expr ->
         let concrete =
@@ -6252,8 +6412,13 @@ class virtual ['ctx] map_with_context =
           Class_field_kind.of_concrete (Cfk_concrete (x0, x1))
     method class_declaration : 'ctx -> Class_declaration.t -> Class_declaration.t  =
       fun _ctx class_declaration ->
-        let class_declaration = self#class_infos_class_expr _ctx class_declaration in
-        class_declaration
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_expr _ctx concrete in
+        Class_declaration.of_concrete concrete
     method module_type : 'ctx -> Module_type.t -> Module_type.t  =
       fun _ctx module_type ->
         let concrete =
@@ -6432,12 +6597,22 @@ class virtual ['ctx] map_with_context =
         Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }
     method include_description : 'ctx -> Include_description.t -> Include_description.t  =
       fun _ctx include_description ->
-        let include_description = self#include_infos_module_type _ctx include_description in
-        include_description
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_type _ctx concrete in
+        Include_description.of_concrete concrete
     method include_declaration : 'ctx -> Include_declaration.t -> Include_declaration.t  =
       fun _ctx include_declaration ->
-        let include_declaration = self#include_infos_module_expr _ctx include_declaration in
-        include_declaration
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_expr _ctx concrete in
+        Include_declaration.of_concrete concrete
     method with_constraint : 'ctx -> With_constraint.t -> With_constraint.t  =
       fun _ctx with_constraint ->
         let concrete =
@@ -6685,8 +6860,13 @@ class virtual ['res] lift =
           self#constr (Some ("longident", 0)) "Lapply" [x0; x1]
     method longident_loc : Longident_loc.t -> 'res  =
       fun longident_loc ->
-        let longident_loc = self#loc self#longident longident_loc in
-        self#node None longident_loc
+        let concrete =
+          match Longident_loc.to_concrete longident_loc with
+          | None -> conversion_failed "longident_loc"
+          | Some n -> n
+        in
+        let concrete = self#loc self#longident concrete in
+        self#node (Some ("longident_loc", 0)) concrete
     method rec_flag : Rec_flag.t -> 'res  =
       fun rec_flag ->
         let concrete =
@@ -6773,8 +6953,13 @@ class virtual ['res] lift =
           self#constr (Some ("closed_flag", 0)) "Open" []
     method label : Label.t -> 'res  =
       fun label ->
-        let label = self#string label in
-        self#node None label
+        let concrete =
+          match Label.to_concrete label with
+          | None -> conversion_failed "label"
+          | Some n -> n
+        in
+        let concrete = self#string concrete in
+        self#node (Some ("label", 0)) concrete
     method arg_label : Arg_label.t -> 'res  =
       fun arg_label ->
         let concrete =
@@ -7496,12 +7681,22 @@ class virtual ['res] lift =
         self#record (Some ("class_infos", 1)) [("pci_virt", pci_virt); ("pci_params", pci_params); ("pci_name", pci_name); ("pci_expr", pci_expr); ("pci_loc", pci_loc); ("pci_attributes", pci_attributes)]
     method class_description : Class_description.t -> 'res  =
       fun class_description ->
-        let class_description = self#class_infos_class_type class_description in
-        self#node None class_description
+        let concrete =
+          match Class_description.to_concrete class_description with
+          | None -> conversion_failed "class_description"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type concrete in
+        self#node (Some ("class_description", 0)) concrete
     method class_type_declaration : Class_type_declaration.t -> 'res  =
       fun class_type_declaration ->
-        let class_type_declaration = self#class_infos_class_type class_type_declaration in
-        self#node None class_type_declaration
+        let concrete =
+          match Class_type_declaration.to_concrete class_type_declaration with
+          | None -> conversion_failed "class_type_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_type concrete in
+        self#node (Some ("class_type_declaration", 0)) concrete
     method class_expr : Class_expr.t -> 'res  =
       fun class_expr ->
         let concrete =
@@ -7627,8 +7822,13 @@ class virtual ['res] lift =
           self#constr (Some ("class_field_kind", 0)) "Cfk_concrete" [x0; x1]
     method class_declaration : Class_declaration.t -> 'res  =
       fun class_declaration ->
-        let class_declaration = self#class_infos_class_expr class_declaration in
-        self#node None class_declaration
+        let concrete =
+          match Class_declaration.to_concrete class_declaration with
+          | None -> conversion_failed "class_declaration"
+          | Some n -> n
+        in
+        let concrete = self#class_infos_class_expr concrete in
+        self#node (Some ("class_declaration", 0)) concrete
     method module_type : Module_type.t -> 'res  =
       fun module_type ->
         let concrete =
@@ -7807,12 +8007,22 @@ class virtual ['res] lift =
         self#record (Some ("include_infos", 1)) [("pincl_mod", pincl_mod); ("pincl_loc", pincl_loc); ("pincl_attributes", pincl_attributes)]
     method include_description : Include_description.t -> 'res  =
       fun include_description ->
-        let include_description = self#include_infos_module_type include_description in
-        self#node None include_description
+        let concrete =
+          match Include_description.to_concrete include_description with
+          | None -> conversion_failed "include_description"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_type concrete in
+        self#node (Some ("include_description", 0)) concrete
     method include_declaration : Include_declaration.t -> 'res  =
       fun include_declaration ->
-        let include_declaration = self#include_infos_module_expr include_declaration in
-        self#node None include_declaration
+        let concrete =
+          match Include_declaration.to_concrete include_declaration with
+          | None -> conversion_failed "include_declaration"
+          | Some n -> n
+        in
+        let concrete = self#include_infos_module_expr concrete in
+        self#node (Some ("include_declaration", 0)) concrete
     method with_constraint : With_constraint.t -> 'res  =
       fun with_constraint ->
         let concrete =

--- a/ast/virtual_traverse_v4_07.mli
+++ b/ast/virtual_traverse_v4_07.mli
@@ -20,7 +20,6 @@ class virtual map :
     method virtual_flag : Virtual_flag.t -> Virtual_flag.t
     method override_flag : Override_flag.t -> Override_flag.t
     method closed_flag : Closed_flag.t -> Closed_flag.t
-    method label : Label.t -> Label.t
     method arg_label : Arg_label.t -> Arg_label.t
     method variance : Variance.t -> Variance.t
     method constant : Constant.t -> Constant.t
@@ -106,7 +105,6 @@ class virtual iter :
     method virtual_flag : Virtual_flag.t -> unit
     method override_flag : Override_flag.t -> unit
     method closed_flag : Closed_flag.t -> unit
-    method label : Label.t -> unit
     method arg_label : Arg_label.t -> unit
     method variance : Variance.t -> unit
     method constant : Constant.t -> unit
@@ -192,7 +190,6 @@ class virtual ['acc] fold :
     method virtual_flag : Virtual_flag.t -> 'acc -> 'acc
     method override_flag : Override_flag.t -> 'acc -> 'acc
     method closed_flag : Closed_flag.t -> 'acc -> 'acc
-    method label : Label.t -> 'acc -> 'acc
     method arg_label : Arg_label.t -> 'acc -> 'acc
     method variance : Variance.t -> 'acc -> 'acc
     method constant : Constant.t -> 'acc -> 'acc
@@ -278,7 +275,6 @@ class virtual ['acc] fold_map :
     method virtual_flag : Virtual_flag.t -> 'acc -> (Virtual_flag.t * 'acc)
     method override_flag : Override_flag.t -> 'acc -> (Override_flag.t * 'acc)
     method closed_flag : Closed_flag.t -> 'acc -> (Closed_flag.t * 'acc)
-    method label : Label.t -> 'acc -> (Label.t * 'acc)
     method arg_label : Arg_label.t -> 'acc -> (Arg_label.t * 'acc)
     method variance : Variance.t -> 'acc -> (Variance.t * 'acc)
     method constant : Constant.t -> 'acc -> (Constant.t * 'acc)
@@ -364,7 +360,6 @@ class virtual ['ctx] map_with_context :
     method virtual_flag : 'ctx -> Virtual_flag.t -> Virtual_flag.t
     method override_flag : 'ctx -> Override_flag.t -> Override_flag.t
     method closed_flag : 'ctx -> Closed_flag.t -> Closed_flag.t
-    method label : 'ctx -> Label.t -> Label.t
     method arg_label : 'ctx -> Arg_label.t -> Arg_label.t
     method variance : 'ctx -> Variance.t -> Variance.t
     method constant : 'ctx -> Constant.t -> Constant.t
@@ -454,7 +449,6 @@ class virtual ['res] lift :
     method virtual_flag : Virtual_flag.t -> 'res
     method override_flag : Override_flag.t -> 'res
     method closed_flag : Closed_flag.t -> 'res
-    method label : Label.t -> 'res
     method arg_label : Arg_label.t -> 'res
     method variance : Variance.t -> 'res
     method constant : Constant.t -> 'res

--- a/astlib/grammar.ml
+++ b/astlib/grammar.ml
@@ -59,15 +59,10 @@ type clause =
 type variant = (string * clause) list
 
 (** A nominal type may contain a structural type, a record type, or a variant type. *)
-type versioned =
+type decl =
   | Wrapper of ty
   | Record of record
   | Variant of variant
-
-(** A declaration may be an unversioned structure type or a versioned node type. *)
-type decl =
-  | Unversioned of ty
-  | Versioned of versioned
 
 (** The "kind" of a type determines its type arguments. [Mono]morphic types have no type
     arguments; [Poly]morphic types have one or more type arguments. *)

--- a/astlib/latest_version.ml
+++ b/astlib/latest_version.ml
@@ -26,7 +26,6 @@ let grammar : Grammar.t =
     , Mono (Variant [("Override", Empty); ("Fresh", Empty)]) )
   ; ( "closed_flag"
     , Mono (Variant [("Closed", Empty); ("Open", Empty)]) )
-  ; ("label", Mono (Wrapper String))
   ; ( "arg_label"
     , Mono
         (Variant
@@ -85,7 +84,7 @@ let grammar : Grammar.t =
                 , Tuple
                     [ List (Name "row_field")
                     ; Name "closed_flag"
-                    ; Option (List (Name "label")) ] )
+                    ; Option (List String) ] )
               ; ("Ptyp_poly", Tuple [List (Loc String); Name "core_type"])
               ; ("Ptyp_package", Tuple [Name "package_type"])
               ; ("Ptyp_extension", Tuple [Name "extension"]) ]) )
@@ -101,7 +100,7 @@ let grammar : Grammar.t =
         (Variant
               [ ( "Rtag"
                 , Tuple
-                    [ Loc (Name "label")
+                    [ Loc String
                     ; Name "attributes"
                     ; Bool
                     ; List (Name "core_type") ] )
@@ -111,7 +110,7 @@ let grammar : Grammar.t =
         (Variant
               [ ( "Otag"
                 , Tuple
-                    [Loc (Name "label"); Name "attributes"; Name "core_type"]
+                    [Loc String; Name "attributes"; Name "core_type"]
                 )
               ; ("Oinherit", Tuple [Name "core_type"]) ]) )
   ; ( "pattern"
@@ -131,7 +130,7 @@ let grammar : Grammar.t =
               ; ("Ppat_tuple", Tuple [List (Name "pattern")])
               ; ( "Ppat_construct"
                 , Tuple [Name "longident_loc"; Option (Name "pattern")] )
-              ; ("Ppat_variant", Tuple [Name "label"; Option (Name "pattern")])
+              ; ("Ppat_variant", Tuple [String; Option (Name "pattern")])
               ; ( "Ppat_record"
                 , Tuple
                     [ List (Tuple [Name "longident_loc"; Name "pattern"])
@@ -179,7 +178,7 @@ let grammar : Grammar.t =
               ; ( "Pexp_construct"
                 , Tuple [Name "longident_loc"; Option (Name "expression")] )
               ; ( "Pexp_variant"
-                , Tuple [Name "label"; Option (Name "expression")] )
+                , Tuple [String; Option (Name "expression")] )
               ; ( "Pexp_record"
                 , Tuple
                     [ List (Tuple [Name "longident_loc"; Name "expression"])
@@ -210,12 +209,12 @@ let grammar : Grammar.t =
                     [ Name "expression"
                     ; Option (Name "core_type")
                     ; Name "core_type" ] )
-              ; ("Pexp_send", Tuple [Name "expression"; Loc (Name "label")])
+              ; ("Pexp_send", Tuple [Name "expression"; Loc String])
               ; ("Pexp_new", Tuple [Name "longident_loc"])
               ; ( "Pexp_setinstvar"
-                , Tuple [Loc (Name "label"); Name "expression"] )
+                , Tuple [Loc String; Name "expression"] )
               ; ( "Pexp_override"
-                , Tuple [List (Tuple [Loc (Name "label"); Name "expression"])]
+                , Tuple [List (Tuple [Loc String; Name "expression"])]
                 )
               ; ( "Pexp_letmodule"
                 , Tuple [Loc String; Name "module_expr"; Name "expression"] )
@@ -355,14 +354,14 @@ let grammar : Grammar.t =
               ; ( "Pctf_val"
                 , Tuple
                     [ Tuple
-                        [ Loc (Name "label")
+                        [ Loc String
                         ; Name "mutable_flag"
                         ; Name "virtual_flag"
                         ; Name "core_type" ] ] )
               ; ( "Pctf_method"
                 , Tuple
                     [ Tuple
-                        [ Loc (Name "label")
+                        [ Loc String
                         ; Name "private_flag"
                         ; Name "virtual_flag"
                         ; Name "core_type" ] ] )
@@ -441,13 +440,13 @@ let grammar : Grammar.t =
               ; ( "Pcf_val"
                 , Tuple
                     [ Tuple
-                        [ Loc (Name "label")
+                        [ Loc String
                         ; Name "mutable_flag"
                         ; Name "class_field_kind" ] ] )
               ; ( "Pcf_method"
                 , Tuple
                     [ Tuple
-                        [ Loc (Name "label")
+                        [ Loc String
                         ; Name "private_flag"
                         ; Name "class_field_kind" ] ] )
               ; ( "Pcf_constraint"

--- a/astlib/latest_version.ml
+++ b/astlib/latest_version.ml
@@ -5,76 +5,69 @@ let conversions : History.conversion list = []
 let grammar : Grammar.t =
   [ ( "longident"
     , Mono
-        (Versioned
-           (Variant
-              [ ("Lident", Tuple [String])
-              ; ("Ldot", Tuple [Name "longident"; String])
-              ; ("Lapply", Tuple [Name "longident"; Name "longident"]) ])) )
-  ; ("longident_loc", Mono (Unversioned (Loc (Name "longident"))))
+        (Variant
+           [ ("Lident", Tuple [String])
+           ; ("Ldot", Tuple [Name "longident"; String])
+           ; ("Lapply", Tuple [Name "longident"; Name "longident"]) ]))
+  ; ("longident_loc", Mono (Wrapper (Loc (Name "longident"))))
   ; ( "rec_flag"
     , Mono
-        (Versioned (Variant [("Nonrecursive", Empty); ("Recursive", Empty)]))
+        (Variant [("Nonrecursive", Empty); ("Recursive", Empty)])
     )
   ; ( "direction_flag"
-    , Mono (Versioned (Variant [("Upto", Empty); ("Downto", Empty)])) )
+    , Mono (Variant [("Upto", Empty); ("Downto", Empty)]) )
   ; ( "private_flag"
-    , Mono (Versioned (Variant [("Private", Empty); ("Public", Empty)])) )
+    , Mono (Variant [("Private", Empty); ("Public", Empty)]) )
   ; ( "mutable_flag"
-    , Mono (Versioned (Variant [("Immutable", Empty); ("Mutable", Empty)])) )
+    , Mono (Variant [("Immutable", Empty); ("Mutable", Empty)]) )
   ; ( "virtual_flag"
-    , Mono (Versioned (Variant [("Virtual", Empty); ("Concrete", Empty)])) )
+    , Mono (Variant [("Virtual", Empty); ("Concrete", Empty)]) )
   ; ( "override_flag"
-    , Mono (Versioned (Variant [("Override", Empty); ("Fresh", Empty)])) )
+    , Mono (Variant [("Override", Empty); ("Fresh", Empty)]) )
   ; ( "closed_flag"
-    , Mono (Versioned (Variant [("Closed", Empty); ("Open", Empty)])) )
-  ; ("label", Mono (Unversioned String))
+    , Mono (Variant [("Closed", Empty); ("Open", Empty)]) )
+  ; ("label", Mono (Wrapper String))
   ; ( "arg_label"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Nolabel", Empty)
               ; ("Labelled", Tuple [String])
-              ; ("Optional", Tuple [String]) ])) )
+              ; ("Optional", Tuple [String]) ]) )
   ; ( "variance"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Covariant", Empty)
               ; ("Contravariant", Empty)
-              ; ("Invariant", Empty) ])) )
+              ; ("Invariant", Empty) ]) )
   ; ( "constant"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Pconst_integer", Tuple [String; Option Char])
               ; ("Pconst_char", Tuple [Char])
               ; ("Pconst_string", Tuple [String; Option String])
-              ; ("Pconst_float", Tuple [String; Option Char]) ])) )
+              ; ("Pconst_float", Tuple [String; Option Char]) ]) )
   ; ( "attribute"
-    , Mono (Versioned (Wrapper (Tuple [Loc String; Name "payload"]))) )
+    , Mono (Wrapper (Tuple [Loc String; Name "payload"])) )
   ; ( "extension"
-    , Mono (Versioned (Wrapper (Tuple [Loc String; Name "payload"]))) )
-  ; ("attributes", Mono (Versioned (Wrapper (List (Name "attribute")))))
+    , Mono (Wrapper (Tuple [Loc String; Name "payload"])) )
+  ; ("attributes", Mono (Wrapper (List (Name "attribute"))))
   ; ( "payload"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("PStr", Tuple [Name "structure"])
               ; ("PSig", Tuple [Name "signature"])
               ; ("PTyp", Tuple [Name "core_type"])
-              ; ("PPat", Tuple [Name "pattern"; Option (Name "expression")]) ]))
+              ; ("PPat", Tuple [Name "pattern"; Option (Name "expression")]) ])
     )
   ; ( "core_type"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("ptyp_desc", Name "core_type_desc")
               ; ("ptyp_loc", Location)
-              ; ("ptyp_attributes", Name "attributes") ])) )
+              ; ("ptyp_attributes", Name "attributes") ]) )
   ; ( "core_type_desc"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Ptyp_any", Empty)
               ; ("Ptyp_var", Tuple [String])
               ; ( "Ptyp_arrow"
@@ -95,46 +88,41 @@ let grammar : Grammar.t =
                     ; Option (List (Name "label")) ] )
               ; ("Ptyp_poly", Tuple [List (Loc String); Name "core_type"])
               ; ("Ptyp_package", Tuple [Name "package_type"])
-              ; ("Ptyp_extension", Tuple [Name "extension"]) ])) )
+              ; ("Ptyp_extension", Tuple [Name "extension"]) ]) )
   ; ( "package_type"
     , Mono
-        (Versioned
-           (Wrapper
+        (Wrapper
               (Tuple
                  [ Name "longident_loc"
-                 ; List (Tuple [Name "longident_loc"; Name "core_type"]) ])))
+                 ; List (Tuple [Name "longident_loc"; Name "core_type"]) ]))
     )
   ; ( "row_field"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ( "Rtag"
                 , Tuple
                     [ Loc (Name "label")
                     ; Name "attributes"
                     ; Bool
                     ; List (Name "core_type") ] )
-              ; ("Rinherit", Tuple [Name "core_type"]) ])) )
+              ; ("Rinherit", Tuple [Name "core_type"]) ]) )
   ; ( "object_field"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ( "Otag"
                 , Tuple
                     [Loc (Name "label"); Name "attributes"; Name "core_type"]
                 )
-              ; ("Oinherit", Tuple [Name "core_type"]) ])) )
+              ; ("Oinherit", Tuple [Name "core_type"]) ]) )
   ; ( "pattern"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("ppat_desc", Name "pattern_desc")
               ; ("ppat_loc", Location)
-              ; ("ppat_attributes", Name "attributes") ])) )
+              ; ("ppat_attributes", Name "attributes") ]) )
   ; ( "pattern_desc"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Ppat_any", Empty)
               ; ("Ppat_var", Tuple [Loc String])
               ; ("Ppat_alias", Tuple [Name "pattern"; Loc String])
@@ -156,19 +144,17 @@ let grammar : Grammar.t =
               ; ("Ppat_unpack", Tuple [Loc String])
               ; ("Ppat_exception", Tuple [Name "pattern"])
               ; ("Ppat_extension", Tuple [Name "extension"])
-              ; ("Ppat_open", Tuple [Name "longident_loc"; Name "pattern"]) ]))
+              ; ("Ppat_open", Tuple [Name "longident_loc"; Name "pattern"]) ])
     )
   ; ( "expression"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pexp_desc", Name "expression_desc")
               ; ("pexp_loc", Location)
-              ; ("pexp_attributes", Name "attributes") ])) )
+              ; ("pexp_attributes", Name "attributes") ]) )
   ; ( "expression_desc"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Pexp_ident", Tuple [Name "longident_loc"])
               ; ("Pexp_constant", Tuple [Name "constant"])
               ; ( "Pexp_let"
@@ -248,27 +234,24 @@ let grammar : Grammar.t =
                     ; Name "longident_loc"
                     ; Name "expression" ] )
               ; ("Pexp_extension", Tuple [Name "extension"])
-              ; ("Pexp_unreachable", Empty) ])) )
+              ; ("Pexp_unreachable", Empty) ]) )
   ; ( "case"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pc_lhs", Name "pattern")
               ; ("pc_guard", Option (Name "expression"))
-              ; ("pc_rhs", Name "expression") ])) )
+              ; ("pc_rhs", Name "expression") ]) )
   ; ( "value_description"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pval_name", Loc String)
               ; ("pval_type", Name "core_type")
               ; ("pval_prim", List String)
               ; ("pval_attributes", Name "attributes")
-              ; ("pval_loc", Location) ])) )
+              ; ("pval_loc", Location) ]) )
   ; ( "type_declaration"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("ptype_name", Loc String)
               ; ( "ptype_params"
                 , List (Tuple [Name "core_type"; Name "variance"]) )
@@ -279,78 +262,69 @@ let grammar : Grammar.t =
               ; ("ptype_private", Name "private_flag")
               ; ("ptype_manifest", Option (Name "core_type"))
               ; ("ptype_attributes", Name "attributes")
-              ; ("ptype_loc", Location) ])) )
+              ; ("ptype_loc", Location) ]) )
   ; ( "type_kind"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Ptype_abstract", Empty)
               ; ("Ptype_variant", Tuple [List (Name "constructor_declaration")])
               ; ("Ptype_record", Tuple [List (Name "label_declaration")])
-              ; ("Ptype_open", Empty) ])) )
+              ; ("Ptype_open", Empty) ]) )
   ; ( "label_declaration"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pld_name", Loc String)
               ; ("pld_mutable", Name "mutable_flag")
               ; ("pld_type", Name "core_type")
               ; ("pld_loc", Location)
-              ; ("pld_attributes", Name "attributes") ])) )
+              ; ("pld_attributes", Name "attributes") ]) )
   ; ( "constructor_declaration"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pcd_name", Loc String)
               ; ("pcd_args", Name "constructor_arguments")
               ; ("pcd_res", Option (Name "core_type"))
               ; ("pcd_loc", Location)
-              ; ("pcd_attributes", Name "attributes") ])) )
+              ; ("pcd_attributes", Name "attributes") ]) )
   ; ( "constructor_arguments"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Pcstr_tuple", Tuple [List (Name "core_type")])
-              ; ("Pcstr_record", Tuple [List (Name "label_declaration")]) ]))
+              ; ("Pcstr_record", Tuple [List (Name "label_declaration")]) ])
     )
   ; ( "type_extension"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("ptyext_path", Name "longident_loc")
               ; ( "ptyext_params"
                 , List (Tuple [Name "core_type"; Name "variance"]) )
               ; ("ptyext_constructors", List (Name "extension_constructor"))
               ; ("ptyext_private", Name "private_flag")
-              ; ("ptyext_attributes", Name "attributes") ])) )
+              ; ("ptyext_attributes", Name "attributes") ]) )
   ; ( "extension_constructor"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pext_name", Loc String)
               ; ("pext_kind", Name "extension_constructor_kind")
               ; ("pext_loc", Location)
-              ; ("pext_attributes", Name "attributes") ])) )
+              ; ("pext_attributes", Name "attributes") ]) )
   ; ( "extension_constructor_kind"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ( "Pext_decl"
                 , Tuple
                     [Name "constructor_arguments"; Option (Name "core_type")]
                 )
-              ; ("Pext_rebind", Tuple [Name "longident_loc"]) ])) )
+              ; ("Pext_rebind", Tuple [Name "longident_loc"]) ]) )
   ; ( "class_type"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pcty_desc", Name "class_type_desc")
               ; ("pcty_loc", Location)
-              ; ("pcty_attributes", Name "attributes") ])) )
+              ; ("pcty_attributes", Name "attributes") ]) )
   ; ( "class_type_desc"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ( "Pcty_constr"
                 , Tuple [Name "longident_loc"; List (Name "core_type")] )
               ; ("Pcty_signature", Tuple [Name "class_signature"])
@@ -362,24 +336,21 @@ let grammar : Grammar.t =
                 , Tuple
                     [ Name "override_flag"
                     ; Name "longident_loc"
-                    ; Name "class_type" ] ) ])) )
+                    ; Name "class_type" ] ) ]) )
   ; ( "class_signature"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pcsig_self", Name "core_type")
-              ; ("pcsig_fields", List (Name "class_type_field")) ])) )
+              ; ("pcsig_fields", List (Name "class_type_field")) ]) )
   ; ( "class_type_field"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pctf_desc", Name "class_type_field_desc")
               ; ("pctf_loc", Location)
-              ; ("pctf_attributes", Name "attributes") ])) )
+              ; ("pctf_attributes", Name "attributes") ]) )
   ; ( "class_type_field_desc"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Pctf_inherit", Tuple [Name "class_type"])
               ; ( "Pctf_val"
                 , Tuple
@@ -398,12 +369,11 @@ let grammar : Grammar.t =
               ; ( "Pctf_constraint"
                 , Tuple [Tuple [Name "core_type"; Name "core_type"]] )
               ; ("Pctf_attribute", Tuple [Name "attribute"])
-              ; ("Pctf_extension", Tuple [Name "extension"]) ])) )
+              ; ("Pctf_extension", Tuple [Name "extension"]) ]) )
   ; ( "class_infos"
     , Poly
         ( ["a"]
-        , Versioned
-            (Record
+        , (Record
                [ ("pci_virt", Name "virtual_flag")
                ; ( "pci_params"
                  , List (Tuple [Name "core_type"; Name "variance"]) )
@@ -412,20 +382,18 @@ let grammar : Grammar.t =
                ; ("pci_loc", Location)
                ; ("pci_attributes", Name "attributes") ]) ) )
   ; ( "class_description"
-    , Mono (Unversioned (Instance ("class_infos", [Name "class_type"]))) )
+    , Mono (Wrapper (Instance ("class_infos", [Name "class_type"]))) )
   ; ( "class_type_declaration"
-    , Mono (Unversioned (Instance ("class_infos", [Name "class_type"]))) )
+    , Mono (Wrapper (Instance ("class_infos", [Name "class_type"]))) )
   ; ( "class_expr"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pcl_desc", Name "class_expr_desc")
               ; ("pcl_loc", Location)
-              ; ("pcl_attributes", Name "attributes") ])) )
+              ; ("pcl_attributes", Name "attributes") ]) )
   ; ( "class_expr_desc"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ( "Pcl_constr"
                 , Tuple [Name "longident_loc"; List (Name "core_type")] )
               ; ("Pcl_structure", Tuple [Name "class_structure"])
@@ -450,24 +418,21 @@ let grammar : Grammar.t =
                 , Tuple
                     [ Name "override_flag"
                     ; Name "longident_loc"
-                    ; Name "class_expr" ] ) ])) )
+                    ; Name "class_expr" ] ) ]) )
   ; ( "class_structure"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pcstr_self", Name "pattern")
-              ; ("pcstr_fields", List (Name "class_field")) ])) )
+              ; ("pcstr_fields", List (Name "class_field")) ]) )
   ; ( "class_field"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pcf_desc", Name "class_field_desc")
               ; ("pcf_loc", Location)
-              ; ("pcf_attributes", Name "attributes") ])) )
+              ; ("pcf_attributes", Name "attributes") ]) )
   ; ( "class_field_desc"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ( "Pcf_inherit"
                 , Tuple
                     [ Name "override_flag"
@@ -489,27 +454,24 @@ let grammar : Grammar.t =
                 , Tuple [Tuple [Name "core_type"; Name "core_type"]] )
               ; ("Pcf_initializer", Tuple [Name "expression"])
               ; ("Pcf_attribute", Tuple [Name "attribute"])
-              ; ("Pcf_extension", Tuple [Name "extension"]) ])) )
+              ; ("Pcf_extension", Tuple [Name "extension"]) ]) )
   ; ( "class_field_kind"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Cfk_virtual", Tuple [Name "core_type"])
               ; ( "Cfk_concrete"
-                , Tuple [Name "override_flag"; Name "expression"] ) ])) )
+                , Tuple [Name "override_flag"; Name "expression"] ) ]) )
   ; ( "class_declaration"
-    , Mono (Unversioned (Instance ("class_infos", [Name "class_expr"]))) )
+    , Mono (Wrapper (Instance ("class_infos", [Name "class_expr"]))) )
   ; ( "module_type"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pmty_desc", Name "module_type_desc")
               ; ("pmty_loc", Location)
-              ; ("pmty_attributes", Name "attributes") ])) )
+              ; ("pmty_attributes", Name "attributes") ]) )
   ; ( "module_type_desc"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Pmty_ident", Tuple [Name "longident_loc"])
               ; ("Pmty_signature", Tuple [Name "signature"])
               ; ( "Pmty_functor"
@@ -521,18 +483,16 @@ let grammar : Grammar.t =
                 , Tuple [Name "module_type"; List (Name "with_constraint")] )
               ; ("Pmty_typeof", Tuple [Name "module_expr"])
               ; ("Pmty_extension", Tuple [Name "extension"])
-              ; ("Pmty_alias", Tuple [Name "longident_loc"]) ])) )
-  ; ("signature", Mono (Versioned (Wrapper (List (Name "signature_item")))))
+              ; ("Pmty_alias", Tuple [Name "longident_loc"]) ]) )
+  ; ("signature", Mono (Wrapper (List (Name "signature_item"))))
   ; ( "signature_item"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("psig_desc", Name "signature_item_desc")
-              ; ("psig_loc", Location) ])) )
+              ; ("psig_loc", Location) ]) )
   ; ( "signature_item_desc"
     , Mono
-        (Versioned
-           (Variant
+        (Variant
               [ ("Psig_value", Tuple [Name "value_description"])
               ; ( "Psig_type"
                 , Tuple [Name "rec_flag"; List (Name "type_declaration")] )
@@ -548,136 +508,123 @@ let grammar : Grammar.t =
                 , Tuple [List (Name "class_type_declaration")] )
               ; ("Psig_attribute", Tuple [Name "attribute"])
               ; ("Psig_extension", Tuple [Name "extension"; Name "attributes"])
-              ])) )
+              ]) )
   ; ( "module_declaration"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pmd_name", Loc String)
               ; ("pmd_type", Name "module_type")
               ; ("pmd_attributes", Name "attributes")
-              ; ("pmd_loc", Location) ])) )
+              ; ("pmd_loc", Location) ]) )
   ; ( "module_type_declaration"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("pmtd_name", Loc String)
               ; ("pmtd_type", Option (Name "module_type"))
               ; ("pmtd_attributes", Name "attributes")
-              ; ("pmtd_loc", Location) ])) )
+              ; ("pmtd_loc", Location) ]) )
   ; ( "open_description"
     , Mono
-        (Versioned
-           (Record
+        (Record
               [ ("popen_lid", Name "longident_loc")
               ; ("popen_override", Name "override_flag")
               ; ("popen_loc", Location)
-              ; ("popen_attributes", Name "attributes") ])) )
+              ; ("popen_attributes", Name "attributes") ]) )
   ; ( "include_infos"
     , Poly
         ( ["a"]
-        , Versioned
-            (Record
-               [ ("pincl_mod", Var "a")
-               ; ("pincl_loc", Location)
-               ; ("pincl_attributes", Name "attributes") ]) ) )
+        , (Record
+             [ ("pincl_mod", Var "a")
+             ; ("pincl_loc", Location)
+             ; ("pincl_attributes", Name "attributes") ]) ) )
   ; ( "include_description"
-    , Mono (Unversioned (Instance ("include_infos", [Name "module_type"]))) )
+    , Mono (Wrapper (Instance ("include_infos", [Name "module_type"]))) )
   ; ( "include_declaration"
-    , Mono (Unversioned (Instance ("include_infos", [Name "module_expr"]))) )
+    , Mono (Wrapper (Instance ("include_infos", [Name "module_expr"]))) )
   ; ( "with_constraint"
     , Mono
-        (Versioned
-           (Variant
-              [ ( "Pwith_type"
-                , Tuple [Name "longident_loc"; Name "type_declaration"] )
-              ; ( "Pwith_module"
-                , Tuple [Name "longident_loc"; Name "longident_loc"] )
-              ; ( "Pwith_typesubst"
-                , Tuple [Name "longident_loc"; Name "type_declaration"] )
-              ; ( "Pwith_modsubst"
-                , Tuple [Name "longident_loc"; Name "longident_loc"] ) ])) )
+        (Variant
+           [ ( "Pwith_type"
+             , Tuple [Name "longident_loc"; Name "type_declaration"] )
+           ; ( "Pwith_module"
+             , Tuple [Name "longident_loc"; Name "longident_loc"] )
+           ; ( "Pwith_typesubst"
+             , Tuple [Name "longident_loc"; Name "type_declaration"] )
+           ; ( "Pwith_modsubst"
+             , Tuple [Name "longident_loc"; Name "longident_loc"] ) ]) )
   ; ( "module_expr"
     , Mono
-        (Versioned
-           (Record
-              [ ("pmod_desc", Name "module_expr_desc")
-              ; ("pmod_loc", Location)
-              ; ("pmod_attributes", Name "attributes") ])) )
+        (Record
+           [ ("pmod_desc", Name "module_expr_desc")
+           ; ("pmod_loc", Location)
+           ; ("pmod_attributes", Name "attributes") ]) )
   ; ( "module_expr_desc"
     , Mono
-        (Versioned
-           (Variant
-              [ ("Pmod_ident", Tuple [Name "longident_loc"])
-              ; ("Pmod_structure", Tuple [Name "structure"])
-              ; ( "Pmod_functor"
-                , Tuple
-                    [ Loc String
-                    ; Option (Name "module_type")
-                    ; Name "module_expr" ] )
-              ; ("Pmod_apply", Tuple [Name "module_expr"; Name "module_expr"])
-              ; ( "Pmod_constraint"
-                , Tuple [Name "module_expr"; Name "module_type"] )
-              ; ("Pmod_unpack", Tuple [Name "expression"])
-              ; ("Pmod_extension", Tuple [Name "extension"]) ])) )
-  ; ("structure", Mono (Versioned (Wrapper (List (Name "structure_item")))))
+        (Variant
+           [ ("Pmod_ident", Tuple [Name "longident_loc"])
+           ; ("Pmod_structure", Tuple [Name "structure"])
+           ; ( "Pmod_functor"
+             , Tuple
+                 [ Loc String
+                 ; Option (Name "module_type")
+                 ; Name "module_expr" ] )
+           ; ("Pmod_apply", Tuple [Name "module_expr"; Name "module_expr"])
+           ; ( "Pmod_constraint"
+             , Tuple [Name "module_expr"; Name "module_type"] )
+           ; ("Pmod_unpack", Tuple [Name "expression"])
+           ; ("Pmod_extension", Tuple [Name "extension"]) ]) )
+  ; ("structure", Mono (Wrapper (List (Name "structure_item"))))
   ; ( "structure_item"
     , Mono
-        (Versioned
-           (Record
-              [ ("pstr_desc", Name "structure_item_desc")
-              ; ("pstr_loc", Location) ])) )
+        (Record
+           [ ("pstr_desc", Name "structure_item_desc")
+           ; ("pstr_loc", Location) ]) )
   ; ( "structure_item_desc"
     , Mono
-        (Versioned
-           (Variant
-              [ ("Pstr_eval", Tuple [Name "expression"; Name "attributes"])
-              ; ( "Pstr_value"
-                , Tuple [Name "rec_flag"; List (Name "value_binding")] )
-              ; ("Pstr_primitive", Tuple [Name "value_description"])
-              ; ( "Pstr_type"
-                , Tuple [Name "rec_flag"; List (Name "type_declaration")] )
-              ; ("Pstr_typext", Tuple [Name "type_extension"])
-              ; ("Pstr_exception", Tuple [Name "extension_constructor"])
-              ; ("Pstr_module", Tuple [Name "module_binding"])
-              ; ("Pstr_recmodule", Tuple [List (Name "module_binding")])
-              ; ("Pstr_modtype", Tuple [Name "module_type_declaration"])
-              ; ("Pstr_open", Tuple [Name "open_description"])
-              ; ("Pstr_class", Tuple [List (Name "class_declaration")])
-              ; ( "Pstr_class_type"
-                , Tuple [List (Name "class_type_declaration")] )
-              ; ("Pstr_include", Tuple [Name "include_declaration"])
-              ; ("Pstr_attribute", Tuple [Name "attribute"])
-              ; ("Pstr_extension", Tuple [Name "extension"; Name "attributes"])
-              ])) )
+        (Variant
+           [ ("Pstr_eval", Tuple [Name "expression"; Name "attributes"])
+           ; ( "Pstr_value"
+             , Tuple [Name "rec_flag"; List (Name "value_binding")] )
+           ; ("Pstr_primitive", Tuple [Name "value_description"])
+           ; ( "Pstr_type"
+             , Tuple [Name "rec_flag"; List (Name "type_declaration")] )
+           ; ("Pstr_typext", Tuple [Name "type_extension"])
+           ; ("Pstr_exception", Tuple [Name "extension_constructor"])
+           ; ("Pstr_module", Tuple [Name "module_binding"])
+           ; ("Pstr_recmodule", Tuple [List (Name "module_binding")])
+           ; ("Pstr_modtype", Tuple [Name "module_type_declaration"])
+           ; ("Pstr_open", Tuple [Name "open_description"])
+           ; ("Pstr_class", Tuple [List (Name "class_declaration")])
+           ; ( "Pstr_class_type"
+             , Tuple [List (Name "class_type_declaration")] )
+           ; ("Pstr_include", Tuple [Name "include_declaration"])
+           ; ("Pstr_attribute", Tuple [Name "attribute"])
+           ; ("Pstr_extension", Tuple [Name "extension"; Name "attributes"])
+           ]) )
   ; ( "value_binding"
     , Mono
-        (Versioned
-           (Record
-              [ ("pvb_pat", Name "pattern")
-              ; ("pvb_expr", Name "expression")
-              ; ("pvb_attributes", Name "attributes")
-              ; ("pvb_loc", Location) ])) )
+        (Record
+           [ ("pvb_pat", Name "pattern")
+           ; ("pvb_expr", Name "expression")
+           ; ("pvb_attributes", Name "attributes")
+           ; ("pvb_loc", Location) ]) )
   ; ( "module_binding"
     , Mono
-        (Versioned
-           (Record
-              [ ("pmb_name", Loc String)
-              ; ("pmb_expr", Name "module_expr")
-              ; ("pmb_attributes", Name "attributes")
-              ; ("pmb_loc", Location) ])) )
+        (Record
+           [ ("pmb_name", Loc String)
+           ; ("pmb_expr", Name "module_expr")
+           ; ("pmb_attributes", Name "attributes")
+           ; ("pmb_loc", Location) ]) )
   ; ( "toplevel_phrase"
     , Mono
-        (Versioned
-           (Variant
-              [ ("Ptop_def", Tuple [Name "structure"])
-              ; ("Ptop_dir", Tuple [String; Name "directive_argument"]) ])) )
+        (Variant
+           [ ("Ptop_def", Tuple [Name "structure"])
+           ; ("Ptop_dir", Tuple [String; Name "directive_argument"]) ]) )
   ; ( "directive_argument"
     , Mono
-        (Versioned
-           (Variant
-              [ ("Pdir_none", Empty)
-              ; ("Pdir_string", Tuple [String])
-              ; ("Pdir_int", Tuple [String; Option Char])
-              ; ("Pdir_ident", Tuple [Name "longident"])
-              ; ("Pdir_bool", Tuple [Bool]) ])) ) ]
+        (Variant
+           [ ("Pdir_none", Empty)
+           ; ("Pdir_string", Tuple [String])
+           ; ("Pdir_int", Tuple [String; Option Char])
+           ; ("Pdir_ident", Tuple [Name "longident"])
+           ; ("Pdir_bool", Tuple [Bool]) ]) ) ]

--- a/astlib/unstable_for_testing.ml
+++ b/astlib/unstable_for_testing.ml
@@ -33,16 +33,11 @@ let update_variant variant =
   List.rev_map variant ~f:(fun (name, clause) ->
     name, update_clause clause)
 
-let update_versioned versioned : Grammar.versioned =
-  match (versioned : Grammar.versioned) with
+let update_decl decl : Grammar.decl =
+  match (decl : Grammar.decl) with
   | Wrapper ty -> Wrapper (update_ty ty)
   | Record record -> Record (update_record record)
   | Variant variant -> Variant (update_variant variant)
-
-let update_decl decl : Grammar.decl =
-  match (decl : Grammar.decl) with
-  | Unversioned ty -> Unversioned (update_ty ty)
-  | Versioned versioned -> Versioned (update_versioned versioned)
 
 let update_kind kind : Grammar.kind =
   match (kind : Grammar.kind) with

--- a/metaquot/expander/ppx_metaquot_expander.ml
+++ b/metaquot/expander/ppx_metaquot_expander.ml
@@ -183,8 +183,7 @@ module Expr (Driver : Driver) = struct
     Expression.create
       ~pexp_loc:loc
       ~pexp_attributes:(Attributes.create [])
-      ~pexp_desc:(Expression_desc.pexp_ident
-                    (Astlib.Loc.create ~loc ~txt:(Longident.lident "loc") ()))
+      ~pexp_desc:(Expression_desc.pexp_ident (Located.lident ~loc "loc"))
   let attributes = None
   class std_lifters loc = object (self)
     inherit Ppx_metaquot_lifters.expression_lifters loc

--- a/metaquot_lifters/ppx_metaquot_lifters.ml
+++ b/metaquot_lifters/ppx_metaquot_lifters.ml
@@ -35,7 +35,7 @@ class expression_lifters loc =
       | None ->
         pexp_record ~loc
           (List.map flds ~f:(fun (lab, e) ->
-             (Astlib.Loc.create ~loc ~txt:(Longident.lident (Ml.id lab)) ()), e))
+             (Located.lident ~loc (Ml.id lab)), e))
           None
     method constr typ id args =
       match typ with
@@ -47,7 +47,7 @@ class expression_lifters loc =
                (List.map args ~f:(fun e -> Arg_label.nolabel, e))
       | None ->
         pexp_construct ~loc
-          (Astlib.Loc.create ~loc ~txt:(Longident.lident (Ml.tag id)) ())
+          (Located.lident ~loc (Ml.tag id))
           (match args with
            | [] -> None
            | l  -> Some (etuple ~loc l))

--- a/ppx_view/lib/deconstructor.ml
+++ b/ppx_view/lib/deconstructor.ml
@@ -16,9 +16,12 @@ let pattern ~loc pat =
     | None -> Error.conversion_failed ~loc "pattern_desc"
     | Some desc -> (ppat_loc, desc)
 
-let longident_loc longident_loc =
-  let loc = Astlib.Loc.loc longident_loc in
-  let longident = Astlib.Loc.txt longident_loc in
-  match Longident.to_concrete longident with
-  | None -> Error.conversion_failed ~loc "longident"
-  | Some longident -> (loc, longident)
+let longident_loc ~loc longident_loc =
+  match Longident_loc.to_concrete longident_loc with
+  | None -> Error.conversion_failed ~loc "longident_loc"
+  | Some longident_loc ->
+    let loc = Astlib.Loc.loc longident_loc in
+    let longident = Astlib.Loc.txt longident_loc in
+    match Longident.to_concrete longident with
+    | None -> Error.conversion_failed ~loc "longident"
+    | Some longident -> (loc, longident)

--- a/ppx_view/lib/deconstructor.mli
+++ b/ppx_view/lib/deconstructor.mli
@@ -16,5 +16,6 @@ val pattern :
   Astlib.Location.t * Pattern_desc.concrete
 
 val longident_loc :
+  loc:Astlib.Location.t ->
   Longident_loc.t ->
   Astlib.Location.t * Longident.concrete

--- a/ppx_view/test/test.ml
+++ b/ppx_view/test/test.ml
@@ -108,7 +108,7 @@ let%expect_test "match with alias" =
 
 let%expect_test "match with record" =
   let match_ident = function%view
-    | Pexp_ident { txt = Lident id; _} -> print_string id
+    | Pexp_ident (Longident_loc { txt = Lident id; _}) -> print_string id
     | _ -> print_string "KO"
   in
   begin

--- a/traverse/ppx_traverse.ml
+++ b/traverse/ppx_traverse.ml
@@ -326,7 +326,7 @@ let rec type_expr_mapper ~(what:what) te =
       let mappers = map_variables ~what vars tes in
       what#abstract ~loc deconstruct (what#combine ~loc mappers ~reconstruct)
     | Ptyp_constr (Longident_loc path, params) ->
-      let f lident = Label.create (method_name lident) in
+      let f lident = method_name lident in
       let map = pexp_send ~loc (evar ~loc "self") (Loc.map path ~f) in
       (match params with
        | [] -> map
@@ -495,7 +495,7 @@ let lift_virtual_methods ~loc methods =
 
     method! expression x acc =
       match%view x with
-      | Pexp_send (_, ({ txt = Label ("tuple"|"record"|"constr"|"other" as s); loc = _; })) ->
+      | Pexp_send (_, ({ txt = ("tuple"|"record"|"constr"|"other" as s); loc = _; })) ->
         String.Set.add acc s
       | _ -> super#expression x acc
   end in
@@ -519,7 +519,7 @@ let lift_virtual_methods ~loc methods =
   in
   List.filter all_virtual_methods ~f:(fun m ->
     match%view m with
-    | Pcf_method ({txt = Label s; _}, _, _) -> String.Set.mem used s
+    | Pcf_method ({txt = s; _}, _, _) -> String.Set.mem used s
     | _ -> false)
 
 let map_lident id ~f =
@@ -549,7 +549,7 @@ let gen_class ~(what:what) ~loc tds =
     List.map (type_deps tds) ~f:(fun (id, arity) ->
       let id = Loc.create ~txt:(lident_last_exn id) ~loc () in
       pcf_method ~loc
-        (Loc.map id ~f:Label.create,
+        (id,
          Private_flag.public,
          Class_field_kind.cfk_virtual
            (mapper_type ~what ~loc id
@@ -568,7 +568,7 @@ let gen_class ~(what:what) ~loc tds =
         in
         let mapper = constrained_mapper ~what ~is_gadt mapper td in
         pcf_method ~loc
-          (Loc.map ptype_name ~f:Label.create,
+          (ptype_name,
            Private_flag.public,
            Class_field_kind.cfk_concrete Override_flag.fresh mapper))
   in


### PR DESCRIPTION
This removes `Unversioned` for grammar definitions. All nodes now need to be versioned. To balance this, it also adds view functions in `Ppx_ast.Viewer` to let one unwrap those and match over the concrete value.

For example, `Longident_loc.t` being abstract again, one can't write:
```ocaml
match%view expr_desc with
| Pexp_ident {txt = Lident s; _} -> ...
```
but they can use the `Longident_loc` constructor to unwrap the abstract value and pattern-match over the concrete underlying `Loc.t`:
```ocaml
match%view expr_desc with
| Pexp_ident (Longident_loc {txt = Lident s; _}) -> ...
```