### PR TITLE
Add tests for astlib history conversion functionality.

### DIFF
--- a/astlib/base/ast.ml
+++ b/astlib/base/ast.ml
@@ -1,0 +1,255 @@
+open! Base
+
+type 'node data = 'node Astlib.Ast.data =
+  | Node of 'node
+  | Bool of bool
+  | Char of char
+  | Int of int
+  | String of string
+  | Location of Location.t
+  | Loc of 'node data Loc.t
+  | List of 'node data list
+  | Option of 'node data option
+  | Tuple of 'node data array
+  | Record of 'node data array
+  | Variant of { tag : string; args : 'node data array }
+[@@deriving compare, equal, sexp_of]
+
+type 'node t = 'node Astlib.Ast.t = { name : string; data : 'node data }
+[@@deriving compare, equal, sexp_of]
+
+let rec matches node ~grammar ~to_ast =
+  let ast : _ t = to_ast node in
+  match Grammar.lookup_mono grammar ~name:ast.name with
+  | Some decl -> data_matches_decl ast.data ~decl ~grammar ~to_ast
+  | None -> false
+
+and matches_instance node ~args ~grammar ~to_ast =
+  let ast : _ t = to_ast node in
+  match Grammar.lookup_instance grammar ~name:ast.name ~args with
+  | Some decl -> data_matches_decl ast.data ~decl ~grammar ~to_ast
+  | None -> false
+
+and data_matches_decl data ~decl ~grammar ~to_ast =
+  match decl with
+  | Ty ty -> data_matches_ty data ~ty ~grammar ~to_ast
+  | Record record -> data_matches_record data ~record ~grammar ~to_ast
+  | Variant variant -> data_matches_variant data ~variant ~grammar ~to_ast
+
+and data_matches_variant data ~variant ~grammar ~to_ast =
+  match data with
+  | Variant { tag; args } ->
+    (match List.Assoc.find variant tag ~equal:String.equal with
+     | None -> false
+     | Some clause -> array_matches_clause args ~clause ~grammar ~to_ast)
+  | _ -> false
+
+and data_matches_record data ~record ~grammar ~to_ast =
+  match data with
+  | Record fields -> array_matches_record fields ~record ~grammar ~to_ast
+  | _ -> false
+
+and array_matches_clause array ~clause ~grammar ~to_ast =
+  match clause with
+  | Empty -> Array.is_empty array
+  | Tuple tuple -> array_matches_tuple array ~tuple ~grammar ~to_ast
+  | Record record -> array_matches_record array ~record ~grammar ~to_ast
+
+and array_matches_record array ~record ~grammar ~to_ast =
+  Array.length array = List.length record
+  && List.for_alli record ~f:(fun i (_, ty) ->
+    data_matches_ty array.(i) ~ty ~grammar ~to_ast)
+
+and array_matches_tuple array ~tuple ~grammar ~to_ast =
+  Array.length array = List.length tuple
+  && List.for_alli tuple ~f:(fun i ty ->
+    data_matches_ty array.(i) ~ty ~grammar ~to_ast)
+
+and data_matches_ty data ~ty ~grammar ~to_ast =
+  match ty with
+  | Var _ -> (* type should be monomorphic *) assert false
+  | Name name -> data_matches_name data ~name ~grammar ~to_ast
+  | Bool -> data_matches_bool data
+  | Char -> data_matches_char data
+  | Int -> data_matches_int data
+  | String -> data_matches_string data
+  | Location -> data_matches_location data
+  | Loc ty -> data_matches_loc data ~ty ~grammar ~to_ast
+  | List ty -> data_matches_list data ~ty ~grammar ~to_ast
+  | Option ty -> data_matches_option data ~ty ~grammar ~to_ast
+  | Tuple tuple -> data_matches_tuple data ~tuple ~grammar ~to_ast
+  | Instance (name, args) -> data_matches_instance data ~name ~args ~grammar ~to_ast
+
+and data_matches_name data ~name ~grammar ~to_ast =
+  match data with
+  | Node node ->
+    let ast : _ t = to_ast node in
+    String.equal ast.name name && matches node ~grammar ~to_ast
+  | _ -> false
+
+and data_matches_bool     = function Bool     _ -> true | _ -> false
+and data_matches_char     = function Char     _ -> true | _ -> false
+and data_matches_int      = function Int      _ -> true | _ -> false
+and data_matches_string   = function String   _ -> true | _ -> false
+and data_matches_location = function Location _ -> true | _ -> false
+
+and data_matches_loc data ~ty ~grammar ~to_ast =
+  match data with
+  | Loc loc -> data_matches_ty loc.txt ~ty ~grammar ~to_ast
+  | _ -> false
+
+and data_matches_list data ~ty ~grammar ~to_ast =
+  match data with
+  | List list -> List.for_all list ~f:(data_matches_ty ~ty ~grammar ~to_ast)
+  | _ -> false
+
+and data_matches_option data ~ty ~grammar ~to_ast =
+  match data with
+  | Option option -> Option.for_all option ~f:(data_matches_ty ~ty ~grammar ~to_ast)
+  | _ -> false
+
+and data_matches_tuple data ~tuple ~grammar ~to_ast =
+  match data with
+  | Tuple values -> array_matches_tuple values ~tuple ~grammar ~to_ast
+  | _ -> false
+
+and data_matches_instance data ~name ~args ~grammar ~to_ast =
+  match data with
+  | Node node ->
+    String.equal (to_ast node).name name && matches_instance node ~args ~grammar ~to_ast
+  | _ -> false
+
+let delay_generator f =
+  Base_quickcheck.Generator.create (fun ~size ~random ->
+    Base_quickcheck.Generator.generate (f ()) ~size ~random)
+
+let rec generator_of_name name ~grammar ~of_ast =
+  match Grammar.lookup_mono grammar ~name with
+  | Some decl -> generator_of_decl decl ~name ~grammar ~of_ast
+  | None -> assert false
+
+and generator_of_decl decl ~name ~grammar ~of_ast =
+  Base_quickcheck.Generator.map
+    ~f:(fun data -> of_ast { data; name })
+    (data_generator_of_decl decl ~grammar ~of_ast)
+
+and data_generator_of_decl decl ~grammar ~of_ast =
+  match (decl : Grammar.decl) with
+  | Ty ty -> data_generator_of_ty ty ~grammar ~of_ast
+  | Record record -> data_generator_of_record record ~grammar ~of_ast
+  | Variant variant -> data_generator_of_variant variant ~grammar ~of_ast
+
+and data_generator_of_variant variant ~grammar ~of_ast =
+  Base_quickcheck.Generator.weighted_union
+    (List.map variant ~f:(fun (tag, clause) ->
+       let weight = 1. /. Float.of_int (1 + Grammar.count_recursions_in_clause clause) in
+       let gen =
+         delay_generator (fun () ->
+           data_generator_of_clause clause ~tag ~grammar ~of_ast)
+       in
+       weight, gen))
+
+and data_generator_of_clause clause ~tag ~grammar ~of_ast =
+  Base_quickcheck.Generator.map
+    ~f:(fun args -> (Variant { tag; args }))
+    (array_generator_of_clause clause ~grammar ~of_ast)
+
+and data_generator_of_record record ~grammar ~of_ast =
+  Base_quickcheck.Generator.map
+    ~f:(fun fields -> (Record fields))
+    (array_generator_of_record record ~grammar ~of_ast)
+
+and array_generator_of_clause clause ~grammar ~of_ast =
+  match clause with
+  | Empty -> Base_quickcheck.Generator.return [||]
+  | Tuple tuple -> array_generator_of_tuple tuple ~grammar ~of_ast
+  | Record record -> array_generator_of_record record ~grammar ~of_ast
+
+and array_generator_of_record record ~grammar ~of_ast =
+  Base_quickcheck.Generator.map ~f:Array.of_list
+    (Base_quickcheck.Generator.all
+       (List.map record ~f:(fun (_, ty) ->
+          data_generator_of_ty ty ~grammar ~of_ast)))
+
+and array_generator_of_tuple tuple ~grammar ~of_ast =
+  Base_quickcheck.Generator.map ~f:Array.of_list
+    (Base_quickcheck.Generator.all
+       (List.map tuple ~f:(fun ty ->
+          data_generator_of_ty ty ~grammar ~of_ast)))
+
+and data_generator_of_ty ty ~grammar ~of_ast =
+  match (ty : Grammar.ty) with
+  | Var _ -> (* should be monomorphic *) assert false
+  | Name name -> data_generator_of_name name ~grammar ~of_ast
+  | Bool -> data_generator_for_bool ()
+  | Char -> data_generator_for_char ()
+  | Int -> data_generator_for_int ()
+  | String -> data_generator_for_string ()
+  | Location -> data_generator_for_location ()
+  | Loc ty -> data_generator_for_loc ty ~grammar ~of_ast
+  | List ty -> data_generator_for_list ty ~grammar ~of_ast
+  | Option ty -> data_generator_for_option ty ~grammar ~of_ast
+  | Tuple tuple -> data_generator_of_tuple tuple ~grammar ~of_ast
+  | Instance (name, args) -> data_generator_of_instance name ~args ~grammar ~of_ast
+
+and data_generator_of_name name ~grammar ~of_ast =
+  Base_quickcheck.Generator.map
+    ~f:(fun node -> Node node)
+    (generator_of_name name ~grammar ~of_ast)
+
+and data_generator_for_bool () =
+  Base_quickcheck.Generator.map
+    Base_quickcheck.Generator.bool
+    ~f:(fun bool -> (Bool bool))
+
+and data_generator_for_char () =
+  Base_quickcheck.Generator.map
+    Base_quickcheck.Generator.char
+    ~f:(fun char -> (Char char))
+
+and data_generator_for_int () =
+  Base_quickcheck.Generator.map
+    Base_quickcheck.Generator.int
+    ~f:(fun int -> (Int int))
+
+and data_generator_for_string () =
+  Base_quickcheck.Generator.map
+    Base_quickcheck.Generator.string
+    ~f:(fun string -> (String string))
+
+and data_generator_for_location () =
+  Base_quickcheck.Generator.return (Location Astlib.Location.none)
+
+and data_generator_for_loc ty ~grammar ~of_ast =
+  Base_quickcheck.Generator.map
+    ~f:(fun txt -> Loc { txt; loc = Astlib.Location.none })
+    (data_generator_of_ty ty ~grammar ~of_ast)
+
+and data_generator_for_list ty ~grammar ~of_ast =
+  Base_quickcheck.Generator.map
+    ~f:(fun list -> List list)
+    (Base_quickcheck.Generator.list (data_generator_of_ty ty ~grammar ~of_ast))
+
+and data_generator_for_option ty ~grammar ~of_ast =
+  Base_quickcheck.Generator.map
+    ~f:(fun option -> Option option)
+    (Base_quickcheck.Generator.option (data_generator_of_ty ty ~grammar ~of_ast))
+
+and data_generator_of_tuple tuple ~grammar ~of_ast =
+  Base_quickcheck.Generator.map
+    ~f:(fun tuple -> Tuple tuple)
+    (array_generator_of_tuple tuple ~grammar ~of_ast)
+
+and data_generator_of_instance name ~args ~grammar ~of_ast =
+  match Grammar.lookup_instance grammar ~name ~args with
+  | Some decl -> data_generator_of_decl decl ~grammar ~of_ast
+  | None -> assert false
+
+let generator grammar ~of_ast =
+  Base_quickcheck.Generator.union
+    (List.filter_map grammar ~f:(fun (name, kind) ->
+       match (kind : Grammar.kind) with
+       | Poly _ -> None
+       | Mono decl ->
+         Some (delay_generator (fun () ->
+           generator_of_decl decl ~name ~grammar ~of_ast))))

--- a/astlib/base/ast.mli
+++ b/astlib/base/ast.mli
@@ -1,0 +1,30 @@
+open! Base
+
+type 'node data = 'node Astlib.Ast.data =
+  | Node of 'node
+  | Bool of bool
+  | Char of char
+  | Int of int
+  | String of string
+  | Location of Location.t
+  | Loc of 'node data Loc.t
+  | List of 'node data list
+  | Option of 'node data option
+  | Tuple of 'node data array
+  | Record of 'node data array
+  | Variant of { tag : string; args : 'node data array }
+[@@deriving compare, equal, sexp_of]
+
+type 'node t = 'node Astlib.Ast.t = { name : string; data : 'node data }
+[@@deriving compare, equal, sexp_of]
+
+val matches
+  :  'node
+  -> grammar:Grammar.t
+  -> to_ast:('node -> 'node t)
+  -> bool
+
+val generator
+  :  Grammar.t
+  -> of_ast:('node t -> 'node)
+  -> 'node Base_quickcheck.Generator.t

--- a/astlib/base/astlib_base.ml
+++ b/astlib/base/astlib_base.ml
@@ -1,0 +1,6 @@
+module Ast = Ast
+module Grammar = Grammar
+module Loc = Loc
+module Location = Location
+module Position = Position
+module Version = Version

--- a/astlib/base/dune
+++ b/astlib/base/dune
@@ -1,0 +1,5 @@
+(library
+ (name astlib_base)
+ (libraries astlib base base_quickcheck)
+ (preprocess (pps ppx_base))
+ (flags (:standard -safe-string)))

--- a/astlib/base/grammar.ml
+++ b/astlib/base/grammar.ml
@@ -1,0 +1,130 @@
+open! Base
+
+type ty = Astlib.Grammar.ty =
+  | Var of string
+  | Name of string
+  | Bool
+  | Char
+  | Int
+  | String
+  | Location
+  | Loc of ty
+  | List of ty
+  | Option of ty
+  | Tuple of tuple
+  | Instance of string * targ list
+
+and tuple = ty list
+
+and targ = Astlib.Grammar.targ =
+  | Tname of string
+  | Tvar of string
+[@@deriving compare, equal, hash, sexp_of]
+
+type record = (string * ty) list
+[@@deriving compare, equal, hash, sexp_of]
+
+type clause = Astlib.Grammar.clause =
+  | Empty
+  | Tuple of tuple
+  | Record of record
+[@@deriving compare, equal, hash, sexp_of]
+
+type variant = (string * clause) list
+[@@deriving compare, equal, hash, sexp_of]
+
+type decl = Astlib.Grammar.decl =
+  | Ty of ty
+  | Record of record
+  | Variant of variant
+[@@deriving compare, equal, hash, sexp_of]
+
+type kind = Astlib.Grammar.kind =
+  | Mono of decl
+  | Poly of string list * decl
+[@@deriving compare, equal, hash, sexp_of]
+
+type t = (string * kind) list
+[@@deriving compare, equal, hash, sexp_of]
+
+let rec count_recursions_in_ty = function
+  | Name _ | Instance _ -> 1
+  | Var _ | Bool | Char | Int | String | Location -> 0
+  | Loc ty | List ty | Option ty -> count_recursions_in_ty ty
+  | Tuple tuple -> count_recursions_in_tuple tuple
+
+and count_recursions_in_tuple tuple =
+  List.sum (module Int) tuple ~f:count_recursions_in_ty
+
+let count_recursions_in_record record =
+  List.sum (module Int) record ~f:(fun (_, ty) ->
+    count_recursions_in_ty ty)
+
+let count_recursions_in_clause = function
+  | Empty -> 0
+  | Tuple tuple -> count_recursions_in_tuple tuple
+  | Record record -> count_recursions_in_record record
+
+let ty_of_targ targ =
+  match targ with
+  | Tname name -> Name name
+  | Tvar name -> Var name
+
+let rec instantiate_ty ty ~subst =
+  match ty with
+  | Var var -> instantiate_var var ~subst
+  | Name _ | Bool | Char | Int | String | Location -> ty
+  | Loc ty -> Loc (instantiate_ty ty ~subst)
+  | List ty -> List (instantiate_ty ty ~subst)
+  | Option ty -> Option (instantiate_ty ty ~subst)
+  | Tuple tuple -> Tuple (instantiate_tuple tuple ~subst)
+  | Instance (name, targs) -> Instance (name, instantiate_targs targs ~subst)
+
+and instantiate_var var ~subst = ty_of_targ (instantiate_tvar var ~subst)
+
+and instantiate_tuple tuple ~subst = List.map tuple ~f:(instantiate_ty ~subst)
+
+and instantiate_targs targs ~subst = List.map targs ~f:(instantiate_targ ~subst)
+
+and instantiate_targ targ ~subst =
+  match targ with
+  | Tvar tvar -> instantiate_tvar tvar ~subst
+  | Tname _ -> targ
+
+and instantiate_tvar tvar ~subst =
+  match List.Assoc.find subst tvar ~equal:String.equal with
+  | Some targ -> targ
+  | None -> (* we should not have partial instantiations *) assert false
+
+let instantiate_record record ~subst =
+  List.Assoc.map record ~f:(instantiate_ty ~subst)
+
+let instantiate_clause clause ~subst =
+  match clause with
+  | Empty -> Empty
+  | Tuple tuple -> Tuple (instantiate_tuple tuple ~subst)
+  | Record record -> Record (instantiate_record record ~subst)
+
+let instantiate_variant variant ~subst =
+  List.Assoc.map variant ~f:(instantiate_clause ~subst)
+
+let instantiate_decl decl ~subst =
+  match decl with
+  | Ty ty -> Ty (instantiate_ty ty ~subst)
+  | Record record -> Record (instantiate_record record ~subst)
+  | Variant variant -> Variant (instantiate_variant variant ~subst)
+
+let lookup (t : t) ~name = List.Assoc.find t name ~equal:String.equal
+
+let lookup_mono t ~name =
+  match lookup t ~name with
+  | Some (Mono decl) -> Some decl
+  | Some (Poly _) | None -> None
+
+let lookup_instance t ~name ~args =
+  match lookup t ~name with
+  | Some (Poly (vars, decl)) ->
+    (match List.zip vars args with
+     | Ok subst -> Some (instantiate_decl decl ~subst)
+     | Unequal_lengths -> None)
+  | Some (Mono _) | None -> None

--- a/astlib/base/grammar.mli
+++ b/astlib/base/grammar.mli
@@ -1,0 +1,56 @@
+open! Base
+
+type tuple = Astlib.Grammar.tuple
+[@@deriving compare, equal, hash, sexp_of]
+
+type record = Astlib.Grammar.record
+[@@deriving compare, equal, hash, sexp_of]
+
+type variant = Astlib.Grammar.variant
+[@@deriving compare, equal, hash, sexp_of]
+
+type targ = Astlib.Grammar.targ =
+  | Tname of string
+  | Tvar of string
+[@@deriving compare, equal, hash, sexp_of]
+
+type ty = Astlib.Grammar.ty =
+  | Var of string
+  | Name of string
+  | Bool
+  | Char
+  | Int
+  | String
+  | Location
+  | Loc of ty
+  | List of ty
+  | Option of ty
+  | Tuple of tuple
+  | Instance of string * targ list
+[@@deriving compare, equal, hash, sexp_of]
+
+type clause = Astlib.Grammar.clause =
+  | Empty
+  | Tuple of tuple
+  | Record of record
+[@@deriving compare, equal, hash, sexp_of]
+
+type decl = Astlib.Grammar.decl =
+  | Ty of ty
+  | Record of record
+  | Variant of variant
+[@@deriving compare, equal, hash, sexp_of]
+
+type kind = Astlib.Grammar.kind =
+  | Mono of decl
+  | Poly of string list * decl
+[@@deriving compare, equal, hash, sexp_of]
+
+type t = Astlib.Grammar.t
+[@@deriving compare, equal, hash, sexp_of]
+
+val count_recursions_in_clause : clause -> int
+
+val lookup_mono : t -> name:string -> decl option
+
+val lookup_instance : t -> name:string -> args:targ list -> decl option

--- a/astlib/base/loc.ml
+++ b/astlib/base/loc.ml
@@ -1,0 +1,7 @@
+open! Base
+
+type 'a t = 'a Astlib.Loc.t =
+  { txt : 'a
+  ; loc : Location.t
+  }
+[@@deriving compare, equal, hash, sexp_of]

--- a/astlib/base/loc.mli
+++ b/astlib/base/loc.mli
@@ -1,0 +1,7 @@
+open! Base
+
+type 'a t = 'a Astlib.Loc.t =
+  { txt : 'a
+  ; loc : Location.t
+  }
+[@@deriving compare, equal, hash, sexp_of]

--- a/astlib/base/location.ml
+++ b/astlib/base/location.ml
@@ -1,0 +1,8 @@
+open! Base
+
+type t = Astlib.Location.t =
+  { loc_start : Position.t
+  ; loc_end : Position.t
+  ; loc_ghost : bool
+  }
+[@@deriving compare, equal, hash, sexp_of]

--- a/astlib/base/location.mli
+++ b/astlib/base/location.mli
@@ -1,0 +1,8 @@
+open! Base
+
+type t = Astlib.Location.t =
+  { loc_start : Position.t
+  ; loc_end : Position.t
+  ; loc_ghost : bool
+  }
+[@@deriving compare, equal, hash, sexp_of]

--- a/astlib/base/position.ml
+++ b/astlib/base/position.ml
@@ -1,0 +1,9 @@
+open! Base
+
+type t = Astlib.Position.t =
+  { pos_fname : string
+  ; pos_lnum : int
+  ; pos_bol : int
+  ; pos_cnum : int
+  }
+[@@deriving compare, equal, hash, sexp_of]

--- a/astlib/base/position.mli
+++ b/astlib/base/position.mli
@@ -1,0 +1,9 @@
+open! Base
+
+type t = Astlib.Position.t =
+  { pos_fname : string
+  ; pos_lnum : int
+  ; pos_bol : int
+  ; pos_cnum : int
+  }
+[@@deriving compare, equal, hash, sexp_of]

--- a/astlib/base/version.ml
+++ b/astlib/base/version.ml
@@ -1,0 +1,9 @@
+open! Base
+
+type t = Astlib.Version.t
+
+let compare = Comparable.lift String.compare ~f:Astlib.Version.to_string
+let equal = Comparable.lift String.equal ~f:Astlib.Version.to_string
+let sexp_of_t t = Sexp.Atom (Astlib.Version.to_string t)
+let hash t = hash_string (Astlib.Version.to_string t)
+let hash_fold_t hash t = hash_fold_string hash (Astlib.Version.to_string t)

--- a/astlib/base/version.mli
+++ b/astlib/base/version.mli
@@ -1,0 +1,4 @@
+open! Base
+
+type t = Astlib.Version.t
+[@@deriving compare, equal, hash, sexp_of]

--- a/astlib/grammar.ml
+++ b/astlib/grammar.ml
@@ -1,6 +1,6 @@
 (** Compile-time representation of ASTs; i.e., their types.
 
-    Lists in these types are always non-empty Tuples and records always have at least one
+    Lists in these types are always non-empty. Tuples and records always have at least one
     field; AST variants always have at least one clause; polymorphic types always have at
     least one argument. *)
 

--- a/astlib/history.mli
+++ b/astlib/history.mli
@@ -21,6 +21,10 @@ val convert
   -> of_ast:('node Ast.t -> version:Version.t -> 'node)
   -> 'node Ast.t
 
+(**/**)
+
+(** Constructors for internal use and for testing. *)
+
 type 'node conversion_function
   = 'node Ast.t
   -> to_ast:('node -> version:Version.t -> 'node Ast.t)

--- a/astlib/test/dune
+++ b/astlib/test/dune
@@ -1,0 +1,9 @@
+(library
+ (name astlib_tests)
+ (libraries
+  astlib
+  astlib_base
+  expect_test_helpers_kernel.expect_test_helpers_base)
+ (preprocess (pps ppx_base ppx_expect ppx_sexp_value))
+ (flags (:standard -safe-string))
+ (inline_tests))

--- a/astlib/test/test_history.ml
+++ b/astlib/test/test_history.ml
@@ -1,0 +1,181 @@
+open! Base
+open Astlib_base
+
+module Node = struct
+  type t = { ast : t Ast.t } [@@deriving equal, sexp_of]
+
+  let of_ast ast = { ast }
+  let to_ast { ast } = ast
+
+  let matches t ~grammar = Ast.matches t ~grammar ~to_ast
+  let generator grammar = Ast.generator grammar ~of_ast
+  let shrinker = Base_quickcheck.Shrinker.atomic
+end
+
+let v1 = Astlib.Version.of_string "v1"
+let v2 = Astlib.Version.of_string "v2"
+let v3 = Astlib.Version.of_string "v3"
+
+(* simple int exprs: constants and binary addition *)
+let (v1_grammar : Astlib.Grammar.t) = [
+  "expr", Mono (Variant [
+    "int", Tuple [Int];
+    "add", Tuple [Name "expr"; Name "expr"];
+  ]);
+]
+
+(* add variables: new variant that has nothing to down-convert to *)
+let (v2_grammar : Astlib.Grammar.t) = [
+  "expr", Mono (Variant [
+    "var", Tuple [String];
+    "int", Tuple [Int];
+    "add", Tuple [Name "expr"; Name "expr"];
+  ]);
+]
+
+(* change addition to n-ary; down-conversion picks arbitrary tree structure *)
+let (v3_grammar : Astlib.Grammar.t) = [
+  "expr", Mono (Variant [
+    "var", Tuple [String];
+    "int", Tuple [Int];
+    "add", Tuple [List (Name "expr")];
+  ]);
+]
+
+let v2_of_v1 x ~to_ast:_ ~of_ast:_ = x
+let v1_of_v2 x ~to_ast:_ ~of_ast:_ = x
+
+let rec v3_addends_of_v2 ast ~to_ast ~of_ast : _ Ast.data list =
+  match (ast : _ Ast.t) with
+  | { name = "expr"; data = Variant { tag = "add"; args = [| Node x; Node y |] } } ->
+    v3_addends_of_v2 (to_ast x ~version:v2) ~to_ast ~of_ast @
+    v3_addends_of_v2 (to_ast y ~version:v2) ~to_ast ~of_ast
+  | _ -> [ Node (of_ast ast ~version:v3) ]
+
+let v3_of_v2 ast ~to_ast ~of_ast =
+  match v3_addends_of_v2 ast ~to_ast ~of_ast with
+  | [ _ ] -> ast
+  | list -> { name = "expr" ; data = Variant { tag = "add" ; args = [| List list |] } }
+
+let v2_add x y ~of_ast : _ Ast.t =
+  { name = "expr"
+  ; data =
+      Variant
+        { tag = "add"
+        ; args = [| Node (of_ast x ~version:v2); Node (of_ast y ~version:v2) |]
+        }
+  }
+
+let v2_of_v3 ast ~to_ast ~of_ast =
+  match (ast : _ Ast.t) with
+  | { name = "expr"; data = Variant { tag = "add"; args = [| List data |] } } ->
+    (match
+       Option.all (List.map data ~f:(function
+         | Node node -> Some (to_ast node ~version:v3)
+         | _ -> None))
+     with
+     | None -> ast
+     | Some asts ->
+       (match List.reduce asts ~f:(v2_add ~of_ast) with
+        | Some ast -> ast
+        | None -> { name = "expr"; data = Variant { tag = "int"; args = [| Int 0 |] } }))
+  | _ -> ast
+
+let versioned_grammars = [
+  v1, v1_grammar;
+  v2, v2_grammar;
+  v3, v3_grammar;
+]
+
+let conversions : Astlib.History.conversion list = [
+  { src_version = v1; dst_version = v2; f = v2_of_v1 };
+  { src_version = v2; dst_version = v1; f = v1_of_v2 };
+  { src_version = v2; dst_version = v3; f = v3_of_v2 };
+  { src_version = v3; dst_version = v2; f = v2_of_v3 };
+]
+
+let history = Astlib.History.create ~versioned_grammars ~conversions
+
+let%expect_test "generator consistency" =
+  List.iter versioned_grammars ~f:(fun (version, grammar) ->
+    Base_quickcheck.Test.run_exn
+      (module struct
+        type t = Node.t
+        let sexp_of_t = Node.sexp_of_t
+        let quickcheck_generator = Node.generator grammar
+        let quickcheck_shrinker = Node.shrinker
+      end)
+      ~f:(fun node ->
+        if not (Node.matches node ~grammar)
+        then raise_s [%sexp "invalid AST", { version : Version.t }]));
+  [%expect {| |}]
+
+(* Down-conversions can fail. We don't currently have a good way to detect when they do,
+   so we don't have a good invariant to express about them on their own. *)
+let%expect_test "history up-conversions always work" =
+  List.iteri versioned_grammars ~f:(fun src_index (src_version, src_grammar) ->
+    List.iteri versioned_grammars ~f:(fun dst_index (dst_version, dst_grammar) ->
+      if dst_index >= src_index then
+        Base_quickcheck.Test.run_exn
+          (module struct
+            type t = Node.t
+            let sexp_of_t = Node.sexp_of_t
+            let quickcheck_generator = Node.generator src_grammar
+            let quickcheck_shrinker = Node.shrinker
+          end)
+          ~f:(fun src ->
+            let dst =
+              src
+              |> Node.to_ast
+              |> Astlib.History.convert history
+                   ~src_version
+                   ~dst_version
+                   ~to_ast:(fun x ~version:_ -> Node.to_ast x)
+                   ~of_ast:(fun x ~version:_ -> Node.of_ast x)
+              |> Node.of_ast
+            in
+            if not (Node.matches dst ~grammar:dst_grammar) then
+              raise_s
+                [%sexp
+                  "invalid conversion"
+                , { src_version : Version.t; dst_version : Version.t; dst : Node.t }])));
+  [%expect{||}]
+
+(* Round-trips aren't guaranteed to end up at the same AST, case in point, here a tree of
+   addends round-tripping through the list version might come back to a
+   differently-balanced tree. But even with down-conversions that can fail, one should
+   always be able to get back to the original grammar. *)
+let%expect_test "history round-trips always work" =
+  List.iter versioned_grammars ~f:(fun (src_version, src_grammar) ->
+    List.iter versioned_grammars ~f:(fun (dst_version, _) ->
+      Base_quickcheck.Test.run_exn
+        (module struct
+          type t = Node.t
+          let sexp_of_t = Node.sexp_of_t
+          let quickcheck_generator = Node.generator src_grammar
+          let quickcheck_shrinker = Node.shrinker
+        end)
+        ~f:(fun original ->
+          let round_trip =
+            original
+            |> Node.to_ast
+            |> Astlib.History.convert history
+                 ~src_version
+                 ~dst_version
+                 ~to_ast:(fun x ~version:_ -> Node.to_ast x)
+                 ~of_ast:(fun x ~version:_ -> Node.of_ast x)
+            |> Astlib.History.convert history
+                 ~src_version:dst_version
+                 ~dst_version:src_version
+                 ~to_ast:(fun x ~version:_ -> Node.to_ast x)
+                 ~of_ast:(fun x ~version:_ -> Node.of_ast x)
+            |> Node.of_ast
+          in
+          if not (Node.matches round_trip ~grammar:src_grammar) then
+            raise_s
+              [%sexp
+                "round-trip failed"
+              , { src_version : Version.t
+                ; dst_version : Version.t
+                ; round_trip : Node.t }])));
+  [%expect {| |}]

--- a/astlib/test/test_history.mli
+++ b/astlib/test/test_history.mli
@@ -1,0 +1,1 @@
+(*_ This signature is deliberately empty. *)


### PR DESCRIPTION
This doesn't test our actual parsetree history, instead it uses some tiny example grammars to make sure History.t does conversions properly.