### PR TITLE
rename Wrapper to ty

### DIFF
--- a/ast/cinaps/gen_builder.ml
+++ b/ast/cinaps/gen_builder.ml
@@ -263,7 +263,7 @@ let builders name (grammar : Astlib.Grammar.kind) shortcut =
   | Poly (_, _) -> []
   | Mono decl ->
     match decl with
-    | Wrapper _ -> []
+    | Ty _ -> []
     | Record r ->
       begin match Builder.of_record name r shortcut with
       | None -> []

--- a/ast/cinaps/gen_conversion.ml
+++ b/ast/cinaps/gen_conversion.ml
@@ -137,7 +137,7 @@ let define_conversion decl ~node_name ~env ~conv =
   let name = Name.make [concrete_prefix ~conv; node_name] (Poly_env.args env) in
   let node_ty = node_ty ~node_name ~env in
   match (decl : Astlib.Grammar.decl) with
-  | Wrapper ty ->
+  | Ty ty ->
     Print.println "and %s x =" name;
     Print.indented (fun () ->
       Print.println "%s x" (fn_value (ty_conversion ~conv (Poly_env.subst_ty ty ~env))))

--- a/ast/cinaps/gen_traverse.ml
+++ b/ast/cinaps/gen_traverse.ml
@@ -207,7 +207,7 @@ let print_method_body
   =
   let value_kind = Ast_type {node_name; targs} in
   match decl with
-  | Wrapper ty -> print_method_for_alias ~traversal ~value_kind ~var ty
+  | Ty ty -> print_method_for_alias ~traversal ~value_kind ~var ty
   | Record fields ->
     let deconstructed = deconstruct_record ~traversal fields in
     let concrete_type = (node_type ~type_:Concrete ~args:targs node_name) in

--- a/ast/cinaps/gen_versions.ml
+++ b/ast/cinaps/gen_versions.ml
@@ -21,7 +21,7 @@ module Render (Config : sig val internal : bool end) = struct
 
   let type_element decl : Ml.element =
     match (decl : Astlib.Grammar.decl) with
-    | Wrapper ty -> Line (string_of_ty ty)
+    | Ty ty -> Line (string_of_ty ty)
     | Record record -> Block (fun () -> print_record_type record)
     | Variant variant -> Block (fun () -> print_variant_type variant)
 end
@@ -41,7 +41,7 @@ module Signature = struct
     let env = Poly_env.uninstantiated tvars in
     let string_of_ty ty = Render.string_of_ty ~nodify:true (Poly_env.subst_ty ty ~env) in
     match (decl : Astlib.Grammar.decl) with
-    | Wrapper ty ->
+    | Ty ty ->
       Ml.declare_val
         "create"
         (Line (Printf.sprintf "%s -> %s"
@@ -140,7 +140,7 @@ module Structure = struct
 
   let define_constructors decl ~node_name ~grammar =
     match (decl : Astlib.Grammar.decl) with
-    | Wrapper ty ->
+    | Ty ty ->
       Print.println "let create =";
       Print.indented (fun () ->
         Print.println "let data = %s in" (ast_of_ty ~grammar ty);
@@ -199,7 +199,7 @@ module Structure = struct
 
   let define_of_concrete decl =
     match (decl : Astlib.Grammar.decl) with
-    | Wrapper _ -> Print.println "let of_concrete = create"
+    | Ty _ -> Print.println "let of_concrete = create"
     | Record record ->
       Print.println "let of_concrete { %s } ="
         (String.concat ~sep:"; "
@@ -253,7 +253,7 @@ module Structure = struct
 
   let define_to_concrete_opt decl ~node_name ~grammar =
     match (decl : Astlib.Grammar.decl) with
-    | Wrapper ty ->
+    | Ty ty ->
       Print.println "let to_concrete_opt t =";
       Print.indented (fun () ->
         Print.println

--- a/ast/cinaps/gen_viewer.ml
+++ b/ast/cinaps/gen_viewer.ml
@@ -10,8 +10,8 @@ let wrapper_types grammar =
   List.fold_left ~init grammar
     ~f:(fun acc (name, kind) ->
       match (kind : Astlib.Grammar.kind) with
-      | Mono (Wrapper ty) -> String.Map.add acc name ([], ty)
-      | Poly (targs, Wrapper ty) -> String.Map.add acc name (targs, ty)
+      | Mono (Ty ty) -> String.Map.add acc name ([], ty)
+      | Poly (targs, Ty ty) -> String.Map.add acc name (targs, ty)
       | _ -> acc)
 
 let shortcut_viewer_name ~shortcut cname =
@@ -324,7 +324,7 @@ let print_viewer ~what ~shortcuts ~wrapper_types (name, kind) =
     assert false
   | _, Record fields ->
     List.iter fields ~f:(M.print_field_viewer ~targs ~name)
-  | _, Wrapper ty ->
+  | _, Ty ty ->
     M.print_wrapper_viewer ~wrapper_types ~targs ~name ty
 
 let print_viewer_ml version =

--- a/ast/cinaps/poly_env.ml
+++ b/ast/cinaps/poly_env.ml
@@ -62,7 +62,7 @@ let subst_variants variants ~env =
 let subst_decl decl ~env =
   let open Astlib.Grammar in
   match decl with
-  | Wrapper ty -> Wrapper (subst_ty ~env ty)
+  | Ty ty -> Ty (subst_ty ~env ty)
   | Record fields -> Record (subst_fields ~env fields)
   | Variant variants -> Variant (subst_variants ~env variants)
 
@@ -90,7 +90,7 @@ let variant_instances variant =
 
 let decl_instances decl =
   match (decl : Astlib.Grammar.decl) with
-  | Wrapper ty -> ty_instances ty
+  | Ty ty -> ty_instances ty
   | Record record -> record_instances record
   | Variant variant -> variant_instances variant
 

--- a/ast/cinaps/shortcut.ml
+++ b/ast/cinaps/shortcut.ml
@@ -65,7 +65,7 @@ module Map = struct
         | Poly (_, _) -> acc
         | Mono decl ->
           match decl with
-          | Wrapper _ | Variant _ -> acc
+          | Ty _ | Variant _ -> acc
           | Record record ->
             match from_record ~name record with
             | None -> acc

--- a/ast/test/cinaps/ppx_ast_tests_cinaps.ml
+++ b/ast/test/cinaps/ppx_ast_tests_cinaps.ml
@@ -52,7 +52,7 @@ let print_deriving_type decl ~index ~name ~tvars =
     (Ml.poly_type name ~tvars);
   Print.indented (fun () ->
     match (decl : Astlib.Grammar.decl) with
-    | Wrapper ty -> Print.println "%s" (string_of_ty ty)
+    | Ty ty -> Print.println "%s" (string_of_ty ty)
     | Record record ->
       Print.println "%s =" (Ml.poly_type ("Compiler_types." ^ name) ~tvars);
       Ml.print_record_type record ~f:string_of_ty
@@ -150,7 +150,7 @@ let print_quickcheck_generator decl ~index ~name ~tvars =
   Print.indented (fun () ->
     let gen_id name = Ml.id ("gen_" ^ name) in
     match (decl : Astlib.Grammar.decl) with
-    | Wrapper ty ->
+    | Ty ty ->
       Print.println "let gen = %s in" (generator_string ty);
       Print.println "Generator.generate gen ~size ~random"
     | Record record ->

--- a/astlib/grammar.ml
+++ b/astlib/grammar.ml
@@ -62,9 +62,9 @@ type clause =
 
 type variant = (string * clause) list
 
-(** A nominal type may contain a structural type, a record type, or a variant type. *)
+(** A type declaration may contain a structural type, a record type, or a variant type. *)
 type decl =
-  | Wrapper of ty
+  | Ty of ty
   | Record of record
   | Variant of variant
 

--- a/astlib/latest_version.ml
+++ b/astlib/latest_version.ml
@@ -9,7 +9,7 @@ let grammar : Grammar.t =
            [ ("Lident", Tuple [String])
            ; ("Ldot", Tuple [Name "longident"; String])
            ; ("Lapply", Tuple [Name "longident"; Name "longident"]) ]))
-  ; ("longident_loc", Mono (Wrapper (Loc (Name "longident"))))
+  ; ("longident_loc", Mono (Ty (Loc (Name "longident"))))
   ; ( "rec_flag"
     , Mono
         (Variant [("Nonrecursive", Empty); ("Recursive", Empty)])
@@ -46,10 +46,10 @@ let grammar : Grammar.t =
               ; ("Pconst_string", Tuple [String; Option String])
               ; ("Pconst_float", Tuple [String; Option Char]) ]) )
   ; ( "attribute"
-    , Mono (Wrapper (Tuple [Loc String; Name "payload"])) )
+    , Mono (Ty (Tuple [Loc String; Name "payload"])) )
   ; ( "extension"
-    , Mono (Wrapper (Tuple [Loc String; Name "payload"])) )
-  ; ("attributes", Mono (Wrapper (List (Name "attribute"))))
+    , Mono (Ty (Tuple [Loc String; Name "payload"])) )
+  ; ("attributes", Mono (Ty (List (Name "attribute"))))
   ; ( "payload"
     , Mono
         (Variant
@@ -90,7 +90,7 @@ let grammar : Grammar.t =
               ; ("Ptyp_extension", Tuple [Name "extension"]) ]) )
   ; ( "package_type"
     , Mono
-        (Wrapper
+        (Ty
               (Tuple
                  [ Name "longident_loc"
                  ; List (Tuple [Name "longident_loc"; Name "core_type"]) ]))
@@ -381,9 +381,9 @@ let grammar : Grammar.t =
                ; ("pci_loc", Location)
                ; ("pci_attributes", Name "attributes") ]) ) )
   ; ( "class_description"
-    , Mono (Wrapper (Instance ("class_infos", [Tname "class_type"]))) )
+    , Mono (Ty (Instance ("class_infos", [Tname "class_type"]))) )
   ; ( "class_type_declaration"
-    , Mono (Wrapper (Instance ("class_infos", [Tname "class_type"]))) )
+    , Mono (Ty (Instance ("class_infos", [Tname "class_type"]))) )
   ; ( "class_expr"
     , Mono
         (Record
@@ -461,7 +461,7 @@ let grammar : Grammar.t =
               ; ( "Cfk_concrete"
                 , Tuple [Name "override_flag"; Name "expression"] ) ]) )
   ; ( "class_declaration"
-    , Mono (Wrapper (Instance ("class_infos", [Tname "class_expr"]))) )
+    , Mono (Ty (Instance ("class_infos", [Tname "class_expr"]))) )
   ; ( "module_type"
     , Mono
         (Record
@@ -483,7 +483,7 @@ let grammar : Grammar.t =
               ; ("Pmty_typeof", Tuple [Name "module_expr"])
               ; ("Pmty_extension", Tuple [Name "extension"])
               ; ("Pmty_alias", Tuple [Name "longident_loc"]) ]) )
-  ; ("signature", Mono (Wrapper (List (Name "signature_item"))))
+  ; ("signature", Mono (Ty (List (Name "signature_item"))))
   ; ( "signature_item"
     , Mono
         (Record
@@ -537,9 +537,9 @@ let grammar : Grammar.t =
              ; ("pincl_loc", Location)
              ; ("pincl_attributes", Name "attributes") ]) ) )
   ; ( "include_description"
-    , Mono (Wrapper (Instance ("include_infos", [Tname "module_type"]))) )
+    , Mono (Ty (Instance ("include_infos", [Tname "module_type"]))) )
   ; ( "include_declaration"
-    , Mono (Wrapper (Instance ("include_infos", [Tname "module_expr"]))) )
+    , Mono (Ty (Instance ("include_infos", [Tname "module_expr"]))) )
   ; ( "with_constraint"
     , Mono
         (Variant
@@ -572,7 +572,7 @@ let grammar : Grammar.t =
              , Tuple [Name "module_expr"; Name "module_type"] )
            ; ("Pmod_unpack", Tuple [Name "expression"])
            ; ("Pmod_extension", Tuple [Name "extension"]) ]) )
-  ; ("structure", Mono (Wrapper (List (Name "structure_item"))))
+  ; ("structure", Mono (Ty (List (Name "structure_item"))))
   ; ( "structure_item"
     , Mono
         (Record

--- a/astlib/unstable_for_testing.ml
+++ b/astlib/unstable_for_testing.ml
@@ -35,7 +35,7 @@ let update_variant variant =
 
 let update_decl decl : Grammar.decl =
   match (decl : Grammar.decl) with
-  | Wrapper ty -> Wrapper (update_ty ty)
+  | Ty ty -> Ty (update_ty ty)
   | Record record -> Record (update_record record)
   | Variant variant -> Variant (update_variant variant)
 


### PR DESCRIPTION
Renaming Wrapper to Ty. Most of the other variant tags in Grammar have the same name as the type, may as well be consistent.