### PR TITLE
Hard-code versions used in History upgrade/downgrade conversions.

### DIFF
--- a/ast/node.ml
+++ b/ast/node.ml
@@ -2,7 +2,7 @@ type t = { version : Astlib.Version.t; node : t Astlib.Ast.node }
 
 let version t = t.version
 
-let of_node node ~version = { version; node }
+let of_node ~version node = { version; node }
 
-let rec to_node { node; version = src_version } ~version:dst_version =
+let rec to_node ~version:dst_version { node; version = src_version } =
   Astlib.History.convert Astlib.history node ~src_version ~dst_version ~to_node ~of_node

--- a/ast/node.mli
+++ b/ast/node.mli
@@ -1,5 +1,5 @@
 type t
 
 val version : t -> Astlib.Version.t
-val of_node : t Astlib.Ast.node -> version:Astlib.Version.t -> t
-val to_node : t -> version:Astlib.Version.t -> t Astlib.Ast.node
+val of_node : version:Astlib.Version.t -> t Astlib.Ast.node -> t
+val to_node : version:Astlib.Version.t -> t -> t Astlib.Ast.node

--- a/astlib/astlib_intf.ml
+++ b/astlib/astlib_intf.ml
@@ -18,8 +18,8 @@ module type History = sig
     -> 'a Ast.node
     -> src_version:Version.t
     -> dst_version:Version.t
-    -> to_node:('a -> version:Version.t -> 'a Ast.node)
-    -> of_node:('a Ast.node -> version:Version.t -> 'a)
+    -> to_node:(version:Version.t -> 'a -> 'a Ast.node)
+    -> of_node:(version:Version.t -> 'a Ast.node -> 'a)
     -> 'a Ast.node
 end
 

--- a/astlib/history.mli
+++ b/astlib/history.mli
@@ -2,8 +2,8 @@ include Astlib_intf.History
 
 type 'a conversion_function
   = 'a Ast.node
-  -> to_node:('a -> version:Version.t -> 'a Ast.node)
-  -> of_node:('a Ast.node -> version:Version.t -> 'a)
+  -> of_src_node:('a Ast.node -> 'a)
+  -> to_dst_node:('a -> 'a Ast.node)
   -> 'a Ast.node
 
 type conversion =

--- a/astlib/unstable_for_testing.ml
+++ b/astlib/unstable_for_testing.ml
@@ -77,13 +77,13 @@ let update_node (node : _ Ast.node) =
 let to_stable : History.conversion =
   { src_version = version
   ; dst_version = Stable.version
-  ; f = fun node ~to_node:_ ~of_node:_ -> update_node node
+  ; f = fun node ~of_src_node:_ ~to_dst_node:_ -> update_node node
   }
 
 let of_stable : History.conversion =
   { src_version = Stable.version
   ; dst_version = version
-  ; f = fun node ~to_node:_ ~of_node:_ -> update_node node
+  ; f = fun node ~of_src_node:_ ~to_dst_node:_ -> update_node node
   }
 
 let conversions = [ to_stable; of_stable ]


### PR DESCRIPTION
This makes writing History changes easier, as one does not have to keep filling in `dst_version` and `src_version`.

While I was at it, I also changed some argument orders, in one case to make it easier to partially apply `to_node` and `of_node`, and in another case to make it easier to read, as `of_src_node` before `to_dst_node` is "chronological" in a sense.