### PR TITLE
Distinguish use of terms "ast" and "node".

### DIFF
--- a/ast/cinaps/gen_versions.ml
+++ b/ast/cinaps/gen_versions.ml
@@ -257,7 +257,7 @@ module Structure = struct
       Print.println "let to_concrete_opt t =";
       Print.indented (fun () ->
         Print.println
-          "match Node.to_node (Unversioned.Private.transparent t) ~version with";
+          "match Node.to_ast (Unversioned.Private.transparent t) ~version with";
         Print.println "| { name = %S; data } -> %s data"
           node_name
           (ast_to_ty ~grammar ty);
@@ -266,7 +266,7 @@ module Structure = struct
       Print.println "let to_concrete_opt t =";
       Print.indented (fun () ->
         Print.println
-          "match Node.to_node (Unversioned.Private.transparent t) ~version with";
+          "match Node.to_ast (Unversioned.Private.transparent t) ~version with";
         Print.println "| { name = %S" node_name;
         Print.indented (fun () ->
           Print.println "; data = Record [| %s |]"
@@ -283,7 +283,7 @@ module Structure = struct
       Print.println "let to_concrete_opt t =";
       Print.indented (fun () ->
         Print.println
-          "match Node.to_node (Unversioned.Private.transparent t) ~version with";
+          "match Node.to_ast (Unversioned.Private.transparent t) ~version with";
         Print.println "| { name = %S; data } ->" node_name;
         Print.indented (fun () ->
           Print.println "begin";
@@ -411,7 +411,7 @@ let print_version_ml version =
     "let version = Astlib.Version.of_string %S"
     (Astlib.Version.to_string version);
   Print.println
-    "let node name data = Unversioned.Private.opaque (Node.of_node ~version { name; data })";
+    "let node name data = Unversioned.Private.opaque (Node.of_ast ~version { name; data })";
   Print.newline ();
   Ml.define_modules grammar ~f:(fun node_name kind ->
     match (kind : Astlib.Grammar.kind) with

--- a/ast/node.ml
+++ b/ast/node.ml
@@ -1,8 +1,8 @@
-type t = { version : Astlib.Version.t; node : t Astlib.Ast.node }
+type t = { version : Astlib.Version.t; ast : t Astlib.Ast.t }
 
 let version t = t.version
 
-let of_node node ~version = { version; node }
+let of_ast ast ~version = { version; ast }
 
-let rec to_node { node; version = src_version } ~version:dst_version =
-  Astlib.History.convert Astlib.history node ~src_version ~dst_version ~to_node ~of_node
+let rec to_ast { ast; version = src_version } ~version:dst_version =
+  Astlib.History.convert Astlib.history ast ~src_version ~dst_version ~to_ast ~of_ast

--- a/ast/node.mli
+++ b/ast/node.mli
@@ -1,5 +1,5 @@
 type t
 
 val version : t -> Astlib.Version.t
-val of_node : t Astlib.Ast.node -> version:Astlib.Version.t -> t
-val to_node : t -> version:Astlib.Version.t -> t Astlib.Ast.node
+val of_ast : t Astlib.Ast.t -> version:Astlib.Version.t -> t
+val to_ast : t -> version:Astlib.Version.t -> t Astlib.Ast.t

--- a/ast/version_unstable_for_testing.ml
+++ b/ast/version_unstable_for_testing.ml
@@ -3,7 +3,7 @@ open Unversioned.Types
 
 (*$ Ppx_ast_cinaps.print_version_ml (Astlib.Version.of_string "unstable_for_testing") *)
 let version = Astlib.Version.of_string "unstable_for_testing"
-let node name data = Unversioned.Private.opaque (Node.of_node ~version { name; data })
+let node name data = Unversioned.Private.opaque (Node.of_ast ~version { name; data })
 
 module Directive_argument = struct
   type t = directive_argument
@@ -64,7 +64,7 @@ module Directive_argument = struct
     | Pdir_none -> pdir_none
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "directive_argument"; data } ->
       begin
         match data with
@@ -135,7 +135,7 @@ module Toplevel_phrase = struct
       ptop_def x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "toplevel_phrase"; data } ->
       begin
         match data with
@@ -188,7 +188,7 @@ module Module_binding = struct
     create ~pmb_loc ~pmb_attributes ~pmb_expr ~pmb_name
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_binding"
       ; data = Record [| pmb_loc; pmb_attributes; pmb_expr; pmb_name |]
       } ->
@@ -236,7 +236,7 @@ module Value_binding = struct
     create ~pvb_loc ~pvb_attributes ~pvb_expr ~pvb_pat
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "value_binding"
       ; data = Record [| pvb_loc; pvb_attributes; pvb_expr; pvb_pat |]
       } ->
@@ -439,7 +439,7 @@ module Structure_item_desc = struct
       pstr_eval x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "structure_item_desc"; data } ->
       begin
         match data with
@@ -543,7 +543,7 @@ module Structure_item = struct
     create ~pstr_loc ~pstr_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "structure_item"
       ; data = Record [| pstr_loc; pstr_desc |]
       } ->
@@ -577,7 +577,7 @@ module Structure = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "structure"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
@@ -684,7 +684,7 @@ module Module_expr_desc = struct
       pmod_ident x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_expr_desc"; data } ->
       begin
         match data with
@@ -758,7 +758,7 @@ module Module_expr = struct
     create ~pmod_attributes ~pmod_loc ~pmod_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_expr"
       ; data = Record [| pmod_attributes; pmod_loc; pmod_desc |]
       } ->
@@ -839,7 +839,7 @@ module With_constraint = struct
       pwith_type x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "with_constraint"; data } ->
       begin
         match data with
@@ -891,7 +891,7 @@ module Include_declaration = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "include_declaration"; data } -> Data.to_node data
     | _ -> None
 
@@ -919,7 +919,7 @@ module Include_description = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "include_description"; data } -> Data.to_node data
     | _ -> None
 
@@ -957,7 +957,7 @@ module Include_infos = struct
     create ~pincl_attributes ~pincl_loc ~pincl_mod
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "include_infos"
       ; data = Record [| pincl_attributes; pincl_loc; pincl_mod |]
       } ->
@@ -1004,7 +1004,7 @@ module Open_description = struct
     create ~popen_attributes ~popen_loc ~popen_override ~popen_lid
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "open_description"
       ; data = Record [| popen_attributes; popen_loc; popen_override; popen_lid |]
       } ->
@@ -1052,7 +1052,7 @@ module Module_type_declaration = struct
     create ~pmtd_loc ~pmtd_attributes ~pmtd_type ~pmtd_name
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_type_declaration"
       ; data = Record [| pmtd_loc; pmtd_attributes; pmtd_type; pmtd_name |]
       } ->
@@ -1100,7 +1100,7 @@ module Module_declaration = struct
     create ~pmd_loc ~pmd_attributes ~pmd_type ~pmd_name
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_declaration"
       ; data = Record [| pmd_loc; pmd_attributes; pmd_type; pmd_name |]
       } ->
@@ -1279,7 +1279,7 @@ module Signature_item_desc = struct
       psig_value x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "signature_item_desc"; data } ->
       begin
         match data with
@@ -1373,7 +1373,7 @@ module Signature_item = struct
     create ~psig_loc ~psig_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "signature_item"
       ; data = Record [| psig_loc; psig_desc |]
       } ->
@@ -1407,7 +1407,7 @@ module Signature = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "signature"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
@@ -1513,7 +1513,7 @@ module Module_type_desc = struct
       pmty_ident x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_type_desc"; data } ->
       begin
         match data with
@@ -1586,7 +1586,7 @@ module Module_type = struct
     create ~pmty_attributes ~pmty_loc ~pmty_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_type"
       ; data = Record [| pmty_attributes; pmty_loc; pmty_desc |]
       } ->
@@ -1621,7 +1621,7 @@ module Class_declaration = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_declaration"; data } -> Data.to_node data
     | _ -> None
 
@@ -1670,7 +1670,7 @@ module Class_field_kind = struct
       cfk_virtual x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_field_kind"; data } ->
       begin
         match data with
@@ -1788,7 +1788,7 @@ module Class_field_desc = struct
       pcf_inherit x1 x2 x3
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_field_desc"; data } ->
       begin
         match data with
@@ -1860,7 +1860,7 @@ module Class_field = struct
     create ~pcf_attributes ~pcf_loc ~pcf_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_field"
       ; data = Record [| pcf_attributes; pcf_loc; pcf_desc |]
       } ->
@@ -1903,7 +1903,7 @@ module Class_structure = struct
     create ~pcstr_fields ~pcstr_self
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_structure"
       ; data = Record [| pcstr_fields; pcstr_self |]
       } ->
@@ -2033,7 +2033,7 @@ module Class_expr_desc = struct
       pcl_constr x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_expr_desc"; data } ->
       begin
         match data with
@@ -2117,7 +2117,7 @@ module Class_expr = struct
     create ~pcl_attributes ~pcl_loc ~pcl_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_expr"
       ; data = Record [| pcl_attributes; pcl_loc; pcl_desc |]
       } ->
@@ -2152,7 +2152,7 @@ module Class_type_declaration = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type_declaration"; data } -> Data.to_node data
     | _ -> None
 
@@ -2180,7 +2180,7 @@ module Class_description = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_description"; data } -> Data.to_node data
     | _ -> None
 
@@ -2224,7 +2224,7 @@ module Class_infos = struct
     create ~pci_attributes ~pci_loc ~pci_expr ~pci_name ~pci_params ~pci_virt
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_infos"
       ; data = Record [| pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt |]
       } ->
@@ -2326,7 +2326,7 @@ module Class_type_field_desc = struct
       pctf_inherit x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type_field_desc"; data } ->
       begin
         match data with
@@ -2392,7 +2392,7 @@ module Class_type_field = struct
     create ~pctf_attributes ~pctf_loc ~pctf_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type_field"
       ; data = Record [| pctf_attributes; pctf_loc; pctf_desc |]
       } ->
@@ -2435,7 +2435,7 @@ module Class_signature = struct
     create ~pcsig_fields ~pcsig_self
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_signature"
       ; data = Record [| pcsig_fields; pcsig_self |]
       } ->
@@ -2527,7 +2527,7 @@ module Class_type_desc = struct
       pcty_constr x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type_desc"; data } ->
       begin
         match data with
@@ -2594,7 +2594,7 @@ module Class_type = struct
     create ~pcty_attributes ~pcty_loc ~pcty_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type"
       ; data = Record [| pcty_attributes; pcty_loc; pcty_desc |]
       } ->
@@ -2650,7 +2650,7 @@ module Extension_constructor_kind = struct
       pext_decl x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "extension_constructor_kind"; data } ->
       begin
         match data with
@@ -2703,7 +2703,7 @@ module Extension_constructor = struct
     create ~pext_attributes ~pext_loc ~pext_kind ~pext_name
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "extension_constructor"
       ; data = Record [| pext_attributes; pext_loc; pext_kind; pext_name |]
       } ->
@@ -2753,7 +2753,7 @@ module Type_extension = struct
     create ~ptyext_attributes ~ptyext_private ~ptyext_constructors ~ptyext_params ~ptyext_path
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "type_extension"
       ; data = Record [| ptyext_attributes; ptyext_private; ptyext_constructors; ptyext_params; ptyext_path |]
       } ->
@@ -2810,7 +2810,7 @@ module Constructor_arguments = struct
       pcstr_tuple x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "constructor_arguments"; data } ->
       begin
         match data with
@@ -2864,7 +2864,7 @@ module Constructor_declaration = struct
     create ~pcd_attributes ~pcd_loc ~pcd_res ~pcd_args ~pcd_name
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "constructor_declaration"
       ; data = Record [| pcd_attributes; pcd_loc; pcd_res; pcd_args; pcd_name |]
       } ->
@@ -2915,7 +2915,7 @@ module Label_declaration = struct
     create ~pld_attributes ~pld_loc ~pld_type ~pld_mutable ~pld_name
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "label_declaration"
       ; data = Record [| pld_attributes; pld_loc; pld_type; pld_mutable; pld_name |]
       } ->
@@ -2980,7 +2980,7 @@ module Type_kind = struct
     | Ptype_abstract -> ptype_abstract
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "type_kind"; data } ->
       begin
         match data with
@@ -3042,7 +3042,7 @@ module Type_declaration = struct
     create ~ptype_loc ~ptype_attributes ~ptype_manifest ~ptype_private ~ptype_kind ~ptype_cstrs ~ptype_params ~ptype_name
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "type_declaration"
       ; data = Record [| ptype_loc; ptype_attributes; ptype_manifest; ptype_private; ptype_kind; ptype_cstrs; ptype_params; ptype_name |]
       } ->
@@ -3096,7 +3096,7 @@ module Value_description = struct
     create ~pval_loc ~pval_attributes ~pval_prim ~pval_type ~pval_name
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "value_description"
       ; data = Record [| pval_loc; pval_attributes; pval_prim; pval_type; pval_name |]
       } ->
@@ -3143,7 +3143,7 @@ module Case = struct
     create ~pc_rhs ~pc_guard ~pc_lhs
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "case"
       ; data = Record [| pc_rhs; pc_guard; pc_lhs |]
       } ->
@@ -3599,7 +3599,7 @@ module Expression_desc = struct
       pexp_ident x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "expression_desc"; data } ->
       begin
         match data with
@@ -3816,7 +3816,7 @@ module Expression = struct
     create ~pexp_attributes ~pexp_loc ~pexp_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "expression"
       ; data = Record [| pexp_attributes; pexp_loc; pexp_desc |]
       } ->
@@ -4048,7 +4048,7 @@ module Pattern_desc = struct
     | Ppat_any -> ppat_any
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "pattern_desc"; data } ->
       begin
         match data with
@@ -4167,7 +4167,7 @@ module Pattern = struct
     create ~ppat_attributes ~ppat_loc ~ppat_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "pattern"
       ; data = Record [| ppat_attributes; ppat_loc; ppat_desc |]
       } ->
@@ -4224,7 +4224,7 @@ module Object_field = struct
       otag x1 x2 x3
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "object_field"; data } ->
       begin
         match data with
@@ -4289,7 +4289,7 @@ module Row_field = struct
       rtag x1 x2 x3 x4
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "row_field"; data } ->
       begin
         match data with
@@ -4332,7 +4332,7 @@ module Package_type = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) ~f2:Data.to_node) data
     | _ -> None
 
@@ -4492,7 +4492,7 @@ module Core_type_desc = struct
     | Ptyp_any -> ptyp_any
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "core_type_desc"; data } ->
       begin
         match data with
@@ -4588,7 +4588,7 @@ module Core_type = struct
     create ~ptyp_attributes ~ptyp_loc ~ptyp_desc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "core_type"
       ; data = Record [| ptyp_attributes; ptyp_loc; ptyp_desc |]
       } ->
@@ -4666,7 +4666,7 @@ module Payload = struct
       pstr x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "payload"; data } ->
       begin
         match data with
@@ -4715,7 +4715,7 @@ module Attributes = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "attributes"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
@@ -4743,7 +4743,7 @@ module Extension = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "extension"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_string)) data
     | _ -> None
 
@@ -4771,7 +4771,7 @@ module Attribute = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "attribute"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_string)) data
     | _ -> None
 
@@ -4844,7 +4844,7 @@ module Constant = struct
       pconst_integer x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "constant"; data } ->
       begin
         match data with
@@ -4905,7 +4905,7 @@ module Variance = struct
     | Covariant -> covariant
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "variance"; data } ->
       begin
         match data with
@@ -4964,7 +4964,7 @@ module Arg_label = struct
     | Nolabel -> nolabel
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "arg_label"; data } ->
       begin
         match data with
@@ -5011,7 +5011,7 @@ module Closed_flag = struct
     | Closed -> closed
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "closed_flag"; data } ->
       begin
         match data with
@@ -5051,7 +5051,7 @@ module Override_flag = struct
     | Override -> override
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "override_flag"; data } ->
       begin
         match data with
@@ -5091,7 +5091,7 @@ module Virtual_flag = struct
     | Virtual -> virtual_
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "virtual_flag"; data } ->
       begin
         match data with
@@ -5131,7 +5131,7 @@ module Mutable_flag = struct
     | Immutable -> immutable
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "mutable_flag"; data } ->
       begin
         match data with
@@ -5171,7 +5171,7 @@ module Private_flag = struct
     | Private -> private_
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "private_flag"; data } ->
       begin
         match data with
@@ -5211,7 +5211,7 @@ module Direction_flag = struct
     | Upto -> upto
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "direction_flag"; data } ->
       begin
         match data with
@@ -5251,7 +5251,7 @@ module Rec_flag = struct
     | Nonrecursive -> nonrecursive
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "rec_flag"; data } ->
       begin
         match data with
@@ -5285,7 +5285,7 @@ module Longident_loc = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
     | _ -> None
 
@@ -5346,7 +5346,7 @@ module Longident = struct
       lident x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "longident"; data } ->
       begin
         match data with

--- a/ast/version_v4_07.ml
+++ b/ast/version_v4_07.ml
@@ -3,7 +3,7 @@ open Unversioned.Types
 
 (*$ Ppx_ast_cinaps.print_version_ml (Astlib.Version.of_string "v4_07") *)
 let version = Astlib.Version.of_string "v4_07"
-let node name data = Unversioned.Private.opaque (Node.of_node ~version { name; data })
+let node name data = Unversioned.Private.opaque (Node.of_ast ~version { name; data })
 
 module Longident = struct
   type t = longident
@@ -50,7 +50,7 @@ module Longident = struct
       lapply x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "longident"; data } ->
       begin
         match data with
@@ -96,7 +96,7 @@ module Longident_loc = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
     | _ -> None
 
@@ -130,7 +130,7 @@ module Rec_flag = struct
     | Recursive -> recursive
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "rec_flag"; data } ->
       begin
         match data with
@@ -170,7 +170,7 @@ module Direction_flag = struct
     | Downto -> downto_
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "direction_flag"; data } ->
       begin
         match data with
@@ -210,7 +210,7 @@ module Private_flag = struct
     | Public -> public
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "private_flag"; data } ->
       begin
         match data with
@@ -250,7 +250,7 @@ module Mutable_flag = struct
     | Mutable -> mutable_
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "mutable_flag"; data } ->
       begin
         match data with
@@ -290,7 +290,7 @@ module Virtual_flag = struct
     | Concrete -> concrete
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "virtual_flag"; data } ->
       begin
         match data with
@@ -330,7 +330,7 @@ module Override_flag = struct
     | Fresh -> fresh
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "override_flag"; data } ->
       begin
         match data with
@@ -370,7 +370,7 @@ module Closed_flag = struct
     | Open -> open_
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "closed_flag"; data } ->
       begin
         match data with
@@ -428,7 +428,7 @@ module Arg_label = struct
       optional x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "arg_label"; data } ->
       begin
         match data with
@@ -479,7 +479,7 @@ module Variance = struct
     | Invariant -> invariant
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "variance"; data } ->
       begin
         match data with
@@ -559,7 +559,7 @@ module Constant = struct
       pconst_float x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "constant"; data } ->
       begin
         match data with
@@ -610,7 +610,7 @@ module Attribute = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "attribute"; data } -> (Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node) data
     | _ -> None
 
@@ -638,7 +638,7 @@ module Extension = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "extension"; data } -> (Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node) data
     | _ -> None
 
@@ -666,7 +666,7 @@ module Attributes = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "attributes"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
@@ -737,7 +737,7 @@ module Payload = struct
       ppat x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "payload"; data } ->
       begin
         match data with
@@ -796,7 +796,7 @@ module Core_type = struct
     create ~ptyp_desc ~ptyp_loc ~ptyp_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "core_type"
       ; data = Record [| ptyp_desc; ptyp_loc; ptyp_attributes |]
       } ->
@@ -963,7 +963,7 @@ module Core_type_desc = struct
       ptyp_extension x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "core_type_desc"; data } ->
       begin
         match data with
@@ -1049,7 +1049,7 @@ module Package_type = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node))) data
     | _ -> None
 
@@ -1100,7 +1100,7 @@ module Row_field = struct
       rinherit x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "row_field"; data } ->
       begin
         match data with
@@ -1165,7 +1165,7 @@ module Object_field = struct
       oinherit x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "object_field"; data } ->
       begin
         match data with
@@ -1217,7 +1217,7 @@ module Pattern = struct
     create ~ppat_desc ~ppat_loc ~ppat_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "pattern"
       ; data = Record [| ppat_desc; ppat_loc; ppat_attributes |]
       } ->
@@ -1449,7 +1449,7 @@ module Pattern_desc = struct
       ppat_open x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "pattern_desc"; data } ->
       begin
         match data with
@@ -1568,7 +1568,7 @@ module Expression = struct
     create ~pexp_desc ~pexp_loc ~pexp_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "expression"
       ; data = Record [| pexp_desc; pexp_loc; pexp_attributes |]
       } ->
@@ -2024,7 +2024,7 @@ module Expression_desc = struct
     | Pexp_unreachable -> pexp_unreachable
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "expression_desc"; data } ->
       begin
         match data with
@@ -2241,7 +2241,7 @@ module Case = struct
     create ~pc_lhs ~pc_guard ~pc_rhs
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "case"
       ; data = Record [| pc_lhs; pc_guard; pc_rhs |]
       } ->
@@ -2290,7 +2290,7 @@ module Value_description = struct
     create ~pval_name ~pval_type ~pval_prim ~pval_attributes ~pval_loc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "value_description"
       ; data = Record [| pval_name; pval_type; pval_prim; pval_attributes; pval_loc |]
       } ->
@@ -2347,7 +2347,7 @@ module Type_declaration = struct
     create ~ptype_name ~ptype_params ~ptype_cstrs ~ptype_kind ~ptype_private ~ptype_manifest ~ptype_attributes ~ptype_loc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "type_declaration"
       ; data = Record [| ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc |]
       } ->
@@ -2415,7 +2415,7 @@ module Type_kind = struct
     | Ptype_open -> ptype_open
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "type_kind"; data } ->
       begin
         match data with
@@ -2471,7 +2471,7 @@ module Label_declaration = struct
     create ~pld_name ~pld_mutable ~pld_type ~pld_loc ~pld_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "label_declaration"
       ; data = Record [| pld_name; pld_mutable; pld_type; pld_loc; pld_attributes |]
       } ->
@@ -2522,7 +2522,7 @@ module Constructor_declaration = struct
     create ~pcd_name ~pcd_args ~pcd_res ~pcd_loc ~pcd_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "constructor_declaration"
       ; data = Record [| pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes |]
       } ->
@@ -2579,7 +2579,7 @@ module Constructor_arguments = struct
       pcstr_record x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "constructor_arguments"; data } ->
       begin
         match data with
@@ -2633,7 +2633,7 @@ module Type_extension = struct
     create ~ptyext_path ~ptyext_params ~ptyext_constructors ~ptyext_private ~ptyext_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "type_extension"
       ; data = Record [| ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes |]
       } ->
@@ -2682,7 +2682,7 @@ module Extension_constructor = struct
     create ~pext_name ~pext_kind ~pext_loc ~pext_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "extension_constructor"
       ; data = Record [| pext_name; pext_kind; pext_loc; pext_attributes |]
       } ->
@@ -2739,7 +2739,7 @@ module Extension_constructor_kind = struct
       pext_rebind x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "extension_constructor_kind"; data } ->
       begin
         match data with
@@ -2790,7 +2790,7 @@ module Class_type = struct
     create ~pcty_desc ~pcty_loc ~pcty_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type"
       ; data = Record [| pcty_desc; pcty_loc; pcty_attributes |]
       } ->
@@ -2883,7 +2883,7 @@ module Class_type_desc = struct
       pcty_open x1 x2 x3
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type_desc"; data } ->
       begin
         match data with
@@ -2948,7 +2948,7 @@ module Class_signature = struct
     create ~pcsig_self ~pcsig_fields
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_signature"
       ; data = Record [| pcsig_self; pcsig_fields |]
       } ->
@@ -2992,7 +2992,7 @@ module Class_type_field = struct
     create ~pctf_desc ~pctf_loc ~pctf_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type_field"
       ; data = Record [| pctf_desc; pctf_loc; pctf_attributes |]
       } ->
@@ -3091,7 +3091,7 @@ module Class_type_field_desc = struct
       pctf_extension x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type_field_desc"; data } ->
       begin
         match data with
@@ -3163,7 +3163,7 @@ module Class_infos = struct
     create ~pci_virt ~pci_params ~pci_name ~pci_expr ~pci_loc ~pci_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_infos"
       ; data = Record [| pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes |]
       } ->
@@ -3201,7 +3201,7 @@ module Class_description = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_description"; data } -> Data.to_node data
     | _ -> None
 
@@ -3229,7 +3229,7 @@ module Class_type_declaration = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_type_declaration"; data } -> Data.to_node data
     | _ -> None
 
@@ -3267,7 +3267,7 @@ module Class_expr = struct
     create ~pcl_desc ~pcl_loc ~pcl_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_expr"
       ; data = Record [| pcl_desc; pcl_loc; pcl_attributes |]
       } ->
@@ -3398,7 +3398,7 @@ module Class_expr_desc = struct
       pcl_open x1 x2 x3
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_expr_desc"; data } ->
       begin
         match data with
@@ -3480,7 +3480,7 @@ module Class_structure = struct
     create ~pcstr_self ~pcstr_fields
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_structure"
       ; data = Record [| pcstr_self; pcstr_fields |]
       } ->
@@ -3524,7 +3524,7 @@ module Class_field = struct
     create ~pcf_desc ~pcf_loc ~pcf_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_field"
       ; data = Record [| pcf_desc; pcf_loc; pcf_attributes |]
       } ->
@@ -3636,7 +3636,7 @@ module Class_field_desc = struct
       pcf_extension x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_field_desc"; data } ->
       begin
         match data with
@@ -3719,7 +3719,7 @@ module Class_field_kind = struct
       cfk_concrete x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_field_kind"; data } ->
       begin
         match data with
@@ -3760,7 +3760,7 @@ module Class_declaration = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "class_declaration"; data } -> Data.to_node data
     | _ -> None
 
@@ -3798,7 +3798,7 @@ module Module_type = struct
     create ~pmty_desc ~pmty_loc ~pmty_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_type"
       ; data = Record [| pmty_desc; pmty_loc; pmty_attributes |]
       } ->
@@ -3911,7 +3911,7 @@ module Module_type_desc = struct
       pmty_alias x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_type_desc"; data } ->
       begin
         match data with
@@ -3974,7 +3974,7 @@ module Signature = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "signature"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
@@ -4010,7 +4010,7 @@ module Signature_item = struct
     create ~psig_desc ~psig_loc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "signature_item"
       ; data = Record [| psig_desc; psig_loc |]
       } ->
@@ -4187,7 +4187,7 @@ module Signature_item_desc = struct
       psig_extension x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "signature_item_desc"; data } ->
       begin
         match data with
@@ -4285,7 +4285,7 @@ module Module_declaration = struct
     create ~pmd_name ~pmd_type ~pmd_attributes ~pmd_loc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_declaration"
       ; data = Record [| pmd_name; pmd_type; pmd_attributes; pmd_loc |]
       } ->
@@ -4333,7 +4333,7 @@ module Module_type_declaration = struct
     create ~pmtd_name ~pmtd_type ~pmtd_attributes ~pmtd_loc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_type_declaration"
       ; data = Record [| pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc |]
       } ->
@@ -4381,7 +4381,7 @@ module Open_description = struct
     create ~popen_lid ~popen_override ~popen_loc ~popen_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "open_description"
       ; data = Record [| popen_lid; popen_override; popen_loc; popen_attributes |]
       } ->
@@ -4427,7 +4427,7 @@ module Include_infos = struct
     create ~pincl_mod ~pincl_loc ~pincl_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "include_infos"
       ; data = Record [| pincl_mod; pincl_loc; pincl_attributes |]
       } ->
@@ -4462,7 +4462,7 @@ module Include_description = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "include_description"; data } -> Data.to_node data
     | _ -> None
 
@@ -4490,7 +4490,7 @@ module Include_declaration = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "include_declaration"; data } -> Data.to_node data
     | _ -> None
 
@@ -4564,7 +4564,7 @@ module With_constraint = struct
       pwith_modsubst x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "with_constraint"; data } ->
       begin
         match data with
@@ -4626,7 +4626,7 @@ module Module_expr = struct
     create ~pmod_desc ~pmod_loc ~pmod_attributes
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_expr"
       ; data = Record [| pmod_desc; pmod_loc; pmod_attributes |]
       } ->
@@ -4740,7 +4740,7 @@ module Module_expr_desc = struct
       pmod_extension x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_expr_desc"; data } ->
       begin
         match data with
@@ -4804,7 +4804,7 @@ module Structure = struct
   let of_concrete = create
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "structure"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
@@ -4840,7 +4840,7 @@ module Structure_item = struct
     create ~pstr_desc ~pstr_loc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "structure_item"
       ; data = Record [| pstr_desc; pstr_loc |]
       } ->
@@ -5041,7 +5041,7 @@ module Structure_item_desc = struct
       pstr_extension x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "structure_item_desc"; data } ->
       begin
         match data with
@@ -5149,7 +5149,7 @@ module Value_binding = struct
     create ~pvb_pat ~pvb_expr ~pvb_attributes ~pvb_loc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "value_binding"
       ; data = Record [| pvb_pat; pvb_expr; pvb_attributes; pvb_loc |]
       } ->
@@ -5197,7 +5197,7 @@ module Module_binding = struct
     create ~pmb_name ~pmb_expr ~pmb_attributes ~pmb_loc
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "module_binding"
       ; data = Record [| pmb_name; pmb_expr; pmb_attributes; pmb_loc |]
       } ->
@@ -5254,7 +5254,7 @@ module Toplevel_phrase = struct
       ptop_dir x1 x2
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "toplevel_phrase"; data } ->
       begin
         match data with
@@ -5342,7 +5342,7 @@ module Directive_argument = struct
       pdir_bool x1
 
   let to_concrete_opt t =
-    match Node.to_node (Unversioned.Private.transparent t) ~version with
+    match Node.to_ast (Unversioned.Private.transparent t) ~version with
     | { name = "directive_argument"; data } ->
       begin
         match data with

--- a/astlib/ast.ml
+++ b/astlib/ast.ml
@@ -10,20 +10,20 @@
 
     Record and variant arguments are stored without names, so that the runtime cost of
     named fields is no higher than the cost of unnamed fields (e.g., tuples). *)
-type 'a data =
-  | Node of 'a
+type 'node data =
+  | Node of 'node
   | Bool of bool
   | Char of char
   | Int of int
   | String of string
   | Location of Location.t
-  | Loc of 'a data Loc.t
-  | List of 'a data list
-  | Option of 'a data option
-  | Tuple of 'a data array
-  | Record of 'a data array
-  | Variant of { tag : string; args : 'a data array }
+  | Loc of 'node data Loc.t
+  | List of 'node data list
+  | Option of 'node data option
+  | Tuple of 'node data array
+  | Record of 'node data array
+  | Variant of { tag : string; args : 'node data array }
 
 (** Represents an AST node. The [name] field specifies the name of the type in the AST's
     grammar, such as "expression" or "pattern". *)
-type 'a node = { name : string; data : 'a data }
+type 'node t = { name : string; data : 'node data }

--- a/astlib/history.ml
+++ b/astlib/history.ml
@@ -1,10 +1,10 @@
 open StdLabels
 
 type 'a conversion_function
-  =  'a Ast.node
-  -> to_node:('a -> version:Version.t -> 'a Ast.node)
-  -> of_node:('a Ast.node -> version:Version.t -> 'a)
-  -> 'a Ast.node
+  =  'a Ast.t
+  -> to_ast:('a -> version:Version.t -> 'a Ast.t)
+  -> of_ast:('a Ast.t -> version:Version.t -> 'a)
+  -> 'a Ast.t
 
 type conversion =
   { src_version : Version.t
@@ -97,22 +97,22 @@ let create ~versioned_grammars ~conversions =
 let versioned_grammars t =
   Array.to_list (Array.map2 t.versions t.grammars ~f:(fun v g -> v, g))
 
-let convert t node ~src_version ~dst_version ~to_node ~of_node =
+let convert t ast ~src_version ~dst_version ~to_ast ~of_ast =
   let src_index = version_index t ~version:src_version in
   let dst_index = version_index t ~version:dst_version in
   if src_index < dst_index
   then (
-    let node = ref node in
+    let ast = ref ast in
     for index = src_index to dst_index - 1 do
-      node := t.to_nexts.(index).f !node ~to_node ~of_node
+      ast := t.to_nexts.(index).f !ast ~to_ast ~of_ast
     done;
-    !node)
+    !ast)
   else if src_index > dst_index
   then (
-    let node = ref node in
+    let ast = ref ast in
     for index = src_index - 1 downto dst_index do
-      node := t.of_nexts.(index).f !node ~to_node ~of_node
+      ast := t.of_nexts.(index).f !ast ~to_ast ~of_ast
     done;
-    !node)
+    !ast)
   else
-    node
+    ast

--- a/astlib/history.mli
+++ b/astlib/history.mli
@@ -8,29 +8,29 @@ val versioned_grammars : t -> (Version.t * Grammar.t) list
     such version in the history. *)
 val find_grammar : t -> version:Version.t -> Grammar.t
 
-(** Converts the given AST node from [src_version]'s grammar to [dst_version]'s grammar,
-    using the conversion functions stored in [t]. Converts ['a] to traverse and/or
-    construct subnodes using [to_node] and [of_node], which may themselves call
-    [convert] as appropriate. *)
+(** Converts the given AST from [src_version]'s grammar to [dst_version]'s grammar, using
+    the conversion functions stored in [t]. Converts ['node] to traverse and/or construct
+    subtrees using [to_ast] and [of_ast], which may themselves call [convert] as
+    appropriate. *)
 val convert
   :  t
-  -> 'a Ast.node
+  -> 'node Ast.t
   -> src_version:Version.t
   -> dst_version:Version.t
-  -> to_node:('a -> version:Version.t -> 'a Ast.node)
-  -> of_node:('a Ast.node -> version:Version.t -> 'a)
-  -> 'a Ast.node
+  -> to_ast:('node -> version:Version.t -> 'node Ast.t)
+  -> of_ast:('node Ast.t -> version:Version.t -> 'node)
+  -> 'node Ast.t
 
-type 'a conversion_function
-  = 'a Ast.node
-  -> to_node:('a -> version:Version.t -> 'a Ast.node)
-  -> of_node:('a Ast.node -> version:Version.t -> 'a)
-  -> 'a Ast.node
+type 'node conversion_function
+  = 'node Ast.t
+  -> to_ast:('node -> version:Version.t -> 'node Ast.t)
+  -> of_ast:('node Ast.t -> version:Version.t -> 'node)
+  -> 'node Ast.t
 
 type conversion =
   { src_version : Version.t
   ; dst_version : Version.t
-  ; f : 'a . 'a conversion_function
+  ; f : 'node . 'node conversion_function
   }
 
 (** It is expected that [versioned_grammars] are provided consecutively in order, and that

--- a/astlib/unstable_for_testing.ml
+++ b/astlib/unstable_for_testing.ml
@@ -71,19 +71,19 @@ and update_array array =
   Array.init len ~f:(fun i ->
     update_data array.(len - i - 1))
 
-let update_node (node : _ Ast.node) =
-  { node with data = update_data node.data }
+let update_ast (ast : _ Ast.t) =
+  { ast with data = update_data ast.data }
 
 let to_stable : History.conversion =
   { src_version = version
   ; dst_version = Stable.version
-  ; f = fun node ~to_node:_ ~of_node:_ -> update_node node
+  ; f = fun ast ~to_ast:_ ~of_ast:_ -> update_ast ast
   }
 
 let of_stable : History.conversion =
   { src_version = Stable.version
   ; dst_version = version
-  ; f = fun node ~to_node:_ ~of_node:_ -> update_node node
+  ; f = fun ast ~to_ast:_ ~of_ast:_ -> update_ast ast
   }
 
 let conversions = [ to_stable; of_stable ]


### PR DESCRIPTION
In the parent, we have `'a Ast.node` containing `'a Ast.data` with `Node of 'a`, making it unclear whether "node" refers to `'a` or `_ Ast.node`.

In this PR, we have `'node Ast.t` containing `'node Ast.t` with `Node of 'node`. Now it is clear that "node" refers to values of type `'node` and "ast" refers to values of type `_ Ast.t`.