### PR TITLE
Make location types transparent.

### DIFF
--- a/ast/builder_common.ml
+++ b/ast/builder_common.ml
@@ -3,7 +3,7 @@ open Versions.V4_07
 open Builder_v4_07
 
 module Located = struct
-  let longident ~loc longident = Longident_loc.create (Astlib.Loc.create ~loc ~txt:longident ())
+  let longident ~loc longident = Longident_loc.create { loc; txt = longident }
   let lident ~loc x = longident ~loc (Longident.lident x)
 
   let dotted ~loc list =
@@ -91,7 +91,7 @@ let pbool ~loc x = ppat_construct ~loc (Located.lident ~loc (Bool.to_string x)) 
 
 let pnil ~loc = ppat_construct ~loc (Located.lident ~loc "[]") None
 
-let pvar ~loc x = ppat_var ~loc (Astlib.Loc.create ~loc ~txt:x ())
+let pvar ~loc x = ppat_var ~loc { loc; txt = x }
 
 let ptuple ~loc list =
   match list with
@@ -115,7 +115,7 @@ module Error_ext = struct
     let loc = Astlib.Location.Error.location error in
     let message = Format.asprintf "%a" Astlib.Location.Error.report error in
     Extension.create
-      (Astlib.Loc.create ~loc ~txt:"ocaml.error" (),
+      ({ loc; txt = "ocaml.error" },
        Payload.pstr
          (Structure.create
             [pstr_eval ~loc (estring ~loc message) (Attributes.create [])]))

--- a/ast/cinaps/gen_conversion.ml
+++ b/ast/cinaps/gen_conversion.ml
@@ -95,29 +95,10 @@ let rec ty_conversion ty ~conv =
   | Var var -> Some (Ml.id (conversion_prefix ~conv ^ "_" ^ var))
   | Name name -> Some (Ml.id (conversion_prefix ~conv ^ "_" ^ name))
   | Bool | Char | Int | String -> None
-  | Location ->
-    (match conv with
-     | `concrete_of -> Some "Astlib.Location.of_location"
-     | `concrete_to -> Some "Astlib.Location.to_location")
+  | Location -> None
   | Loc ty ->
-    let conv_string =
-      let loc_conv =
-        match conv with
-        | `concrete_of -> "Astlib.Loc.of_loc"
-        | `concrete_to -> "Astlib.Loc.to_loc"
-      in
-      let loc_map =
-        Option.map (ty_conversion ty ~conv) ~f:(fun ty_conv ->
-          Printf.sprintf "(Astlib.Loc.map ~f:%s)" ty_conv)
-      in
-      match loc_map with
-      | None -> loc_conv
-      | Some loc_map ->
-        (match conv with
-         | `concrete_of -> Printf.sprintf "(Fn.compose %s %s)" loc_map loc_conv
-         | `concrete_to -> Printf.sprintf "(Fn.compose %s %s)" loc_conv loc_map)
-    in
-    Some conv_string
+    Option.map (ty_conversion ty ~conv) ~f:(fun ty_conv ->
+      Printf.sprintf "(Astlib.Loc.map ~f:%s)" ty_conv)
   | List ty ->
     Option.map (ty_conversion ty ~conv)
       ~f:(Printf.sprintf "(List.map ~f:%s)")

--- a/ast/conversion.ml
+++ b/ast/conversion.ml
@@ -41,7 +41,7 @@ and ast_of_longident_loc x =
   Versions.V4_07.Longident_loc.of_concrete (concrete_of_longident_loc x)
 
 and concrete_of_longident_loc x =
-  (Fn.compose (Astlib.Loc.map ~f:ast_of_longident) Astlib.Loc.of_loc) x
+  (Astlib.Loc.map ~f:ast_of_longident) x
 
 and ast_to_longident_loc x =
   let option = Versions.V4_07.Longident_loc.to_concrete x in
@@ -53,7 +53,7 @@ and ast_to_longident_loc x =
   concrete_to_longident_loc concrete
 
 and concrete_to_longident_loc x =
-  (Fn.compose Astlib.Loc.to_loc (Astlib.Loc.map ~f:ast_to_longident)) x
+  (Astlib.Loc.map ~f:ast_to_longident) x
 
 and ast_of_rec_flag x =
   Versions.V4_07.Rec_flag.of_concrete (concrete_of_rec_flag x)
@@ -299,7 +299,7 @@ and ast_of_attribute x =
   Versions.V4_07.Attribute.of_concrete (concrete_of_attribute x)
 
 and concrete_of_attribute x =
-  (Tuple.map2 ~f1:Astlib.Loc.of_loc ~f2:ast_of_payload) x
+  (Tuple.map2 ~f1:Fn.id ~f2:ast_of_payload) x
 
 and ast_to_attribute x =
   let option = Versions.V4_07.Attribute.to_concrete x in
@@ -311,13 +311,13 @@ and ast_to_attribute x =
   concrete_to_attribute concrete
 
 and concrete_to_attribute x =
-  (Tuple.map2 ~f1:Astlib.Loc.to_loc ~f2:ast_to_payload) x
+  (Tuple.map2 ~f1:Fn.id ~f2:ast_to_payload) x
 
 and ast_of_extension x =
   Versions.V4_07.Extension.of_concrete (concrete_of_extension x)
 
 and concrete_of_extension x =
-  (Tuple.map2 ~f1:Astlib.Loc.of_loc ~f2:ast_of_payload) x
+  (Tuple.map2 ~f1:Fn.id ~f2:ast_of_payload) x
 
 and ast_to_extension x =
   let option = Versions.V4_07.Extension.to_concrete x in
@@ -329,7 +329,7 @@ and ast_to_extension x =
   concrete_to_extension concrete
 
 and concrete_to_extension x =
-  (Tuple.map2 ~f1:Astlib.Loc.to_loc ~f2:ast_to_payload) x
+  (Tuple.map2 ~f1:Fn.id ~f2:ast_to_payload) x
 
 and ast_of_attributes x =
   Versions.V4_07.Attributes.of_concrete (concrete_of_attributes x)
@@ -400,7 +400,6 @@ and concrete_of_core_type
   ({ ptyp_desc; ptyp_loc; ptyp_attributes } : Compiler_types.core_type)
 =
   let ptyp_desc = ast_of_core_type_desc ptyp_desc in
-  let ptyp_loc = Astlib.Location.of_location ptyp_loc in
   let ptyp_attributes = ast_of_attributes ptyp_attributes in
   ({ ptyp_desc; ptyp_loc; ptyp_attributes } : Versions.V4_07.Core_type.concrete)
 
@@ -417,7 +416,6 @@ and concrete_to_core_type
   ({ ptyp_desc; ptyp_loc; ptyp_attributes } : Versions.V4_07.Core_type.concrete)
 =
   let ptyp_desc = ast_to_core_type_desc ptyp_desc in
-  let ptyp_loc = Astlib.Location.to_location ptyp_loc in
   let ptyp_attributes = ast_to_attributes ptyp_attributes in
   ({ ptyp_desc; ptyp_loc; ptyp_attributes } : Compiler_types.core_type)
 
@@ -457,7 +455,6 @@ and concrete_of_core_type_desc x : Versions.V4_07.Core_type_desc.concrete =
     let x2 = ast_of_closed_flag x2 in
     Ptyp_variant (x1, x2, x3)
   | Ptyp_poly (x1, x2) ->
-    let x1 = (List.map ~f:Astlib.Loc.of_loc) x1 in
     let x2 = ast_of_core_type x2 in
     Ptyp_poly (x1, x2)
   | Ptyp_package (x1) ->
@@ -509,7 +506,6 @@ and concrete_to_core_type_desc x : Compiler_types.core_type_desc =
     let x2 = ast_to_closed_flag x2 in
     Ptyp_variant (x1, x2, x3)
   | Ptyp_poly (x1, x2) ->
-    let x1 = (List.map ~f:Astlib.Loc.to_loc) x1 in
     let x2 = ast_to_core_type x2 in
     Ptyp_poly (x1, x2)
   | Ptyp_package (x1) ->
@@ -543,7 +539,6 @@ and ast_of_row_field x =
 and concrete_of_row_field x : Versions.V4_07.Row_field.concrete =
   match (x : Compiler_types.row_field) with
   | Rtag (x1, x2, x3, x4) ->
-    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = ast_of_attributes x2 in
     let x4 = (List.map ~f:ast_of_core_type) x4 in
     Rtag (x1, x2, x3, x4)
@@ -563,7 +558,6 @@ and ast_to_row_field x =
 and concrete_to_row_field x : Compiler_types.row_field =
   match (x : Versions.V4_07.Row_field.concrete) with
   | Rtag (x1, x2, x3, x4) ->
-    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = ast_to_attributes x2 in
     let x4 = (List.map ~f:ast_to_core_type) x4 in
     Rtag (x1, x2, x3, x4)
@@ -577,7 +571,6 @@ and ast_of_object_field x =
 and concrete_of_object_field x : Versions.V4_07.Object_field.concrete =
   match (x : Compiler_types.object_field) with
   | Otag (x1, x2, x3) ->
-    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = ast_of_attributes x2 in
     let x3 = ast_of_core_type x3 in
     Otag (x1, x2, x3)
@@ -597,7 +590,6 @@ and ast_to_object_field x =
 and concrete_to_object_field x : Compiler_types.object_field =
   match (x : Versions.V4_07.Object_field.concrete) with
   | Otag (x1, x2, x3) ->
-    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = ast_to_attributes x2 in
     let x3 = ast_to_core_type x3 in
     Otag (x1, x2, x3)
@@ -612,7 +604,6 @@ and concrete_of_pattern
   ({ ppat_desc; ppat_loc; ppat_attributes } : Compiler_types.pattern)
 =
   let ppat_desc = ast_of_pattern_desc ppat_desc in
-  let ppat_loc = Astlib.Location.of_location ppat_loc in
   let ppat_attributes = ast_of_attributes ppat_attributes in
   ({ ppat_desc; ppat_loc; ppat_attributes } : Versions.V4_07.Pattern.concrete)
 
@@ -629,7 +620,6 @@ and concrete_to_pattern
   ({ ppat_desc; ppat_loc; ppat_attributes } : Versions.V4_07.Pattern.concrete)
 =
   let ppat_desc = ast_to_pattern_desc ppat_desc in
-  let ppat_loc = Astlib.Location.to_location ppat_loc in
   let ppat_attributes = ast_to_attributes ppat_attributes in
   ({ ppat_desc; ppat_loc; ppat_attributes } : Compiler_types.pattern)
 
@@ -640,11 +630,9 @@ and concrete_of_pattern_desc x : Versions.V4_07.Pattern_desc.concrete =
   match (x : Compiler_types.pattern_desc) with
   | Ppat_any -> Ppat_any
   | Ppat_var (x1) ->
-    let x1 = Astlib.Loc.of_loc x1 in
     Ppat_var (x1)
   | Ppat_alias (x1, x2) ->
     let x1 = ast_of_pattern x1 in
-    let x2 = Astlib.Loc.of_loc x2 in
     Ppat_alias (x1, x2)
   | Ppat_constant (x1) ->
     let x1 = ast_of_constant x1 in
@@ -685,7 +673,6 @@ and concrete_of_pattern_desc x : Versions.V4_07.Pattern_desc.concrete =
     let x1 = ast_of_pattern x1 in
     Ppat_lazy (x1)
   | Ppat_unpack (x1) ->
-    let x1 = Astlib.Loc.of_loc x1 in
     Ppat_unpack (x1)
   | Ppat_exception (x1) ->
     let x1 = ast_of_pattern x1 in
@@ -711,11 +698,9 @@ and concrete_to_pattern_desc x : Compiler_types.pattern_desc =
   match (x : Versions.V4_07.Pattern_desc.concrete) with
   | Ppat_any -> Ppat_any
   | Ppat_var (x1) ->
-    let x1 = Astlib.Loc.to_loc x1 in
     Ppat_var (x1)
   | Ppat_alias (x1, x2) ->
     let x1 = ast_to_pattern x1 in
-    let x2 = Astlib.Loc.to_loc x2 in
     Ppat_alias (x1, x2)
   | Ppat_constant (x1) ->
     let x1 = ast_to_constant x1 in
@@ -756,7 +741,6 @@ and concrete_to_pattern_desc x : Compiler_types.pattern_desc =
     let x1 = ast_to_pattern x1 in
     Ppat_lazy (x1)
   | Ppat_unpack (x1) ->
-    let x1 = Astlib.Loc.to_loc x1 in
     Ppat_unpack (x1)
   | Ppat_exception (x1) ->
     let x1 = ast_to_pattern x1 in
@@ -776,7 +760,6 @@ and concrete_of_expression
   ({ pexp_desc; pexp_loc; pexp_attributes } : Compiler_types.expression)
 =
   let pexp_desc = ast_of_expression_desc pexp_desc in
-  let pexp_loc = Astlib.Location.of_location pexp_loc in
   let pexp_attributes = ast_of_attributes pexp_attributes in
   ({ pexp_desc; pexp_loc; pexp_attributes } : Versions.V4_07.Expression.concrete)
 
@@ -793,7 +776,6 @@ and concrete_to_expression
   ({ pexp_desc; pexp_loc; pexp_attributes } : Versions.V4_07.Expression.concrete)
 =
   let pexp_desc = ast_to_expression_desc pexp_desc in
-  let pexp_loc = Astlib.Location.to_location pexp_loc in
   let pexp_attributes = ast_to_attributes pexp_attributes in
   ({ pexp_desc; pexp_loc; pexp_attributes } : Compiler_types.expression)
 
@@ -891,20 +873,17 @@ and concrete_of_expression_desc x : Versions.V4_07.Expression_desc.concrete =
     Pexp_coerce (x1, x2, x3)
   | Pexp_send (x1, x2) ->
     let x1 = ast_of_expression x1 in
-    let x2 = Astlib.Loc.of_loc x2 in
     Pexp_send (x1, x2)
   | Pexp_new (x1) ->
     let x1 = ast_of_longident_loc x1 in
     Pexp_new (x1)
   | Pexp_setinstvar (x1, x2) ->
-    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = ast_of_expression x2 in
     Pexp_setinstvar (x1, x2)
   | Pexp_override (x1) ->
-    let x1 = (List.map ~f:(Tuple.map2 ~f1:Astlib.Loc.of_loc ~f2:ast_of_expression)) x1 in
+    let x1 = (List.map ~f:(Tuple.map2 ~f1:Fn.id ~f2:ast_of_expression)) x1 in
     Pexp_override (x1)
   | Pexp_letmodule (x1, x2, x3) ->
-    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = ast_of_module_expr x2 in
     let x3 = ast_of_expression x3 in
     Pexp_letmodule (x1, x2, x3)
@@ -926,7 +905,6 @@ and concrete_of_expression_desc x : Versions.V4_07.Expression_desc.concrete =
     let x1 = ast_of_class_structure x1 in
     Pexp_object (x1)
   | Pexp_newtype (x1, x2) ->
-    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = ast_of_expression x2 in
     Pexp_newtype (x1, x2)
   | Pexp_pack (x1) ->
@@ -1042,20 +1020,17 @@ and concrete_to_expression_desc x : Compiler_types.expression_desc =
     Pexp_coerce (x1, x2, x3)
   | Pexp_send (x1, x2) ->
     let x1 = ast_to_expression x1 in
-    let x2 = Astlib.Loc.to_loc x2 in
     Pexp_send (x1, x2)
   | Pexp_new (x1) ->
     let x1 = ast_to_longident_loc x1 in
     Pexp_new (x1)
   | Pexp_setinstvar (x1, x2) ->
-    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = ast_to_expression x2 in
     Pexp_setinstvar (x1, x2)
   | Pexp_override (x1) ->
-    let x1 = (List.map ~f:(Tuple.map2 ~f1:Astlib.Loc.to_loc ~f2:ast_to_expression)) x1 in
+    let x1 = (List.map ~f:(Tuple.map2 ~f1:Fn.id ~f2:ast_to_expression)) x1 in
     Pexp_override (x1)
   | Pexp_letmodule (x1, x2, x3) ->
-    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = ast_to_module_expr x2 in
     let x3 = ast_to_expression x3 in
     Pexp_letmodule (x1, x2, x3)
@@ -1077,7 +1052,6 @@ and concrete_to_expression_desc x : Compiler_types.expression_desc =
     let x1 = ast_to_class_structure x1 in
     Pexp_object (x1)
   | Pexp_newtype (x1, x2) ->
-    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = ast_to_expression x2 in
     Pexp_newtype (x1, x2)
   | Pexp_pack (x1) ->
@@ -1127,10 +1101,8 @@ and ast_of_value_description x =
 and concrete_of_value_description
   ({ pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Compiler_types.value_description)
 =
-  let pval_name = Astlib.Loc.of_loc pval_name in
   let pval_type = ast_of_core_type pval_type in
   let pval_attributes = ast_of_attributes pval_attributes in
-  let pval_loc = Astlib.Location.of_location pval_loc in
   ({ pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Versions.V4_07.Value_description.concrete)
 
 and ast_to_value_description x =
@@ -1145,10 +1117,8 @@ and ast_to_value_description x =
 and concrete_to_value_description
   ({ pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Versions.V4_07.Value_description.concrete)
 =
-  let pval_name = Astlib.Loc.to_loc pval_name in
   let pval_type = ast_to_core_type pval_type in
   let pval_attributes = ast_to_attributes pval_attributes in
-  let pval_loc = Astlib.Location.to_location pval_loc in
   ({ pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Compiler_types.value_description)
 
 and ast_of_type_declaration x =
@@ -1157,14 +1127,12 @@ and ast_of_type_declaration x =
 and concrete_of_type_declaration
   ({ ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Compiler_types.type_declaration)
 =
-  let ptype_name = Astlib.Loc.of_loc ptype_name in
   let ptype_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) ptype_params in
-  let ptype_cstrs = (List.map ~f:(Tuple.map3 ~f1:ast_of_core_type ~f2:ast_of_core_type ~f3:Astlib.Location.of_location)) ptype_cstrs in
+  let ptype_cstrs = (List.map ~f:(Tuple.map3 ~f1:ast_of_core_type ~f2:ast_of_core_type ~f3:Fn.id)) ptype_cstrs in
   let ptype_kind = ast_of_type_kind ptype_kind in
   let ptype_private = ast_of_private_flag ptype_private in
   let ptype_manifest = (Option.map ~f:ast_of_core_type) ptype_manifest in
   let ptype_attributes = ast_of_attributes ptype_attributes in
-  let ptype_loc = Astlib.Location.of_location ptype_loc in
   ({ ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Versions.V4_07.Type_declaration.concrete)
 
 and ast_to_type_declaration x =
@@ -1179,14 +1147,12 @@ and ast_to_type_declaration x =
 and concrete_to_type_declaration
   ({ ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Versions.V4_07.Type_declaration.concrete)
 =
-  let ptype_name = Astlib.Loc.to_loc ptype_name in
   let ptype_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) ptype_params in
-  let ptype_cstrs = (List.map ~f:(Tuple.map3 ~f1:ast_to_core_type ~f2:ast_to_core_type ~f3:Astlib.Location.to_location)) ptype_cstrs in
+  let ptype_cstrs = (List.map ~f:(Tuple.map3 ~f1:ast_to_core_type ~f2:ast_to_core_type ~f3:Fn.id)) ptype_cstrs in
   let ptype_kind = ast_to_type_kind ptype_kind in
   let ptype_private = ast_to_private_flag ptype_private in
   let ptype_manifest = (Option.map ~f:ast_to_core_type) ptype_manifest in
   let ptype_attributes = ast_to_attributes ptype_attributes in
-  let ptype_loc = Astlib.Location.to_location ptype_loc in
   ({ ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Compiler_types.type_declaration)
 
 and ast_of_type_kind x =
@@ -1229,10 +1195,8 @@ and ast_of_label_declaration x =
 and concrete_of_label_declaration
   ({ pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Compiler_types.label_declaration)
 =
-  let pld_name = Astlib.Loc.of_loc pld_name in
   let pld_mutable = ast_of_mutable_flag pld_mutable in
   let pld_type = ast_of_core_type pld_type in
-  let pld_loc = Astlib.Location.of_location pld_loc in
   let pld_attributes = ast_of_attributes pld_attributes in
   ({ pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Versions.V4_07.Label_declaration.concrete)
 
@@ -1248,10 +1212,8 @@ and ast_to_label_declaration x =
 and concrete_to_label_declaration
   ({ pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Versions.V4_07.Label_declaration.concrete)
 =
-  let pld_name = Astlib.Loc.to_loc pld_name in
   let pld_mutable = ast_to_mutable_flag pld_mutable in
   let pld_type = ast_to_core_type pld_type in
-  let pld_loc = Astlib.Location.to_location pld_loc in
   let pld_attributes = ast_to_attributes pld_attributes in
   ({ pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Compiler_types.label_declaration)
 
@@ -1261,10 +1223,8 @@ and ast_of_constructor_declaration x =
 and concrete_of_constructor_declaration
   ({ pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Compiler_types.constructor_declaration)
 =
-  let pcd_name = Astlib.Loc.of_loc pcd_name in
   let pcd_args = ast_of_constructor_arguments pcd_args in
   let pcd_res = (Option.map ~f:ast_of_core_type) pcd_res in
-  let pcd_loc = Astlib.Location.of_location pcd_loc in
   let pcd_attributes = ast_of_attributes pcd_attributes in
   ({ pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Versions.V4_07.Constructor_declaration.concrete)
 
@@ -1280,10 +1240,8 @@ and ast_to_constructor_declaration x =
 and concrete_to_constructor_declaration
   ({ pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Versions.V4_07.Constructor_declaration.concrete)
 =
-  let pcd_name = Astlib.Loc.to_loc pcd_name in
   let pcd_args = ast_to_constructor_arguments pcd_args in
   let pcd_res = (Option.map ~f:ast_to_core_type) pcd_res in
-  let pcd_loc = Astlib.Location.to_location pcd_loc in
   let pcd_attributes = ast_to_attributes pcd_attributes in
   ({ pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Compiler_types.constructor_declaration)
 
@@ -1355,9 +1313,7 @@ and ast_of_extension_constructor x =
 and concrete_of_extension_constructor
   ({ pext_name; pext_kind; pext_loc; pext_attributes } : Compiler_types.extension_constructor)
 =
-  let pext_name = Astlib.Loc.of_loc pext_name in
   let pext_kind = ast_of_extension_constructor_kind pext_kind in
-  let pext_loc = Astlib.Location.of_location pext_loc in
   let pext_attributes = ast_of_attributes pext_attributes in
   ({ pext_name; pext_kind; pext_loc; pext_attributes } : Versions.V4_07.Extension_constructor.concrete)
 
@@ -1373,9 +1329,7 @@ and ast_to_extension_constructor x =
 and concrete_to_extension_constructor
   ({ pext_name; pext_kind; pext_loc; pext_attributes } : Versions.V4_07.Extension_constructor.concrete)
 =
-  let pext_name = Astlib.Loc.to_loc pext_name in
   let pext_kind = ast_to_extension_constructor_kind pext_kind in
-  let pext_loc = Astlib.Location.to_location pext_loc in
   let pext_attributes = ast_to_attributes pext_attributes in
   ({ pext_name; pext_kind; pext_loc; pext_attributes } : Compiler_types.extension_constructor)
 
@@ -1418,7 +1372,6 @@ and concrete_of_class_type
   ({ pcty_desc; pcty_loc; pcty_attributes } : Compiler_types.class_type)
 =
   let pcty_desc = ast_of_class_type_desc pcty_desc in
-  let pcty_loc = Astlib.Location.of_location pcty_loc in
   let pcty_attributes = ast_of_attributes pcty_attributes in
   ({ pcty_desc; pcty_loc; pcty_attributes } : Versions.V4_07.Class_type.concrete)
 
@@ -1435,7 +1388,6 @@ and concrete_to_class_type
   ({ pcty_desc; pcty_loc; pcty_attributes } : Versions.V4_07.Class_type.concrete)
 =
   let pcty_desc = ast_to_class_type_desc pcty_desc in
-  let pcty_loc = Astlib.Location.to_location pcty_loc in
   let pcty_attributes = ast_to_attributes pcty_attributes in
   ({ pcty_desc; pcty_loc; pcty_attributes } : Compiler_types.class_type)
 
@@ -1530,7 +1482,6 @@ and concrete_of_class_type_field
   ({ pctf_desc; pctf_loc; pctf_attributes } : Compiler_types.class_type_field)
 =
   let pctf_desc = ast_of_class_type_field_desc pctf_desc in
-  let pctf_loc = Astlib.Location.of_location pctf_loc in
   let pctf_attributes = ast_of_attributes pctf_attributes in
   ({ pctf_desc; pctf_loc; pctf_attributes } : Versions.V4_07.Class_type_field.concrete)
 
@@ -1547,7 +1498,6 @@ and concrete_to_class_type_field
   ({ pctf_desc; pctf_loc; pctf_attributes } : Versions.V4_07.Class_type_field.concrete)
 =
   let pctf_desc = ast_to_class_type_field_desc pctf_desc in
-  let pctf_loc = Astlib.Location.to_location pctf_loc in
   let pctf_attributes = ast_to_attributes pctf_attributes in
   ({ pctf_desc; pctf_loc; pctf_attributes } : Compiler_types.class_type_field)
 
@@ -1560,10 +1510,10 @@ and concrete_of_class_type_field_desc x : Versions.V4_07.Class_type_field_desc.c
     let x1 = ast_of_class_type x1 in
     Pctf_inherit (x1)
   | Pctf_val (x1) ->
-    let x1 = (Tuple.map4 ~f1:Astlib.Loc.of_loc ~f2:ast_of_mutable_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
+    let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_of_mutable_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
     Pctf_val (x1)
   | Pctf_method (x1) ->
-    let x1 = (Tuple.map4 ~f1:Astlib.Loc.of_loc ~f2:ast_of_private_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
+    let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_of_private_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
     Pctf_method (x1)
   | Pctf_constraint (x1) ->
     let x1 = (Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_core_type) x1 in
@@ -1590,10 +1540,10 @@ and concrete_to_class_type_field_desc x : Compiler_types.class_type_field_desc =
     let x1 = ast_to_class_type x1 in
     Pctf_inherit (x1)
   | Pctf_val (x1) ->
-    let x1 = (Tuple.map4 ~f1:Astlib.Loc.to_loc ~f2:ast_to_mutable_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
+    let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_to_mutable_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
     Pctf_val (x1)
   | Pctf_method (x1) ->
-    let x1 = (Tuple.map4 ~f1:Astlib.Loc.to_loc ~f2:ast_to_private_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
+    let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_to_private_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
     Pctf_method (x1)
   | Pctf_constraint (x1) ->
     let x1 = (Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_core_type) x1 in
@@ -1613,9 +1563,7 @@ and concrete_of_class_infos_class_expr
 =
   let pci_virt = ast_of_virtual_flag pci_virt in
   let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) pci_params in
-  let pci_name = Astlib.Loc.of_loc pci_name in
   let pci_expr = ast_of_class_expr pci_expr in
-  let pci_loc = Astlib.Location.of_location pci_loc in
   let pci_attributes = ast_of_attributes pci_attributes in
   ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Versions.V4_07.Class_expr.t Versions.V4_07.Class_infos.concrete)
 
@@ -1633,9 +1581,7 @@ and concrete_to_class_infos_class_expr
 =
   let pci_virt = ast_to_virtual_flag pci_virt in
   let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) pci_params in
-  let pci_name = Astlib.Loc.to_loc pci_name in
   let pci_expr = ast_to_class_expr pci_expr in
-  let pci_loc = Astlib.Location.to_location pci_loc in
   let pci_attributes = ast_to_attributes pci_attributes in
   ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Compiler_types.class_expr Compiler_types.class_infos)
 
@@ -1647,9 +1593,7 @@ and concrete_of_class_infos_class_type
 =
   let pci_virt = ast_of_virtual_flag pci_virt in
   let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) pci_params in
-  let pci_name = Astlib.Loc.of_loc pci_name in
   let pci_expr = ast_of_class_type pci_expr in
-  let pci_loc = Astlib.Location.of_location pci_loc in
   let pci_attributes = ast_of_attributes pci_attributes in
   ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Versions.V4_07.Class_type.t Versions.V4_07.Class_infos.concrete)
 
@@ -1667,9 +1611,7 @@ and concrete_to_class_infos_class_type
 =
   let pci_virt = ast_to_virtual_flag pci_virt in
   let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) pci_params in
-  let pci_name = Astlib.Loc.to_loc pci_name in
   let pci_expr = ast_to_class_type pci_expr in
-  let pci_loc = Astlib.Location.to_location pci_loc in
   let pci_attributes = ast_to_attributes pci_attributes in
   ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Compiler_types.class_type Compiler_types.class_infos)
 
@@ -1716,7 +1658,6 @@ and concrete_of_class_expr
   ({ pcl_desc; pcl_loc; pcl_attributes } : Compiler_types.class_expr)
 =
   let pcl_desc = ast_of_class_expr_desc pcl_desc in
-  let pcl_loc = Astlib.Location.of_location pcl_loc in
   let pcl_attributes = ast_of_attributes pcl_attributes in
   ({ pcl_desc; pcl_loc; pcl_attributes } : Versions.V4_07.Class_expr.concrete)
 
@@ -1733,7 +1674,6 @@ and concrete_to_class_expr
   ({ pcl_desc; pcl_loc; pcl_attributes } : Versions.V4_07.Class_expr.concrete)
 =
   let pcl_desc = ast_to_class_expr_desc pcl_desc in
-  let pcl_loc = Astlib.Location.to_location pcl_loc in
   let pcl_attributes = ast_to_attributes pcl_attributes in
   ({ pcl_desc; pcl_loc; pcl_attributes } : Compiler_types.class_expr)
 
@@ -1856,7 +1796,6 @@ and concrete_of_class_field
   ({ pcf_desc; pcf_loc; pcf_attributes } : Compiler_types.class_field)
 =
   let pcf_desc = ast_of_class_field_desc pcf_desc in
-  let pcf_loc = Astlib.Location.of_location pcf_loc in
   let pcf_attributes = ast_of_attributes pcf_attributes in
   ({ pcf_desc; pcf_loc; pcf_attributes } : Versions.V4_07.Class_field.concrete)
 
@@ -1873,7 +1812,6 @@ and concrete_to_class_field
   ({ pcf_desc; pcf_loc; pcf_attributes } : Versions.V4_07.Class_field.concrete)
 =
   let pcf_desc = ast_to_class_field_desc pcf_desc in
-  let pcf_loc = Astlib.Location.to_location pcf_loc in
   let pcf_attributes = ast_to_attributes pcf_attributes in
   ({ pcf_desc; pcf_loc; pcf_attributes } : Compiler_types.class_field)
 
@@ -1885,13 +1823,12 @@ and concrete_of_class_field_desc x : Versions.V4_07.Class_field_desc.concrete =
   | Pcf_inherit (x1, x2, x3) ->
     let x1 = ast_of_override_flag x1 in
     let x2 = ast_of_class_expr x2 in
-    let x3 = (Option.map ~f:Astlib.Loc.of_loc) x3 in
     Pcf_inherit (x1, x2, x3)
   | Pcf_val (x1) ->
-    let x1 = (Tuple.map3 ~f1:Astlib.Loc.of_loc ~f2:ast_of_mutable_flag ~f3:ast_of_class_field_kind) x1 in
+    let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_of_mutable_flag ~f3:ast_of_class_field_kind) x1 in
     Pcf_val (x1)
   | Pcf_method (x1) ->
-    let x1 = (Tuple.map3 ~f1:Astlib.Loc.of_loc ~f2:ast_of_private_flag ~f3:ast_of_class_field_kind) x1 in
+    let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_of_private_flag ~f3:ast_of_class_field_kind) x1 in
     Pcf_method (x1)
   | Pcf_constraint (x1) ->
     let x1 = (Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_core_type) x1 in
@@ -1920,13 +1857,12 @@ and concrete_to_class_field_desc x : Compiler_types.class_field_desc =
   | Pcf_inherit (x1, x2, x3) ->
     let x1 = ast_to_override_flag x1 in
     let x2 = ast_to_class_expr x2 in
-    let x3 = (Option.map ~f:Astlib.Loc.to_loc) x3 in
     Pcf_inherit (x1, x2, x3)
   | Pcf_val (x1) ->
-    let x1 = (Tuple.map3 ~f1:Astlib.Loc.to_loc ~f2:ast_to_mutable_flag ~f3:ast_to_class_field_kind) x1 in
+    let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_to_mutable_flag ~f3:ast_to_class_field_kind) x1 in
     Pcf_val (x1)
   | Pcf_method (x1) ->
-    let x1 = (Tuple.map3 ~f1:Astlib.Loc.to_loc ~f2:ast_to_private_flag ~f3:ast_to_class_field_kind) x1 in
+    let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_to_private_flag ~f3:ast_to_class_field_kind) x1 in
     Pcf_method (x1)
   | Pcf_constraint (x1) ->
     let x1 = (Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_core_type) x1 in
@@ -1998,7 +1934,6 @@ and concrete_of_module_type
   ({ pmty_desc; pmty_loc; pmty_attributes } : Compiler_types.module_type)
 =
   let pmty_desc = ast_of_module_type_desc pmty_desc in
-  let pmty_loc = Astlib.Location.of_location pmty_loc in
   let pmty_attributes = ast_of_attributes pmty_attributes in
   ({ pmty_desc; pmty_loc; pmty_attributes } : Versions.V4_07.Module_type.concrete)
 
@@ -2015,7 +1950,6 @@ and concrete_to_module_type
   ({ pmty_desc; pmty_loc; pmty_attributes } : Versions.V4_07.Module_type.concrete)
 =
   let pmty_desc = ast_to_module_type_desc pmty_desc in
-  let pmty_loc = Astlib.Location.to_location pmty_loc in
   let pmty_attributes = ast_to_attributes pmty_attributes in
   ({ pmty_desc; pmty_loc; pmty_attributes } : Compiler_types.module_type)
 
@@ -2031,7 +1965,6 @@ and concrete_of_module_type_desc x : Versions.V4_07.Module_type_desc.concrete =
     let x1 = ast_of_signature x1 in
     Pmty_signature (x1)
   | Pmty_functor (x1, x2, x3) ->
-    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = (Option.map ~f:ast_of_module_type) x2 in
     let x3 = ast_of_module_type x3 in
     Pmty_functor (x1, x2, x3)
@@ -2067,7 +2000,6 @@ and concrete_to_module_type_desc x : Compiler_types.module_type_desc =
     let x1 = ast_to_signature x1 in
     Pmty_signature (x1)
   | Pmty_functor (x1, x2, x3) ->
-    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = (Option.map ~f:ast_to_module_type) x2 in
     let x3 = ast_to_module_type x3 in
     Pmty_functor (x1, x2, x3)
@@ -2110,7 +2042,6 @@ and concrete_of_signature_item
   ({ psig_desc; psig_loc } : Compiler_types.signature_item)
 =
   let psig_desc = ast_of_signature_item_desc psig_desc in
-  let psig_loc = Astlib.Location.of_location psig_loc in
   ({ psig_desc; psig_loc } : Versions.V4_07.Signature_item.concrete)
 
 and ast_to_signature_item x =
@@ -2126,7 +2057,6 @@ and concrete_to_signature_item
   ({ psig_desc; psig_loc } : Versions.V4_07.Signature_item.concrete)
 =
   let psig_desc = ast_to_signature_item_desc psig_desc in
-  let psig_loc = Astlib.Location.to_location psig_loc in
   ({ psig_desc; psig_loc } : Compiler_types.signature_item)
 
 and ast_of_signature_item_desc x =
@@ -2235,10 +2165,8 @@ and ast_of_module_declaration x =
 and concrete_of_module_declaration
   ({ pmd_name; pmd_type; pmd_attributes; pmd_loc } : Compiler_types.module_declaration)
 =
-  let pmd_name = Astlib.Loc.of_loc pmd_name in
   let pmd_type = ast_of_module_type pmd_type in
   let pmd_attributes = ast_of_attributes pmd_attributes in
-  let pmd_loc = Astlib.Location.of_location pmd_loc in
   ({ pmd_name; pmd_type; pmd_attributes; pmd_loc } : Versions.V4_07.Module_declaration.concrete)
 
 and ast_to_module_declaration x =
@@ -2253,10 +2181,8 @@ and ast_to_module_declaration x =
 and concrete_to_module_declaration
   ({ pmd_name; pmd_type; pmd_attributes; pmd_loc } : Versions.V4_07.Module_declaration.concrete)
 =
-  let pmd_name = Astlib.Loc.to_loc pmd_name in
   let pmd_type = ast_to_module_type pmd_type in
   let pmd_attributes = ast_to_attributes pmd_attributes in
-  let pmd_loc = Astlib.Location.to_location pmd_loc in
   ({ pmd_name; pmd_type; pmd_attributes; pmd_loc } : Compiler_types.module_declaration)
 
 and ast_of_module_type_declaration x =
@@ -2265,10 +2191,8 @@ and ast_of_module_type_declaration x =
 and concrete_of_module_type_declaration
   ({ pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Compiler_types.module_type_declaration)
 =
-  let pmtd_name = Astlib.Loc.of_loc pmtd_name in
   let pmtd_type = (Option.map ~f:ast_of_module_type) pmtd_type in
   let pmtd_attributes = ast_of_attributes pmtd_attributes in
-  let pmtd_loc = Astlib.Location.of_location pmtd_loc in
   ({ pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Versions.V4_07.Module_type_declaration.concrete)
 
 and ast_to_module_type_declaration x =
@@ -2283,10 +2207,8 @@ and ast_to_module_type_declaration x =
 and concrete_to_module_type_declaration
   ({ pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Versions.V4_07.Module_type_declaration.concrete)
 =
-  let pmtd_name = Astlib.Loc.to_loc pmtd_name in
   let pmtd_type = (Option.map ~f:ast_to_module_type) pmtd_type in
   let pmtd_attributes = ast_to_attributes pmtd_attributes in
-  let pmtd_loc = Astlib.Location.to_location pmtd_loc in
   ({ pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Compiler_types.module_type_declaration)
 
 and ast_of_open_description x =
@@ -2297,7 +2219,6 @@ and concrete_of_open_description
 =
   let popen_lid = ast_of_longident_loc popen_lid in
   let popen_override = ast_of_override_flag popen_override in
-  let popen_loc = Astlib.Location.of_location popen_loc in
   let popen_attributes = ast_of_attributes popen_attributes in
   ({ popen_lid; popen_override; popen_loc; popen_attributes } : Versions.V4_07.Open_description.concrete)
 
@@ -2315,7 +2236,6 @@ and concrete_to_open_description
 =
   let popen_lid = ast_to_longident_loc popen_lid in
   let popen_override = ast_to_override_flag popen_override in
-  let popen_loc = Astlib.Location.to_location popen_loc in
   let popen_attributes = ast_to_attributes popen_attributes in
   ({ popen_lid; popen_override; popen_loc; popen_attributes } : Compiler_types.open_description)
 
@@ -2326,7 +2246,6 @@ and concrete_of_include_infos_module_expr
   ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_expr Compiler_types.include_infos)
 =
   let pincl_mod = ast_of_module_expr pincl_mod in
-  let pincl_loc = Astlib.Location.of_location pincl_loc in
   let pincl_attributes = ast_of_attributes pincl_attributes in
   ({ pincl_mod; pincl_loc; pincl_attributes } : Versions.V4_07.Module_expr.t Versions.V4_07.Include_infos.concrete)
 
@@ -2343,7 +2262,6 @@ and concrete_to_include_infos_module_expr
   ({ pincl_mod; pincl_loc; pincl_attributes } : Versions.V4_07.Module_expr.t Versions.V4_07.Include_infos.concrete)
 =
   let pincl_mod = ast_to_module_expr pincl_mod in
-  let pincl_loc = Astlib.Location.to_location pincl_loc in
   let pincl_attributes = ast_to_attributes pincl_attributes in
   ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_expr Compiler_types.include_infos)
 
@@ -2354,7 +2272,6 @@ and concrete_of_include_infos_module_type
   ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_type Compiler_types.include_infos)
 =
   let pincl_mod = ast_of_module_type pincl_mod in
-  let pincl_loc = Astlib.Location.of_location pincl_loc in
   let pincl_attributes = ast_of_attributes pincl_attributes in
   ({ pincl_mod; pincl_loc; pincl_attributes } : Versions.V4_07.Module_type.t Versions.V4_07.Include_infos.concrete)
 
@@ -2371,7 +2288,6 @@ and concrete_to_include_infos_module_type
   ({ pincl_mod; pincl_loc; pincl_attributes } : Versions.V4_07.Module_type.t Versions.V4_07.Include_infos.concrete)
 =
   let pincl_mod = ast_to_module_type pincl_mod in
-  let pincl_loc = Astlib.Location.to_location pincl_loc in
   let pincl_attributes = ast_to_attributes pincl_attributes in
   ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_type Compiler_types.include_infos)
 
@@ -2468,7 +2384,6 @@ and concrete_of_module_expr
   ({ pmod_desc; pmod_loc; pmod_attributes } : Compiler_types.module_expr)
 =
   let pmod_desc = ast_of_module_expr_desc pmod_desc in
-  let pmod_loc = Astlib.Location.of_location pmod_loc in
   let pmod_attributes = ast_of_attributes pmod_attributes in
   ({ pmod_desc; pmod_loc; pmod_attributes } : Versions.V4_07.Module_expr.concrete)
 
@@ -2485,7 +2400,6 @@ and concrete_to_module_expr
   ({ pmod_desc; pmod_loc; pmod_attributes } : Versions.V4_07.Module_expr.concrete)
 =
   let pmod_desc = ast_to_module_expr_desc pmod_desc in
-  let pmod_loc = Astlib.Location.to_location pmod_loc in
   let pmod_attributes = ast_to_attributes pmod_attributes in
   ({ pmod_desc; pmod_loc; pmod_attributes } : Compiler_types.module_expr)
 
@@ -2501,7 +2415,6 @@ and concrete_of_module_expr_desc x : Versions.V4_07.Module_expr_desc.concrete =
     let x1 = ast_of_structure x1 in
     Pmod_structure (x1)
   | Pmod_functor (x1, x2, x3) ->
-    let x1 = Astlib.Loc.of_loc x1 in
     let x2 = (Option.map ~f:ast_of_module_type) x2 in
     let x3 = ast_of_module_expr x3 in
     Pmod_functor (x1, x2, x3)
@@ -2538,7 +2451,6 @@ and concrete_to_module_expr_desc x : Compiler_types.module_expr_desc =
     let x1 = ast_to_structure x1 in
     Pmod_structure (x1)
   | Pmod_functor (x1, x2, x3) ->
-    let x1 = Astlib.Loc.to_loc x1 in
     let x2 = (Option.map ~f:ast_to_module_type) x2 in
     let x3 = ast_to_module_expr x3 in
     Pmod_functor (x1, x2, x3)
@@ -2582,7 +2494,6 @@ and concrete_of_structure_item
   ({ pstr_desc; pstr_loc } : Compiler_types.structure_item)
 =
   let pstr_desc = ast_of_structure_item_desc pstr_desc in
-  let pstr_loc = Astlib.Location.of_location pstr_loc in
   ({ pstr_desc; pstr_loc } : Versions.V4_07.Structure_item.concrete)
 
 and ast_to_structure_item x =
@@ -2598,7 +2509,6 @@ and concrete_to_structure_item
   ({ pstr_desc; pstr_loc } : Versions.V4_07.Structure_item.concrete)
 =
   let pstr_desc = ast_to_structure_item_desc pstr_desc in
-  let pstr_loc = Astlib.Location.to_location pstr_loc in
   ({ pstr_desc; pstr_loc } : Compiler_types.structure_item)
 
 and ast_of_structure_item_desc x =
@@ -2726,7 +2636,6 @@ and concrete_of_value_binding
   let pvb_pat = ast_of_pattern pvb_pat in
   let pvb_expr = ast_of_expression pvb_expr in
   let pvb_attributes = ast_of_attributes pvb_attributes in
-  let pvb_loc = Astlib.Location.of_location pvb_loc in
   ({ pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Versions.V4_07.Value_binding.concrete)
 
 and ast_to_value_binding x =
@@ -2744,7 +2653,6 @@ and concrete_to_value_binding
   let pvb_pat = ast_to_pattern pvb_pat in
   let pvb_expr = ast_to_expression pvb_expr in
   let pvb_attributes = ast_to_attributes pvb_attributes in
-  let pvb_loc = Astlib.Location.to_location pvb_loc in
   ({ pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Compiler_types.value_binding)
 
 and ast_of_module_binding x =
@@ -2753,10 +2661,8 @@ and ast_of_module_binding x =
 and concrete_of_module_binding
   ({ pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Compiler_types.module_binding)
 =
-  let pmb_name = Astlib.Loc.of_loc pmb_name in
   let pmb_expr = ast_of_module_expr pmb_expr in
   let pmb_attributes = ast_of_attributes pmb_attributes in
-  let pmb_loc = Astlib.Location.of_location pmb_loc in
   ({ pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Versions.V4_07.Module_binding.concrete)
 
 and ast_to_module_binding x =
@@ -2771,10 +2677,8 @@ and ast_to_module_binding x =
 and concrete_to_module_binding
   ({ pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Versions.V4_07.Module_binding.concrete)
 =
-  let pmb_name = Astlib.Loc.to_loc pmb_name in
   let pmb_expr = ast_to_module_expr pmb_expr in
   let pmb_attributes = ast_to_attributes pmb_attributes in
-  let pmb_loc = Astlib.Location.to_location pmb_loc in
   ({ pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Compiler_types.module_binding)
 
 and ast_of_toplevel_phrase x =

--- a/ast/data.ml
+++ b/ast/data.ml
@@ -3,7 +3,7 @@ open Stdppx
 module Optional = struct
   module Loc = struct
     let map (loc : _ Astlib.Loc.t) ~f =
-      Option.map (f (Astlib.Loc.txt loc)) ~f:(fun txt -> Astlib.Loc.update_txt loc ~txt)
+      Option.map (f loc.txt) ~f:(fun txt -> { loc with txt })
   end
 
   module List = struct

--- a/ast/traverse_builtins.ml
+++ b/ast/traverse_builtins.ml
@@ -24,24 +24,24 @@ class map =
 
     method position : Astlib.Position.t T.map = fun x ->
       let open Astlib.Position in
-      let fname = self#string (fname x) in
-      let lnum = self#int (lnum x) in
-      let bol = self#int (bol x) in
-      let cnum = self#int (cnum x) in
-      create ~fname ~lnum ~bol ~cnum ()
+      let pos_fname = self#string x.pos_fname in
+      let pos_lnum = self#int x.pos_lnum in
+      let pos_bol = self#int x.pos_bol in
+      let pos_cnum = self#int x.pos_cnum in
+      { pos_fname; pos_lnum; pos_bol; pos_cnum }
 
     method location : Astlib.Location.t T.map = fun x ->
       let open Astlib.Location in
-      let start = self#position (start x) in
-      let end_ = self#position (end_ x) in
-      let ghost = self#bool (ghost x) in
-      create ~start ~end_ ~ghost ()
+      let loc_start = self#position x.loc_start in
+      let loc_end = self#position x.loc_end in
+      let loc_ghost = self#bool x.loc_ghost in
+      { loc_start; loc_end; loc_ghost }
 
     method loc : 'a. 'a T.map -> 'a Astlib.Loc.t T.map = fun f x ->
       let open Astlib.Loc in
-      let txt = f (txt x) in
-      let loc = self#location (loc x) in
-      create ~txt ~loc ()
+      let txt = f x.txt in
+      let loc = self#location x.loc in
+      { txt; loc }
   end
 
 class iter =
@@ -61,21 +61,21 @@ class iter =
 
     method position : Astlib.Position.t T.iter = fun x ->
       let open Astlib.Position in
-      self#string (fname x);
-      self#int (lnum x);
-      self#int (bol x);
-      self#int (cnum x)
+      self#string x.pos_fname;
+      self#int x.pos_lnum;
+      self#int x.pos_bol;
+      self#int x.pos_cnum
 
     method location : Astlib.Location.t T.iter = fun x ->
       let open Astlib.Location in
-      self#position (start x);
-      self#position (end_ x);
-      self#bool (ghost x)
+      self#position x.loc_start;
+      self#position x.loc_end;
+      self#bool x.loc_ghost
 
     method loc : 'a. 'a T.iter -> 'a Astlib.Loc.t T.iter = fun f x ->
       let open Astlib.Loc in
-      f (txt x);
-      self#location (loc x)
+      f x.txt;
+      self#location x.loc
   end
 
 class ['acc] fold =
@@ -108,21 +108,21 @@ class ['acc] fold =
 
     method position : (Astlib.Position.t, 'acc) T.fold = fun x acc ->
       let open Astlib.Position in
-      let acc = self#string (fname x) acc in
-      let acc = self#int (lnum x) acc in
-      let acc = self#int (bol x) acc in
-      self#int (cnum x) acc
+      let acc = self#string x.pos_fname acc in
+      let acc = self#int x.pos_lnum acc in
+      let acc = self#int x.pos_bol acc in
+      self#int x.pos_cnum acc
 
     method location : (Astlib.Location.t, 'acc) T.fold = fun x acc ->
       let open Astlib.Location in
-      let acc = self#position (start x) acc in
-      let acc = self#position (end_ x) acc in
-      self#bool (ghost x) acc
+      let acc = self#position x.loc_start acc in
+      let acc = self#position x.loc_end acc in
+      self#bool x.loc_ghost acc
 
     method loc : 'a. ('a, 'acc) T.fold -> ('a Astlib.Loc.t, 'acc) T.fold = fun f x acc ->
       let open Astlib.Loc in
-      let acc = f (txt x) acc in
-      self#location (loc x) acc
+      let acc = f x.txt acc in
+      self#location x.loc acc
   end
 
 class ['acc] fold_map =
@@ -169,26 +169,26 @@ class ['acc] fold_map =
 
     method position : (Astlib.Position.t, 'acc) T.fold_map = fun x acc ->
       let open Astlib.Position in
-      let (fname, acc) = self#string (fname x) acc in
-      let (lnum, acc) = self#int (lnum x) acc in
-      let (bol, acc) = self#int (bol x) acc in
-      let (cnum, acc) = self#int (cnum x) acc in
-      (create ~fname ~lnum ~bol ~cnum (), acc)
+      let (pos_fname, acc) = self#string x.pos_fname acc in
+      let (pos_lnum, acc) = self#int x.pos_lnum acc in
+      let (pos_bol, acc) = self#int x.pos_bol acc in
+      let (pos_cnum, acc) = self#int x.pos_cnum acc in
+      ({ pos_fname; pos_lnum; pos_bol; pos_cnum }, acc)
 
     method location : (Astlib.Location.t, 'acc) T.fold_map = fun x acc ->
       let open Astlib.Location in
-      let (start, acc) = self#position (start x) acc in
-      let (end_, acc) = self#position (end_ x) acc in
-      let (ghost, acc) = self#bool (ghost x) acc in
-      (create ~start ~end_ ~ghost (), acc)
+      let (loc_start, acc) = self#position x.loc_start acc in
+      let (loc_end, acc) = self#position x.loc_end acc in
+      let (loc_ghost, acc) = self#bool x.loc_ghost acc in
+      ({ loc_start; loc_end; loc_ghost }, acc)
 
     method loc :
       'a. ('a, 'acc) T.fold_map -> ('a Astlib.Loc.t, 'acc) T.fold_map =
       fun f x acc ->
       let open Astlib.Loc in
-      let (txt, acc) = f (txt x) acc in
-      let (loc, acc) = self#location (loc x) acc in
-      (create ~txt ~loc (), acc)
+      let (txt, acc) = f x.txt acc in
+      let (loc, acc) = self#location x.loc acc in
+      ({ txt; loc }, acc)
   end
 
 class ['ctx] map_with_context =
@@ -216,27 +216,27 @@ class ['ctx] map_with_context =
 
     method position : ('ctx, Astlib.Position.t) T.map_with_context = fun ctx x ->
       let open Astlib.Position in
-      let fname = self#string ctx (fname x) in
-      let lnum = self#int ctx (lnum x) in
-      let bol = self#int ctx (bol x) in
-      let cnum = self#int ctx (cnum x) in
-      create ~fname ~lnum ~bol ~cnum ()
+      let pos_fname = self#string ctx x.pos_fname in
+      let pos_lnum = self#int ctx x.pos_lnum in
+      let pos_bol = self#int ctx x.pos_bol in
+      let pos_cnum = self#int ctx x.pos_cnum in
+      { pos_fname; pos_lnum; pos_bol; pos_cnum }
 
     method location : ('ctx, Astlib.Location.t) T.map_with_context = fun ctx x ->
       let open Astlib.Location in
-      let start = self#position ctx (start x) in
-      let end_ = self#position ctx (end_ x) in
-      let ghost = self#bool ctx (ghost x) in
-      create ~start ~end_ ~ghost ()
+      let loc_start = self#position ctx x.loc_start in
+      let loc_end = self#position ctx x.loc_end in
+      let loc_ghost = self#bool ctx x.loc_ghost in
+      { loc_start; loc_end; loc_ghost }
 
     method loc
       : 'a. ('ctx, 'a) T.map_with_context ->
         ('ctx, 'a Astlib.Loc.t) T.map_with_context
       = fun f ctx x ->
       let open Astlib.Loc in
-      let txt = f ctx (txt x) in
-      let loc = self#location ctx (loc x) in
-      create ~txt ~loc ()
+      let txt = f ctx x.txt in
+      let loc = self#location ctx x.loc in
+      { txt; loc }
   end
 
 class virtual ['res] lift =
@@ -270,26 +270,31 @@ class virtual ['res] lift =
 
     method position : (Astlib.Position.t, 'res) T.lift = fun x ->
       let open Astlib.Position in
-      let fname = self#string (fname x) in
-      let lnum = self#int (lnum x) in
-      let bol = self#int (bol x) in
-      let cnum = self#int (cnum x) in
+      let pos_fname = self#string x.pos_fname in
+      let pos_lnum = self#int x.pos_lnum in
+      let pos_bol = self#int x.pos_bol in
+      let pos_cnum = self#int x.pos_cnum in
       self#record
         None
-        [("fname", fname); ("lnum", lnum); ("bol", bol); ("cnum", cnum)]
+        [ ("pos_fname", pos_fname)
+        ; ("pos_lnum", pos_lnum)
+        ; ("pos_bol", pos_bol)
+        ; ("pos_cnum", pos_cnum) ]
 
     method location : (Astlib.Location.t, 'res) T.lift = fun x ->
       let open Astlib.Location in
-      let start = self#position (start x) in
-      let end_ = self#position (end_ x) in
-      let ghost = self#bool (ghost x) in
-      self#record None [("start", start); ("end_", end_); ("ghost", ghost)]
+      let loc_start = self#position x.loc_start in
+      let loc_end = self#position x.loc_end in
+      let loc_ghost = self#bool x.loc_ghost in
+      self#record
+        None
+        [("loc_start", loc_start); ("loc_end", loc_end); ("loc_ghost", loc_ghost)]
 
     method loc : 'a. ('a, 'res) T.lift -> ('a Astlib.Loc.t, 'res) T.lift
       = fun f x ->
       let open Astlib.Loc in
-      let txt = f (txt x) in
-      let loc = self#location (loc x) in
+      let txt = f x.txt in
+      let loc = self#location x.loc in
       self#record None [("txt", txt); ("loc", loc)]
   end
 

--- a/ast/viewer_common.ml
+++ b/ast/viewer_common.ml
@@ -1,11 +1,20 @@
-let txt'match view value = view (Astlib.Loc.txt value)
-let loc'match view value = view (Astlib.Loc.loc value)
+include struct
+  open Astlib.Loc
+  let txt'match view value = view value.txt
+  let loc'match view value = view value.loc
+end
 
-let loc_start'match view value = view (Astlib.Location.start value)
-let loc_end'match view value = view (Astlib.Location.end_ value)
-let loc_ghost'match view value = view (Astlib.Location.ghost value)
+include struct
+  open Astlib.Location
+  let loc_start'match view value = view value.loc_start
+  let loc_end'match view value = view value.loc_end
+  let loc_ghost'match view value = view value.loc_ghost
+end
 
-let pos_fname'match view value = view (Astlib.Position.fname value)
-let pos_lnum'match view value = view (Astlib.Position.lnum value)
-let pos_bol'match view value = view (Astlib.Position.bol value)
-let pos_cnum'match view value = view (Astlib.Position.cnum value)
+include struct
+  open Astlib.Position
+  let pos_fname'match view value = view value.pos_fname
+  let pos_lnum'match view value = view value.pos_lnum
+  let pos_bol'match view value = view value.pos_bol
+  let pos_cnum'match view value = view value.pos_cnum
+end

--- a/astlib/loc.ml
+++ b/astlib/loc.ml
@@ -3,20 +3,4 @@ type 'a t = 'a Ocaml_common.Location.loc =
   ; loc : Ocaml_common.Location.t
   }
 
-let of_loc (t : _ t) = t
-let to_loc (t : _ t) = t
-
-let txt t = t.txt
-let loc t = Location.of_location t.loc
-
-let create ~txt ~loc () = { txt; loc = Location.to_location loc }
-
-let update_internal t ?(txt = txt t) ?(loc = loc t) () = create ~txt ~loc ()
-
-let update ?txt ?loc t = update_internal t ?txt ?loc ()
-
-let update_txt_internal t ~txt ?(loc = loc t) () = create ~txt ~loc ()
-
-let update_txt ~txt ?loc t = update_txt_internal t ~txt ?loc ()
-
-let map t ~f = update_txt t ~txt:(f t.txt)
+let map t ~f = { t with txt = f t.txt }

--- a/astlib/loc.mli
+++ b/astlib/loc.mli
@@ -1,45 +1,10 @@
-(** Stable interface for arbitrary values annotated with Astlib locations.
-
-    Astlib location annotations use the same representation as location annotations in the
-    compiler; however, we allow for the possibility that new fields will be added to the
-    type over time. We provide a [create] function that can be extended with optional
-    arguments in a backward-compatible way, and we may add new accessors as well. *)
+(** Stable interface for arbitrary values annotated with Astlib locations. *)
 
 (** {1 Type} *)
 
-type 'a t
-
-(** {1 Conversions} It should always be possible to convert to/from
-    [Ocaml_common.Location.loc]. *)
-
-val of_loc : 'a Ocaml_common.Location.loc -> 'a t
-val to_loc : 'a t -> 'a Ocaml_common.Location.loc
-
-(** {1 Accessors} These should be stable. *)
-
-val txt : 'a t -> 'a
-val loc : 'a t -> Location.t
-
-(** {1 Constructors} These may have additional optional arguments added over time. Where
-    necessary, we add an unnamed [unit] argument so that optional arguments can be
-    dropped, even if there currently are none. *)
-
-val create
-  :  txt : 'a
-  -> loc : Location.t
-  -> unit
-  -> 'a t
-
-val update
-  :  ?txt : 'a
-  -> ?loc : Location.t
-  -> 'a t
-  -> 'a t
-
-val update_txt
-  :  txt : 'a
-  -> ?loc : Location.t
-  -> _ t
-  -> 'a t
+type 'a t = 'a Ocaml_common.Location.loc =
+  { txt : 'a
+  ; loc : Location.t
+  }
 
 val map : 'a t -> f:('a -> 'b) -> 'b t

--- a/astlib/location.ml
+++ b/astlib/location.ml
@@ -1,28 +1,10 @@
 type t = Ocaml_common.Location.t =
-  { loc_start : Lexing.position
-  ; loc_end : Lexing.position
+  { loc_start : Position.t
+  ; loc_end : Position.t
   ; loc_ghost : bool
   }
 
-let of_location (t : t) = t
-let to_location (t : t) = t
-
-let start t = Position.of_position t.loc_start
-let end_ t = Position.of_position t.loc_end
-let ghost t = t.loc_ghost
-
-let create ~start ~end_ ?(ghost = false) () =
-  { loc_start = Position.to_position start
-  ; loc_end = Position.to_position end_
-  ; loc_ghost = ghost
-  }
-
-let none = of_location Ocaml_common.Location.none
-
-let update_internal t ?(start = start t) ?(end_ = end_ t) ?(ghost = ghost t) () =
-  create ~start ~end_ ~ghost ()
-
-let update ?start ?end_ ?ghost t = update_internal t ?start ?end_ ?ghost ()
+let none = Ocaml_common.Location.none
 
 type location = t
 

--- a/astlib/location.mli
+++ b/astlib/location.mli
@@ -1,43 +1,12 @@
-(** Stable interface for Astlib locations.
-
-    Astlib locations use the same representation as locations in the compiler; however, we
-    allow for the possibility that new fields will be added to the type over time. We
-    provide a [create] function that can be extended with optional arguments in a
-    backward-compatible way, and we may add new accessors as well. *)
+(** Stable interface for Astlib locations. *)
 
 (** {1 Type} *)
 
-type t
-
-(** {1 Conversions} It should always be possible to convert to/from
-    [Ocaml_common.Location.t]. *)
-
-val of_location : Ocaml_common.Location.t -> t
-val to_location : t -> Ocaml_common.Location.t
-
-(** {1 Accessors} These should be stable. *)
-
-val start : t -> Position.t
-val end_ : t -> Position.t
-val ghost : t -> bool
-
-(** {1 Constructors} These may have additional optional arguments added over time. Where
-    necessary, we add an unnamed [unit] argument so that optional arguments can be
-    dropped, even if there currently are none. *)
-
-val create
-  :  start : Position.t
-  -> end_ : Position.t
-  -> ?ghost : bool (** default: [false] *)
-  -> unit
-  -> t
-
-val update
-  :  ?start : Position.t
-  -> ?end_ : Position.t
-  -> ?ghost : bool
-  -> t
-  -> t
+type t = Ocaml_common.Location.t =
+  { loc_start : Position.t
+  ; loc_end : Position.t
+  ; loc_ghost : bool
+  }
 
 val none : t
 

--- a/astlib/position.ml
+++ b/astlib/position.ml
@@ -4,30 +4,3 @@ type t = Lexing.position =
   ; pos_bol : int
   ; pos_cnum : int
   }
-
-let of_position (t : t) = t
-let to_position (t : t) = t
-
-let fname t = t.pos_fname
-let lnum t = t.pos_lnum
-let bol t = t.pos_bol
-let cnum t = t.pos_cnum
-
-let create ~fname ~lnum ~bol ~cnum () =
-  { pos_fname = fname
-  ; pos_lnum = lnum
-  ; pos_bol = bol
-  ; pos_cnum = cnum
-  }
-
-let update_internal
-      t
-      ?(fname = fname t)
-      ?(lnum = lnum t)
-      ?(bol = bol t)
-      ?(cnum = cnum t)
-      ()
-  =
-  create ~fname ~lnum ~bol ~cnum ()
-
-let update ?fname ?lnum ?bol ?cnum t = update_internal t ?fname ?lnum ?bol ?cnum ()

--- a/astlib/position.mli
+++ b/astlib/position.mli
@@ -1,45 +1,11 @@
 (** Stable interface for Astlib positions, which are used as the start and end of AST
-    locations.
-
-    Astlib positions use the same representation as positions in the compiler; however, we
-    allow for the possibility that new fields will be added to the type over time. We
-    expose the type as [private] to discourage explicit construction, and provide a
-    [create] function that can be extended with optional arguments in a
-    backward-compatible way. *)
+    locations. *)
 
 (** {1 Type} *)
 
-(** The type equivalence with [Lexing.position] is expected to stay stable. *)
-type t = private Lexing.position
-
-(** {1 Conversions} It should always be possible to convert to/from [Lexing.position]. *)
-
-val of_position : Lexing.position -> t
-val to_position : t -> Lexing.position
-
-(** {1 Accessors} These should be stable. *)
-
-val fname : t -> string
-val lnum : t -> int
-val bol : t -> int
-val cnum : t -> int
-
-(** {1 Constructors} These may have additional optional arguments added over time. Where
-    necessary, we add an unnamed [unit] argument so that optional arguments can be
-    dropped, even if there currently are none. *)
-
-val create
-  :  fname : string
-  -> lnum : int
-  -> bol : int
-  -> cnum : int
-  -> unit
-  -> t
-
-val update
-  :  ?fname : string
-  -> ?lnum : int
-  -> ?bol : int
-  -> ?cnum : int
-  -> t
-  -> t
+type t = Lexing.position =
+  { pos_fname : string
+  ; pos_lnum : int
+  ; pos_bol : int
+  ; pos_cnum : int
+  }

--- a/bootstrap/runner/ppx_bootstrap_runner.ml
+++ b/bootstrap/runner/ppx_bootstrap_runner.ml
@@ -58,13 +58,11 @@ let t =
 let unsupported_extension extension =
   match Extension.to_concrete extension with
   | None -> assert false
-  | Some (name_loc, _) ->
-    let loc = Astlib.Loc.loc name_loc in
-    let name = Astlib.Loc.txt name_loc in
+  | Some ({ loc; txt = name }, _) ->
     let expr = estring ~loc ("unsupported bootstrap extension " ^ name) in
     let item = pstr_eval ~loc expr (Attributes.create []) in
     let payload = Payload.pstr (Structure.create [item]) in
-    Extension.create (Astlib.Loc.create ~txt:"error" ~loc (), payload)
+    Extension.create ({ txt = "error"; loc }, payload)
 ;;
 
 let expression_extension expr =
@@ -98,9 +96,7 @@ let rewriter =
     method! expression expr =
       match expression_extension expr with
       | None -> super#expression expr
-      | Some (name_loc, payload, ext) ->
-        let loc = Astlib.Loc.loc name_loc in
-        let txt = Astlib.Loc.txt name_loc in
+      | Some ({ loc; txt }, payload, ext) ->
         (match Label_map.find t.expr txt with
          | Some entry -> self#expression (entry.callback ~loc payload)
          | None -> pexp_extension ~loc (unsupported_extension ext))
@@ -108,9 +104,7 @@ let rewriter =
     method! pattern pat =
       match pattern_extension pat with
       | None -> super#pattern pat
-      | Some (name_loc, payload, ext) ->
-        let loc = Astlib.Loc.loc name_loc in
-        let txt = Astlib.Loc.txt name_loc in
+      | Some ({ loc; txt }, payload, ext) ->
         (match Label_map.find t.patt txt with
          | Some entry -> self#pattern (entry.callback ~loc payload)
          | None -> ppat_extension ~loc (unsupported_extension ext))

--- a/metaquot/test/test.ml
+++ b/metaquot/test/test.ml
@@ -4,7 +4,14 @@
 let loc = Astlib.Location.none
 let () = Clflags.dump_source := true
 [%%expect{|
-val loc : Astlib.Location.t = <abstr>
+val loc : Location.t =
+  {Astlib.Location.loc_start =
+    {Astlib__.Position.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     pos_cnum = -1};
+   loc_end =
+    {Astlib__.Position.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     pos_cnum = -1};
+   loc_ghost = true}
 |}]
 
 

--- a/ppx_view/lib/deconstructor.ml
+++ b/ppx_view/lib/deconstructor.ml
@@ -19,9 +19,7 @@ let pattern ~loc pat =
 let longident_loc ~loc longident_loc =
   match Longident_loc.to_concrete longident_loc with
   | None -> Error.conversion_failed ~loc "longident_loc"
-  | Some longident_loc ->
-    let loc = Astlib.Loc.loc longident_loc in
-    let longident = Astlib.Loc.txt longident_loc in
+  | Some { loc; txt = longident } ->
     match Longident.to_concrete longident with
     | None -> Error.conversion_failed ~loc "longident"
     | Some longident -> (loc, longident)

--- a/ppx_view/lib/error.ml
+++ b/ppx_view/lib/error.ml
@@ -1,7 +1,6 @@
 let ast_version = "4.07"
 
 let errorf ~loc fmt =
-  let loc = Astlib.Location.to_location loc in
   Ocaml_common.Location.raise_errorf ~loc
     ("ppx_view: " ^^ fmt)
 

--- a/ppx_view/lib/expand.ml
+++ b/ppx_view/lib/expand.ml
@@ -89,9 +89,7 @@ let same_variables ~err_loc vl vl' =
       let (_, desc') = Deconstructor.pattern ~loc:err_loc v' in
       match desc, desc' with
       | Ppat_var loc_name, Ppat_var loc_name' ->
-        let name = Astlib.Loc.txt loc_name in
-        let name' = Astlib.Loc.txt loc_name' in
-        name = name'
+        loc_name.txt = loc_name'.txt
       | _ -> false)
 
 let rec translate_pattern ~err_loc pattern =
@@ -272,13 +270,12 @@ let translate_case ~loc ~err_loc match_case =
     let f = Builder.view_lib_ident ~loc "case" in
     Builder.Exp.apply_lident ~loc f [pattern; body]
 
-let pos_argument loc =
-  let start = Astlib.Location.start loc in
-  let bol = Astlib.Position.bol start in
-  let lnum = Astlib.Position.lnum start in
-  let cnum = Astlib.Position.cnum start in
-  let fname = Astlib.Position.fname start in
-  pexp_tuple ~loc [estring ~loc fname; eint ~loc lnum; eint ~loc (cnum - bol)]
+let pos_argument (loc : Astlib.Location.t) =
+  let pos = loc.loc_start in
+  pexp_tuple ~loc
+    [ estring ~loc pos.pos_fname
+    ; eint ~loc pos.pos_lnum
+    ; eint ~loc (pos.pos_cnum - pos.pos_bol) ]
 
 let translate_match ~loc ~err_loc ?match_expr match_cases =
   let pos = pos_argument loc in

--- a/ppx_view/lib/view_attr.ml
+++ b/ppx_view/lib/view_attr.ml
@@ -20,9 +20,7 @@ let fields_from_payload ~loc payload =
 let fields_from_attribute ~loc attribute =
   match Attribute.to_concrete attribute with
   | None -> Error.conversion_failed ~loc "attribute"
-  | Some (name, payload) ->
-    let loc = Astlib.Loc.loc name in
-    let name = Astlib.Loc.txt name in
+  | Some ({ loc; txt = name }, payload) ->
     match name with
     | "view" -> Some (fields_from_payload ~loc payload)
     | _ -> None

--- a/ppx_view/lib_deprecated/ppx_view_lib_deprecated.ml
+++ b/ppx_view/lib_deprecated/ppx_view_lib_deprecated.ml
@@ -1,6 +1,5 @@
 module Expand = struct
   let parsetree_payload ~loc payload_expr =
-    let loc = Astlib.Location.of_location loc in
     let astlib_payload_expr = Ppx_ast.Conversion.ast_of_expression payload_expr in
     let expanded = Ppx_view_lib.Expand.payload ~loc astlib_payload_expr in
     Ppx_ast.Conversion.ast_to_expression expanded

--- a/ppx_view/test/test.ml
+++ b/ppx_view/test/test.ml
@@ -1,7 +1,7 @@
 open Ppx_ast
 open V4_07
 
-let loc = Astlib.Location.of_location Ocaml_common.Location.none
+let loc = Ocaml_common.Location.none
 [@@warning "-3"]
 
 let int x = eint ~loc x
@@ -11,14 +11,12 @@ let ident x = pexp_ident ~loc (Located.lident ~loc x)
 
 let class_infos =
   let extension =
-    Extension.create
-      ( Astlib.Loc.create ~txt:"ext" ~loc ()
-      , Payload.pstr (Structure.create []) )
+    Extension.create ({ loc; txt = "ext" } , Payload.pstr (Structure.create []) )
   in
   Class_infos.create
     ~pci_virt:Virtual_flag.virtual_
     ~pci_params:[]
-    ~pci_name:(Astlib.Loc.create ~txt:"name" ~loc ())
+    ~pci_name:{ loc; txt = "name" }
     ~pci_loc:loc
     ~pci_attributes:(Attributes.create [])
     ~pci_expr:(pcty_extension ~loc extension)
@@ -29,7 +27,7 @@ let%expect_test "match failure" =
       print_string "matched"
   with e ->
     print_string (Printexc.to_string e)
-  end;[%expect {|"Match_failure ppx_view/test/test.ml:27:12"|}]
+  end;[%expect {|"Match_failure ppx_view/test/test.ml:25:12"|}]
 
 let%expect_test "match simple" =
   let match_3 = function%view

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -11,8 +11,7 @@ let parse (T f) loc ?on_error x k =
   try f { matched = 0 } loc x k
   with Expected (loc, expected) ->
     match on_error with
-    | None ->
-      Location.raise_errorf ~loc:(Astlib.Location.to_location loc) "%s expected" expected
+    | None -> Location.raise_errorf ~loc "%s expected" expected
     | Some f -> f ()
 
 module Packed = struct

--- a/src/ast_pattern0.ml
+++ b/src/ast_pattern0.ml
@@ -2,9 +2,7 @@ open! Import
 
 include Ppx_bootstrap.Expected
 
-let fail loc expected =
-  raise (Expected (Astlib.Location.of_location loc, expected))
-;;
+let fail loc expected = raise (Expected (loc, expected))
 
 type context =
   { (* [matched] counts how many constructors have been matched. This is used to find what

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -315,8 +315,7 @@ let declare_inline_with_path_arg name context pattern k =
 
 let of_bootstrap_extension ext =
   let wrap f of_ast ~loc ~path:_ x =
-    of_ast
-      (f ~loc:(Astlib.Location.of_location loc) (Ppx_ast.Conversion.ast_of_payload x))
+    of_ast (f ~loc (Ppx_ast.Conversion.ast_of_payload x))
   in
   match (ext : Ppx_bootstrap.Extension.t) with
   | Patt { name; callback } ->

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -6,12 +6,10 @@ let foo =
   Deriving.add "foo"
     ~str_type_decl:(Deriving.Generator.make_noarg
                       (fun ~loc ~path:_ _ ->
-                         let loc = Astlib.Location.of_location loc in
                          [%str let x = 42]
                          |> Ppx_ast.Conversion.ast_to_structure))
     ~sig_type_decl:(Deriving.Generator.make_noarg
                       (fun ~loc ~path:_ _ ->
-                         let loc = Astlib.Location.of_location loc in
                          [%sig: val y : int]
                          |> Ppx_ast.Conversion.ast_to_signature))
 [%%expect{|
@@ -22,7 +20,6 @@ let bar =
   Deriving.add "bar"
     ~str_type_decl:
       (Deriving.Generator.make_noarg ~deps:[foo] (fun ~loc ~path:_ _ ->
-         let loc = Astlib.Location.of_location loc in
          [%str let () = Printf.printf "x = %d\n" x]
          |> Ppx_ast.Conversion.ast_to_structure))
 [%%expect{|
@@ -34,13 +31,11 @@ let mtd =
     ~sig_module_type_decl:(
       Deriving.Generator.make_noarg
         (fun ~loc ~path:_ _ ->
-           let loc = Astlib.Location.of_location loc in
            [%sig: val y : int]
            |> Ppx_ast.Conversion.ast_to_signature))
     ~str_module_type_decl:(
       Deriving.Generator.make_noarg
         (fun ~loc ~path:_ _ ->
-           let loc = Astlib.Location.of_location loc in
            [%str let y = 42]
            |> Ppx_ast.Conversion.ast_to_structure))
 [%%expect{|


### PR DESCRIPTION
Make position, location, and loc transparent. Continue to provide a stable interface. Remove now-unnecessary constructors and accessors.