### PR TITLE
Use compiler's error type as Astlib's error type.

### DIFF
--- a/ast/builder_common.ml
+++ b/ast/builder_common.ml
@@ -111,10 +111,19 @@ let plist ~loc exprs =
 module Error_ext = struct
   open Versions
 
+  let extension_of_error error =
+    let loc = Astlib.Location.Error.location error in
+    let message = Format.asprintf "%a" Astlib.Location.Error.report error in
+    Extension.create
+      (Astlib.Loc.create ~loc ~txt:"ocaml.error" (),
+       Payload.pstr
+         (Structure.create
+            [pstr_eval ~loc (estring ~loc message) (Attributes.create [])]))
+
   let extension ~loc msg =
     let pp fmt = Format.pp_print_string fmt msg in
     let error = Astlib.Location.Error.make ~loc pp in
-    Conversion.ast_of_extension (Astlib.Location.Error.to_extension error)
+    extension_of_error error
 
   let build_ext : 'node 'a .
     (loc: Astlib.Location.t -> extension -> 'node) ->

--- a/ast/builder_common.mli
+++ b/ast/builder_common.mli
@@ -49,6 +49,8 @@ module Error_ext : sig
       the required context, [exprf] for [expression], [patf] for [pattern],
       etc. *)
 
+  val extension_of_error : Astlib.Location.Error.t -> Versions.extension
+
   val exprf :
     loc:Astlib.Location.t ->
     ('a, unit, string, Versions.expression) format4 ->

--- a/astlib/location.ml
+++ b/astlib/location.ml
@@ -41,4 +41,6 @@ module Error = struct
     | None -> None
     | Some `Already_displayed -> None
     | Some (`Ok t) -> Some t
+
+  exception Error = Ocaml_common.Location.Error
 end

--- a/astlib/location.mli
+++ b/astlib/location.mli
@@ -41,11 +41,21 @@ val update
 
 val none : t
 
+(** {1 Errors} *)
+
 type location = t
 
 module Error : sig
   (** The type for located errors *)
   type t
+
+  (** {2 Conversions} It should always be possible to convert to/from
+      [Ocaml_common.Location.error]. *)
+
+  val of_error : Ocaml_common.Location.error -> t
+  val to_error : t -> Ocaml_common.Location.error
+
+  (** {2 Constructors} *)
 
   (** [make ~loc pp_msg] returns the error located at [loc] with the message
       formatted by [pp_msg] *)
@@ -54,10 +64,16 @@ module Error : sig
     (Format.formatter -> unit) ->
     t
 
-  (** Report the error on the given formatter *)
+  (** {2 Accessors} *)
+
+  val location : t -> location
   val report : Format.formatter -> t -> unit
 
-  (** Convert the given error to a [[%ocaml.error ...]] extension point so that
-      it can later be reported by the compiler just as [report] would. *)
-  val to_extension : t -> Parsetree.extension
+  (** {2 Exceptions} *)
+
+  (** Add a conversion for a new exception constructor. *)
+  val register_of_exn : (exn -> t option) -> unit
+
+  (** Extract a [t] from an exception using registered conversions. *)
+  val of_exn : exn -> t option
 end

--- a/astlib/location.mli
+++ b/astlib/location.mli
@@ -69,11 +69,16 @@ module Error : sig
   val location : t -> location
   val report : Format.formatter -> t -> unit
 
-  (** {2 Exceptions} *)
+  (** {2 Exceptions}
+
+      TODO: we probably want to cut the entire exceptions section before upstreaming. *)
 
   (** Add a conversion for a new exception constructor. *)
   val register_of_exn : (exn -> t option) -> unit
 
   (** Extract a [t] from an exception using registered conversions. *)
   val of_exn : exn -> t option
+
+  (** Used to raise/catch [t] as an exception. *)
+  exception Error of t
 end


### PR DESCRIPTION
Convert's Astlib's `Location.Error` representation. This lets us better piggyback on the compiler's internal error reporting functions.

Exported exn conversion functionality, this will help us adapt existing code to the error type. If we want to move away from exceptions, we can remove this functionality before upstreaming; I think for now it is helpful to make it easy to transition code.

Also moved `to_extension` functionality into Builder library, so we only construct error extensions using the new AST rather than Parsetree.