### PR TITLE
Enforce polymorphic types are only instantiated with nodes

### DIFF
--- a/ast/cinaps/gen_conversion.ml
+++ b/ast/cinaps/gen_conversion.ml
@@ -28,6 +28,11 @@ let type_name name ~view =
   | `parsetree ->
     Printf.sprintf "Compiler_types.%s" (Ml.id name)
 
+let string_of_targ ~view targ =
+  match (targ : Astlib.Grammar.targ) with
+  | Tname name -> type_name name ~view
+  | Tvar var -> Ml.tvar var
+
 let rec string_of_ty ty ~view =
   match (ty : Astlib.Grammar.ty) with
   | Var var -> Ml.tvar var
@@ -58,7 +63,7 @@ let rec string_of_ty ty ~view =
     in
     Ml.poly_inst
       (type_name poly ~view)
-      ~args:(List.map args ~f:(string_of_ty ~view:arg_view))
+      ~args:(List.map args ~f:(string_of_targ ~view:arg_view))
 
 and string_of_tuple tuple ~view =
   Printf.sprintf "(%s)"

--- a/ast/cinaps/gen_traverse.ml
+++ b/ast/cinaps/gen_traverse.ml
@@ -1,6 +1,6 @@
 open Stdppx
 
-let string_of_ty ty = Grammar.string_of_ty ~internal:false ty
+let string_of_targ targ = Grammar.string_of_targ ~internal:false targ
 
 let parens x = Printf.sprintf "(%s)" x
 
@@ -82,7 +82,7 @@ type deconstructed =
     in an [of_concrete] call in the [Ast_type _] case.
     Other traversal classes can ignore the context. *)
 type value_kind =
-  | Ast_type of {node_name : string; targs : Astlib.Grammar.ty list}
+  | Ast_type of {node_name : string; targs : Astlib.Grammar.targ list}
   | Abstract
 
 (** The type used to describe the various traversal classes and how to generate
@@ -117,7 +117,7 @@ type type_ = Concrete | T
 let node_type ~type_ ~args node_name =
   let type_name = match type_ with T -> "t" | Concrete -> "concrete" in
   let node_type = Printf.sprintf "%s.%s" (Ml.module_name node_name) type_name in
-  let args = List.map args ~f:string_of_ty in
+  let args = List.map args ~f:string_of_targ in
   Ml.poly_inst node_type ~args
 
 let fun_arg type_name = Ml.id (Printf.sprintf "f%s" type_name)

--- a/ast/cinaps/gen_viewer.ml
+++ b/ast/cinaps/gen_viewer.ml
@@ -227,11 +227,7 @@ module Signature : VIEWER_PRINTER = struct
       | None -> substituted_ty
       | Some (poly_env, ty) -> aux ~poly_env ty
     in
-    let poly_env =
-      Poly_env.create
-        ~vars:targs
-        ~args:(List.map targs ~f:(fun s -> Astlib.Grammar.Var s))
-    in
+    let poly_env = Poly_env.uninstantiated targs in
     aux ~poly_env ty
 
   let print_wrapper_viewer ~wrapper_types ~targs ~name ty =

--- a/ast/cinaps/grammar.ml
+++ b/ast/cinaps/grammar.ml
@@ -1,24 +1,38 @@
 open Stdppx
 
-let rec string_of_ty ~internal ty =
+let string_of_name ~internal name =
+  if internal then Ml.id name else Ml.module_name name ^ ".t"
+
+let string_of_var ~nodify var =
+  if nodify then
+    Ml.poly_inst "node" ~args:[Ml.tvar var]
+  else
+    Ml.tvar var
+
+let string_of_targ ?(nodify=false) ~internal targ =
+  match (targ : Astlib.Grammar.targ) with
+  | Tname name -> string_of_name ~internal name
+  | Tvar var -> string_of_var ~nodify var
+
+let rec string_of_ty ?(nodify=false) ~internal ty =
   match (ty : Astlib.Grammar.ty) with
-  | Var var -> Ml.tvar var
-  | Name name -> if internal then Ml.id name else Ml.module_name name ^ ".t"
+  | Var var -> string_of_var ~nodify var
+  | Name name -> string_of_name ~internal name
   | Bool -> "bool"
   | Char -> "char"
   | Int -> "int"
   | String -> "string"
   | Location -> "Astlib.Location.t"
-  | Loc ty -> string_of_ty ~internal ty ^ " Astlib.Loc.t"
-  | List ty -> string_of_ty ~internal ty ^ " list"
-  | Option ty -> string_of_ty ~internal ty ^ " option"
-  | Tuple tuple -> string_of_tuple_type ~internal tuple
+  | Loc ty -> string_of_ty ~nodify ~internal ty ^ " Astlib.Loc.t"
+  | List ty -> string_of_ty ~nodify ~internal ty ^ " list"
+  | Option ty -> string_of_ty ~nodify ~internal ty ^ " option"
+  | Tuple tuple -> string_of_tuple_type ~nodify ~internal tuple
   | Instance (poly, args) ->
     let name = if poly = "node" || internal then poly else poly ^ ".t" in
-    Ml.poly_inst name ~args:(List.map args ~f:(string_of_ty ~internal))
+    Ml.poly_inst name ~args:(List.map args ~f:(string_of_targ ~nodify ~internal))
 
-and string_of_tuple_type ~internal ?(parens = true) tuple =
+and string_of_tuple_type ?nodify ~internal ?(parens = true) tuple =
   Printf.sprintf "%s%s%s"
     (if parens then "(" else "")
-    (Ml.tuple_type (List.map tuple ~f:(string_of_ty ~internal)))
+    (Ml.tuple_type (List.map tuple ~f:(string_of_ty ?nodify ~internal)))
     (if parens then ")" else "")

--- a/ast/cinaps/grammar.mli
+++ b/ast/cinaps/grammar.mli
@@ -1,5 +1,18 @@
-val string_of_ty : internal: bool -> Astlib.Grammar.ty -> string
+(** Helper functions to print [Astlib.Grammar] values as the OCaml types they
+    represent.
+
+    The [nodify] optional argument is used to replace type variables by
+    instances of the [node] type, e.g. it will replace any ['a] by ['a node]
+    when printing the type. This is used to enforce that some functions in
+    [Versions] only accept polymorphic types instantiated with other AST
+    types. *)
+
+val string_of_targ : ?nodify: bool -> internal: bool -> Astlib.Grammar.targ -> string
+
+val string_of_ty : ?nodify: bool -> internal: bool -> Astlib.Grammar.ty -> string
+
 val string_of_tuple_type :
+  ?nodify: bool ->
   internal: bool ->
   ?parens: bool ->
   Astlib.Grammar.ty list ->

--- a/ast/cinaps/name.ml
+++ b/ast/cinaps/name.ml
@@ -1,21 +1,9 @@
 open StdLabels
 
-let rec add_ty_suffix ty acc =
-  match (ty : Astlib.Grammar.ty) with
-  | Var var -> var :: acc
-  | Name name -> name :: acc
-  | Instance (poly, args) -> add_tuple_suffix args (poly :: acc)
-  | Bool -> "bool" :: acc
-  | Char -> "char" :: acc
-  | Int -> "int" :: acc
-  | String -> "string" :: acc
-  | Location -> "location" :: acc
-  | Loc ty -> add_ty_suffix ty ("loc" :: acc)
-  | List ty -> add_ty_suffix ty ("list" :: acc)
-  | Option ty -> add_ty_suffix ty ("option" :: acc)
-  | Tuple tuple -> add_tuple_suffix tuple acc
-
-and add_tuple_suffix tuple acc = List.fold_right tuple ~init:acc ~f:add_ty_suffix
+let name_of_targ targ =
+  match (targ : Astlib.Grammar.targ) with
+  | Tname name -> name
+  | Tvar var -> var
 
 let builtins =
   [ "and"; "as"; "assert"; "asr"; "begin"; "class"; "constraint"; "do"; "done"; "downto"
@@ -31,8 +19,8 @@ let fix_builtin name =
   then name ^ "_"
   else name
 
-let make prefix tys =
+let make prefix targs =
   fix_builtin
     (String.concat ~sep:"_"
        (List.map ~f:Ml.id
-          (prefix @ add_tuple_suffix tys [])))
+          (prefix @ List.map targs ~f:name_of_targ)))

--- a/ast/cinaps/name.mli
+++ b/ast/cinaps/name.mli
@@ -1,1 +1,1 @@
-val make : string list -> Astlib.Grammar.ty list -> string
+val make : string list -> Astlib.Grammar.targ list -> string

--- a/ast/cinaps/poly_env.mli
+++ b/ast/cinaps/poly_env.mli
@@ -4,15 +4,14 @@ type env_table
 val env_table : Astlib.Grammar.t -> env_table
 val find : env_table -> string -> env list
 
-val create : vars:string list -> args:Astlib.Grammar.ty list -> env
+val create : vars:string list -> args:Astlib.Grammar.targ list -> env
+
+val uninstantiated : string list -> env
 
 val empty_env : env
 val env_is_empty : env -> bool
 
-val args : env -> Astlib.Grammar.ty list
-
-(** Substitute ['a] for ['a node] *)
-val nodify_targs : string list -> env
+val args : env -> Astlib.Grammar.targ list
 
 val subst_ty : Astlib.Grammar.ty -> env:env -> Astlib.Grammar.ty
 val subst_decl : Astlib.Grammar.decl -> env:env -> Astlib.Grammar.decl

--- a/astlib/grammar.ml
+++ b/astlib/grammar.ml
@@ -10,7 +10,7 @@
 
     [Name "expression"] represents the type [expression].
 
-    [Instance ("class_infos", [Name "class_expr"])] represents the type
+    [Instance ("class_infos", [Tname "class_expr"])] represents the type
     [class_expr class_infos]. *)
 type ty =
   | Var of string
@@ -24,9 +24,13 @@ type ty =
   | List of ty
   | Option of ty
   | Tuple of tuple
-  | Instance of string * ty list
+  | Instance of string * targ list
 
 and tuple = ty list
+
+and targ =
+  | Tname of string
+  | Tvar of string
 
 (** Represents named fields of a record. *)
 type record = (string * ty) list

--- a/astlib/latest_version.ml
+++ b/astlib/latest_version.ml
@@ -381,9 +381,9 @@ let grammar : Grammar.t =
                ; ("pci_loc", Location)
                ; ("pci_attributes", Name "attributes") ]) ) )
   ; ( "class_description"
-    , Mono (Wrapper (Instance ("class_infos", [Name "class_type"]))) )
+    , Mono (Wrapper (Instance ("class_infos", [Tname "class_type"]))) )
   ; ( "class_type_declaration"
-    , Mono (Wrapper (Instance ("class_infos", [Name "class_type"]))) )
+    , Mono (Wrapper (Instance ("class_infos", [Tname "class_type"]))) )
   ; ( "class_expr"
     , Mono
         (Record
@@ -461,7 +461,7 @@ let grammar : Grammar.t =
               ; ( "Cfk_concrete"
                 , Tuple [Name "override_flag"; Name "expression"] ) ]) )
   ; ( "class_declaration"
-    , Mono (Wrapper (Instance ("class_infos", [Name "class_expr"]))) )
+    , Mono (Wrapper (Instance ("class_infos", [Tname "class_expr"]))) )
   ; ( "module_type"
     , Mono
         (Record
@@ -537,9 +537,9 @@ let grammar : Grammar.t =
              ; ("pincl_loc", Location)
              ; ("pincl_attributes", Name "attributes") ]) ) )
   ; ( "include_description"
-    , Mono (Wrapper (Instance ("include_infos", [Name "module_type"]))) )
+    , Mono (Wrapper (Instance ("include_infos", [Tname "module_type"]))) )
   ; ( "include_declaration"
-    , Mono (Wrapper (Instance ("include_infos", [Name "module_expr"]))) )
+    , Mono (Wrapper (Instance ("include_infos", [Tname "module_expr"]))) )
   ; ( "with_constraint"
     , Mono
         (Variant

--- a/astlib/unstable_for_testing.ml
+++ b/astlib/unstable_for_testing.ml
@@ -14,7 +14,7 @@ let rec update_ty ty : Grammar.ty =
   | List ty -> List (update_ty ty)
   | Option ty -> Option (update_ty ty)
   | Tuple tuple -> Tuple (update_tuple tuple)
-  | Instance (name, tuple) -> Instance (name, update_tuple tuple)
+  | Instance _ -> ty
 
 and update_tuple tuple =
   List.rev_map tuple ~f:update_ty


### PR DESCRIPTION
Depends on #68 so I'm marking as WIP until it's merged!

This modifies `Grammar` so that polymorphic types from a grammar can only be instantiated by another named type it declares.

