### PR TITLE
Partial conversion functions

### DIFF
--- a/ast/cinaps/gen_versions.ml
+++ b/ast/cinaps/gen_versions.ml
@@ -258,7 +258,7 @@ module Structure = struct
       Print.indented (fun () ->
         Print.println
           "match Node.unwrap (Unversioned.Private.transparent t) ~version with";
-        Print.println "| { name = %S; data } -> %s data"
+        Print.println "| Some { name = %S; data } -> %s data"
           node_name
           (ast_to_ty ~grammar ty);
         Print.println "| _ -> None")
@@ -267,7 +267,7 @@ module Structure = struct
       Print.indented (fun () ->
         Print.println
           "match Node.unwrap (Unversioned.Private.transparent t) ~version with";
-        Print.println "| { name = %S" node_name;
+        Print.println "| Some { name = %S" node_name;
         Print.indented (fun () ->
           Print.println "; data = Record [| %s |]"
             (String.concat ~sep:"; "
@@ -284,7 +284,7 @@ module Structure = struct
       Print.indented (fun () ->
         Print.println
           "match Node.unwrap (Unversioned.Private.transparent t) ~version with";
-        Print.println "| { name = %S; data } ->" node_name;
+        Print.println "| Some { name = %S; data } ->" node_name;
         Print.indented (fun () ->
           Print.println "begin";
           Print.indented (fun () ->

--- a/ast/node.ml
+++ b/ast/node.ml
@@ -4,5 +4,14 @@ let version t = t.version
 
 let wrap ~version ast = { version; ast }
 
-let rec unwrap ~version:dst_version { ast; version = src_version } =
-  Astlib.History.convert Astlib.history ast ~src_version ~dst_version ~unwrap ~wrap
+let rec convert ~version:dst_version { ast; version = src_version } =
+  let version, ast =
+    Astlib.History.convert Astlib.history ast ~src_version ~dst_version ~unwrap ~wrap
+  in
+  { version; ast }
+
+and unwrap ~version t =
+  let t = convert t ~version in
+  if Astlib.Version.equal t.version version
+  then Some t.ast
+  else None

--- a/ast/node.mli
+++ b/ast/node.mli
@@ -2,4 +2,4 @@ type t
 
 val version : t -> Astlib.Version.t
 val wrap : version:Astlib.Version.t -> t Astlib.Ast.t -> t
-val unwrap : version:Astlib.Version.t -> t -> t Astlib.Ast.t
+val unwrap : version:Astlib.Version.t -> t -> t Astlib.Ast.t option

--- a/ast/version_unstable_for_testing.ml
+++ b/ast/version_unstable_for_testing.ml
@@ -65,7 +65,7 @@ module Directive_argument = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "directive_argument"; data } ->
+    | Some { name = "directive_argument"; data } ->
       begin
         match data with
         | Variant { tag = "Pdir_bool"; args = [| x1 |] } ->
@@ -136,7 +136,7 @@ module Toplevel_phrase = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "toplevel_phrase"; data } ->
+    | Some { name = "toplevel_phrase"; data } ->
       begin
         match data with
         | Variant { tag = "Ptop_dir"; args = [| x1; x2 |] } ->
@@ -189,7 +189,7 @@ module Module_binding = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_binding"
+    | Some { name = "module_binding"
       ; data = Record [| pmb_loc; pmb_attributes; pmb_expr; pmb_name |]
       } ->
         Option.bind (Data.to_location pmb_loc) ~f:(fun pmb_loc ->
@@ -237,7 +237,7 @@ module Value_binding = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "value_binding"
+    | Some { name = "value_binding"
       ; data = Record [| pvb_loc; pvb_attributes; pvb_expr; pvb_pat |]
       } ->
         Option.bind (Data.to_location pvb_loc) ~f:(fun pvb_loc ->
@@ -440,7 +440,7 @@ module Structure_item_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "structure_item_desc"; data } ->
+    | Some { name = "structure_item_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pstr_extension"; args = [| x1; x2 |] } ->
@@ -544,7 +544,7 @@ module Structure_item = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "structure_item"
+    | Some { name = "structure_item"
       ; data = Record [| pstr_loc; pstr_desc |]
       } ->
         Option.bind (Data.to_location pstr_loc) ~f:(fun pstr_loc ->
@@ -578,7 +578,7 @@ module Structure = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "structure"; data } -> (Data.to_list ~f:Data.to_node) data
+    | Some { name = "structure"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -685,7 +685,7 @@ module Module_expr_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_expr_desc"; data } ->
+    | Some { name = "module_expr_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pmod_extension"; args = [| x1 |] } ->
@@ -759,7 +759,7 @@ module Module_expr = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_expr"
+    | Some { name = "module_expr"
       ; data = Record [| pmod_attributes; pmod_loc; pmod_desc |]
       } ->
         Option.bind (Data.to_node pmod_attributes) ~f:(fun pmod_attributes ->
@@ -840,7 +840,7 @@ module With_constraint = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "with_constraint"; data } ->
+    | Some { name = "with_constraint"; data } ->
       begin
         match data with
         | Variant { tag = "Pwith_modsubst"; args = [| x1; x2 |] } ->
@@ -892,7 +892,7 @@ module Include_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "include_declaration"; data } -> Data.to_node data
+    | Some { name = "include_declaration"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -920,7 +920,7 @@ module Include_description = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "include_description"; data } -> Data.to_node data
+    | Some { name = "include_description"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -958,7 +958,7 @@ module Include_infos = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "include_infos"
+    | Some { name = "include_infos"
       ; data = Record [| pincl_attributes; pincl_loc; pincl_mod |]
       } ->
         Option.bind (Data.to_node pincl_attributes) ~f:(fun pincl_attributes ->
@@ -1005,7 +1005,7 @@ module Open_description = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "open_description"
+    | Some { name = "open_description"
       ; data = Record [| popen_attributes; popen_loc; popen_override; popen_lid |]
       } ->
         Option.bind (Data.to_node popen_attributes) ~f:(fun popen_attributes ->
@@ -1053,7 +1053,7 @@ module Module_type_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_type_declaration"
+    | Some { name = "module_type_declaration"
       ; data = Record [| pmtd_loc; pmtd_attributes; pmtd_type; pmtd_name |]
       } ->
         Option.bind (Data.to_location pmtd_loc) ~f:(fun pmtd_loc ->
@@ -1101,7 +1101,7 @@ module Module_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_declaration"
+    | Some { name = "module_declaration"
       ; data = Record [| pmd_loc; pmd_attributes; pmd_type; pmd_name |]
       } ->
         Option.bind (Data.to_location pmd_loc) ~f:(fun pmd_loc ->
@@ -1280,7 +1280,7 @@ module Signature_item_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "signature_item_desc"; data } ->
+    | Some { name = "signature_item_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Psig_extension"; args = [| x1; x2 |] } ->
@@ -1374,7 +1374,7 @@ module Signature_item = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "signature_item"
+    | Some { name = "signature_item"
       ; data = Record [| psig_loc; psig_desc |]
       } ->
         Option.bind (Data.to_location psig_loc) ~f:(fun psig_loc ->
@@ -1408,7 +1408,7 @@ module Signature = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "signature"; data } -> (Data.to_list ~f:Data.to_node) data
+    | Some { name = "signature"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -1514,7 +1514,7 @@ module Module_type_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_type_desc"; data } ->
+    | Some { name = "module_type_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pmty_alias"; args = [| x1 |] } ->
@@ -1587,7 +1587,7 @@ module Module_type = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_type"
+    | Some { name = "module_type"
       ; data = Record [| pmty_attributes; pmty_loc; pmty_desc |]
       } ->
         Option.bind (Data.to_node pmty_attributes) ~f:(fun pmty_attributes ->
@@ -1622,7 +1622,7 @@ module Class_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_declaration"; data } -> Data.to_node data
+    | Some { name = "class_declaration"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -1671,7 +1671,7 @@ module Class_field_kind = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_field_kind"; data } ->
+    | Some { name = "class_field_kind"; data } ->
       begin
         match data with
         | Variant { tag = "Cfk_concrete"; args = [| x1; x2 |] } ->
@@ -1789,7 +1789,7 @@ module Class_field_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_field_desc"; data } ->
+    | Some { name = "class_field_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pcf_extension"; args = [| x1 |] } ->
@@ -1861,7 +1861,7 @@ module Class_field = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_field"
+    | Some { name = "class_field"
       ; data = Record [| pcf_attributes; pcf_loc; pcf_desc |]
       } ->
         Option.bind (Data.to_node pcf_attributes) ~f:(fun pcf_attributes ->
@@ -1904,7 +1904,7 @@ module Class_structure = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_structure"
+    | Some { name = "class_structure"
       ; data = Record [| pcstr_fields; pcstr_self |]
       } ->
         Option.bind ((Data.to_list ~f:Data.to_node) pcstr_fields) ~f:(fun pcstr_fields ->
@@ -2034,7 +2034,7 @@ module Class_expr_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_expr_desc"; data } ->
+    | Some { name = "class_expr_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pcl_open"; args = [| x1; x2; x3 |] } ->
@@ -2118,7 +2118,7 @@ module Class_expr = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_expr"
+    | Some { name = "class_expr"
       ; data = Record [| pcl_attributes; pcl_loc; pcl_desc |]
       } ->
         Option.bind (Data.to_node pcl_attributes) ~f:(fun pcl_attributes ->
@@ -2153,7 +2153,7 @@ module Class_type_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type_declaration"; data } -> Data.to_node data
+    | Some { name = "class_type_declaration"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -2181,7 +2181,7 @@ module Class_description = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_description"; data } -> Data.to_node data
+    | Some { name = "class_description"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -2225,7 +2225,7 @@ module Class_infos = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_infos"
+    | Some { name = "class_infos"
       ; data = Record [| pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt |]
       } ->
         Option.bind (Data.to_node pci_attributes) ~f:(fun pci_attributes ->
@@ -2327,7 +2327,7 @@ module Class_type_field_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type_field_desc"; data } ->
+    | Some { name = "class_type_field_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pctf_extension"; args = [| x1 |] } ->
@@ -2393,7 +2393,7 @@ module Class_type_field = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type_field"
+    | Some { name = "class_type_field"
       ; data = Record [| pctf_attributes; pctf_loc; pctf_desc |]
       } ->
         Option.bind (Data.to_node pctf_attributes) ~f:(fun pctf_attributes ->
@@ -2436,7 +2436,7 @@ module Class_signature = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_signature"
+    | Some { name = "class_signature"
       ; data = Record [| pcsig_fields; pcsig_self |]
       } ->
         Option.bind ((Data.to_list ~f:Data.to_node) pcsig_fields) ~f:(fun pcsig_fields ->
@@ -2528,7 +2528,7 @@ module Class_type_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type_desc"; data } ->
+    | Some { name = "class_type_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pcty_open"; args = [| x1; x2; x3 |] } ->
@@ -2595,7 +2595,7 @@ module Class_type = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type"
+    | Some { name = "class_type"
       ; data = Record [| pcty_attributes; pcty_loc; pcty_desc |]
       } ->
         Option.bind (Data.to_node pcty_attributes) ~f:(fun pcty_attributes ->
@@ -2651,7 +2651,7 @@ module Extension_constructor_kind = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "extension_constructor_kind"; data } ->
+    | Some { name = "extension_constructor_kind"; data } ->
       begin
         match data with
         | Variant { tag = "Pext_rebind"; args = [| x1 |] } ->
@@ -2704,7 +2704,7 @@ module Extension_constructor = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "extension_constructor"
+    | Some { name = "extension_constructor"
       ; data = Record [| pext_attributes; pext_loc; pext_kind; pext_name |]
       } ->
         Option.bind (Data.to_node pext_attributes) ~f:(fun pext_attributes ->
@@ -2754,7 +2754,7 @@ module Type_extension = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "type_extension"
+    | Some { name = "type_extension"
       ; data = Record [| ptyext_attributes; ptyext_private; ptyext_constructors; ptyext_params; ptyext_path |]
       } ->
         Option.bind (Data.to_node ptyext_attributes) ~f:(fun ptyext_attributes ->
@@ -2811,7 +2811,7 @@ module Constructor_arguments = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "constructor_arguments"; data } ->
+    | Some { name = "constructor_arguments"; data } ->
       begin
         match data with
         | Variant { tag = "Pcstr_record"; args = [| x1 |] } ->
@@ -2865,7 +2865,7 @@ module Constructor_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "constructor_declaration"
+    | Some { name = "constructor_declaration"
       ; data = Record [| pcd_attributes; pcd_loc; pcd_res; pcd_args; pcd_name |]
       } ->
         Option.bind (Data.to_node pcd_attributes) ~f:(fun pcd_attributes ->
@@ -2916,7 +2916,7 @@ module Label_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "label_declaration"
+    | Some { name = "label_declaration"
       ; data = Record [| pld_attributes; pld_loc; pld_type; pld_mutable; pld_name |]
       } ->
         Option.bind (Data.to_node pld_attributes) ~f:(fun pld_attributes ->
@@ -2981,7 +2981,7 @@ module Type_kind = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "type_kind"; data } ->
+    | Some { name = "type_kind"; data } ->
       begin
         match data with
         | Variant { tag = "Ptype_open"; args = [||] } -> Some Ptype_open
@@ -3043,7 +3043,7 @@ module Type_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "type_declaration"
+    | Some { name = "type_declaration"
       ; data = Record [| ptype_loc; ptype_attributes; ptype_manifest; ptype_private; ptype_kind; ptype_cstrs; ptype_params; ptype_name |]
       } ->
         Option.bind (Data.to_location ptype_loc) ~f:(fun ptype_loc ->
@@ -3097,7 +3097,7 @@ module Value_description = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "value_description"
+    | Some { name = "value_description"
       ; data = Record [| pval_loc; pval_attributes; pval_prim; pval_type; pval_name |]
       } ->
         Option.bind (Data.to_location pval_loc) ~f:(fun pval_loc ->
@@ -3144,7 +3144,7 @@ module Case = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "case"
+    | Some { name = "case"
       ; data = Record [| pc_rhs; pc_guard; pc_lhs |]
       } ->
         Option.bind (Data.to_node pc_rhs) ~f:(fun pc_rhs ->
@@ -3600,7 +3600,7 @@ module Expression_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "expression_desc"; data } ->
+    | Some { name = "expression_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pexp_unreachable"; args = [||] } -> Some Pexp_unreachable
@@ -3817,7 +3817,7 @@ module Expression = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "expression"
+    | Some { name = "expression"
       ; data = Record [| pexp_attributes; pexp_loc; pexp_desc |]
       } ->
         Option.bind (Data.to_node pexp_attributes) ~f:(fun pexp_attributes ->
@@ -4049,7 +4049,7 @@ module Pattern_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "pattern_desc"; data } ->
+    | Some { name = "pattern_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Ppat_open"; args = [| x1; x2 |] } ->
@@ -4168,7 +4168,7 @@ module Pattern = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "pattern"
+    | Some { name = "pattern"
       ; data = Record [| ppat_attributes; ppat_loc; ppat_desc |]
       } ->
         Option.bind (Data.to_node ppat_attributes) ~f:(fun ppat_attributes ->
@@ -4225,7 +4225,7 @@ module Object_field = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "object_field"; data } ->
+    | Some { name = "object_field"; data } ->
       begin
         match data with
         | Variant { tag = "Oinherit"; args = [| x1 |] } ->
@@ -4290,7 +4290,7 @@ module Row_field = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "row_field"; data } ->
+    | Some { name = "row_field"; data } ->
       begin
         match data with
         | Variant { tag = "Rinherit"; args = [| x1 |] } ->
@@ -4333,7 +4333,7 @@ module Package_type = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) ~f2:Data.to_node) data
+    | Some { name = "package_type"; data } -> (Data.to_tuple2 ~f1:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node)) ~f2:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -4493,7 +4493,7 @@ module Core_type_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "core_type_desc"; data } ->
+    | Some { name = "core_type_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Ptyp_extension"; args = [| x1 |] } ->
@@ -4589,7 +4589,7 @@ module Core_type = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "core_type"
+    | Some { name = "core_type"
       ; data = Record [| ptyp_attributes; ptyp_loc; ptyp_desc |]
       } ->
         Option.bind (Data.to_node ptyp_attributes) ~f:(fun ptyp_attributes ->
@@ -4667,7 +4667,7 @@ module Payload = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "payload"; data } ->
+    | Some { name = "payload"; data } ->
       begin
         match data with
         | Variant { tag = "PPat"; args = [| x1; x2 |] } ->
@@ -4716,7 +4716,7 @@ module Attributes = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "attributes"; data } -> (Data.to_list ~f:Data.to_node) data
+    | Some { name = "attributes"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -4744,7 +4744,7 @@ module Extension = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "extension"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_string)) data
+    | Some { name = "extension"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_string)) data
     | _ -> None
 
   let to_concrete node =
@@ -4772,7 +4772,7 @@ module Attribute = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "attribute"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_string)) data
+    | Some { name = "attribute"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_loc ~f:Data.to_string)) data
     | _ -> None
 
   let to_concrete node =
@@ -4845,7 +4845,7 @@ module Constant = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "constant"; data } ->
+    | Some { name = "constant"; data } ->
       begin
         match data with
         | Variant { tag = "Pconst_float"; args = [| x1; x2 |] } ->
@@ -4906,7 +4906,7 @@ module Variance = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "variance"; data } ->
+    | Some { name = "variance"; data } ->
       begin
         match data with
         | Variant { tag = "Invariant"; args = [||] } -> Some Invariant
@@ -4965,7 +4965,7 @@ module Arg_label = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "arg_label"; data } ->
+    | Some { name = "arg_label"; data } ->
       begin
         match data with
         | Variant { tag = "Optional"; args = [| x1 |] } ->
@@ -5012,7 +5012,7 @@ module Closed_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "closed_flag"; data } ->
+    | Some { name = "closed_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Open"; args = [||] } -> Some Open
@@ -5052,7 +5052,7 @@ module Override_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "override_flag"; data } ->
+    | Some { name = "override_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Fresh"; args = [||] } -> Some Fresh
@@ -5092,7 +5092,7 @@ module Virtual_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "virtual_flag"; data } ->
+    | Some { name = "virtual_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Concrete"; args = [||] } -> Some Concrete
@@ -5132,7 +5132,7 @@ module Mutable_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "mutable_flag"; data } ->
+    | Some { name = "mutable_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Mutable"; args = [||] } -> Some Mutable
@@ -5172,7 +5172,7 @@ module Private_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "private_flag"; data } ->
+    | Some { name = "private_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Public"; args = [||] } -> Some Public
@@ -5212,7 +5212,7 @@ module Direction_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "direction_flag"; data } ->
+    | Some { name = "direction_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Downto"; args = [||] } -> Some Downto
@@ -5252,7 +5252,7 @@ module Rec_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "rec_flag"; data } ->
+    | Some { name = "rec_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Recursive"; args = [||] } -> Some Recursive
@@ -5286,7 +5286,7 @@ module Longident_loc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
+    | Some { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -5347,7 +5347,7 @@ module Longident = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "longident"; data } ->
+    | Some { name = "longident"; data } ->
       begin
         match data with
         | Variant { tag = "Lapply"; args = [| x1; x2 |] } ->

--- a/ast/version_v4_07.ml
+++ b/ast/version_v4_07.ml
@@ -51,7 +51,7 @@ module Longident = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "longident"; data } ->
+    | Some { name = "longident"; data } ->
       begin
         match data with
         | Variant { tag = "Lident"; args = [| x1 |] } ->
@@ -97,7 +97,7 @@ module Longident_loc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
+    | Some { name = "longident_loc"; data } -> (Data.to_loc ~f:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -131,7 +131,7 @@ module Rec_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "rec_flag"; data } ->
+    | Some { name = "rec_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Nonrecursive"; args = [||] } -> Some Nonrecursive
@@ -171,7 +171,7 @@ module Direction_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "direction_flag"; data } ->
+    | Some { name = "direction_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Upto"; args = [||] } -> Some Upto
@@ -211,7 +211,7 @@ module Private_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "private_flag"; data } ->
+    | Some { name = "private_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Private"; args = [||] } -> Some Private
@@ -251,7 +251,7 @@ module Mutable_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "mutable_flag"; data } ->
+    | Some { name = "mutable_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Immutable"; args = [||] } -> Some Immutable
@@ -291,7 +291,7 @@ module Virtual_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "virtual_flag"; data } ->
+    | Some { name = "virtual_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Virtual"; args = [||] } -> Some Virtual
@@ -331,7 +331,7 @@ module Override_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "override_flag"; data } ->
+    | Some { name = "override_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Override"; args = [||] } -> Some Override
@@ -371,7 +371,7 @@ module Closed_flag = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "closed_flag"; data } ->
+    | Some { name = "closed_flag"; data } ->
       begin
         match data with
         | Variant { tag = "Closed"; args = [||] } -> Some Closed
@@ -429,7 +429,7 @@ module Arg_label = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "arg_label"; data } ->
+    | Some { name = "arg_label"; data } ->
       begin
         match data with
         | Variant { tag = "Nolabel"; args = [||] } -> Some Nolabel
@@ -480,7 +480,7 @@ module Variance = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "variance"; data } ->
+    | Some { name = "variance"; data } ->
       begin
         match data with
         | Variant { tag = "Covariant"; args = [||] } -> Some Covariant
@@ -560,7 +560,7 @@ module Constant = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "constant"; data } ->
+    | Some { name = "constant"; data } ->
       begin
         match data with
         | Variant { tag = "Pconst_integer"; args = [| x1; x2 |] } ->
@@ -611,7 +611,7 @@ module Attribute = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "attribute"; data } -> (Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node) data
+    | Some { name = "attribute"; data } -> (Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -639,7 +639,7 @@ module Extension = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "extension"; data } -> (Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node) data
+    | Some { name = "extension"; data } -> (Data.to_tuple2 ~f1:(Data.to_loc ~f:Data.to_string) ~f2:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -667,7 +667,7 @@ module Attributes = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "attributes"; data } -> (Data.to_list ~f:Data.to_node) data
+    | Some { name = "attributes"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -738,7 +738,7 @@ module Payload = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "payload"; data } ->
+    | Some { name = "payload"; data } ->
       begin
         match data with
         | Variant { tag = "PStr"; args = [| x1 |] } ->
@@ -797,7 +797,7 @@ module Core_type = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "core_type"
+    | Some { name = "core_type"
       ; data = Record [| ptyp_desc; ptyp_loc; ptyp_attributes |]
       } ->
         Option.bind (Data.to_node ptyp_desc) ~f:(fun ptyp_desc ->
@@ -964,7 +964,7 @@ module Core_type_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "core_type_desc"; data } ->
+    | Some { name = "core_type_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Ptyp_any"; args = [||] } -> Some Ptyp_any
@@ -1050,7 +1050,7 @@ module Package_type = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "package_type"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node))) data
+    | Some { name = "package_type"; data } -> (Data.to_tuple2 ~f1:Data.to_node ~f2:(Data.to_list ~f:(Data.to_tuple2 ~f1:Data.to_node ~f2:Data.to_node))) data
     | _ -> None
 
   let to_concrete node =
@@ -1101,7 +1101,7 @@ module Row_field = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "row_field"; data } ->
+    | Some { name = "row_field"; data } ->
       begin
         match data with
         | Variant { tag = "Rtag"; args = [| x1; x2; x3; x4 |] } ->
@@ -1166,7 +1166,7 @@ module Object_field = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "object_field"; data } ->
+    | Some { name = "object_field"; data } ->
       begin
         match data with
         | Variant { tag = "Otag"; args = [| x1; x2; x3 |] } ->
@@ -1218,7 +1218,7 @@ module Pattern = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "pattern"
+    | Some { name = "pattern"
       ; data = Record [| ppat_desc; ppat_loc; ppat_attributes |]
       } ->
         Option.bind (Data.to_node ppat_desc) ~f:(fun ppat_desc ->
@@ -1450,7 +1450,7 @@ module Pattern_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "pattern_desc"; data } ->
+    | Some { name = "pattern_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Ppat_any"; args = [||] } -> Some Ppat_any
@@ -1569,7 +1569,7 @@ module Expression = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "expression"
+    | Some { name = "expression"
       ; data = Record [| pexp_desc; pexp_loc; pexp_attributes |]
       } ->
         Option.bind (Data.to_node pexp_desc) ~f:(fun pexp_desc ->
@@ -2025,7 +2025,7 @@ module Expression_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "expression_desc"; data } ->
+    | Some { name = "expression_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pexp_ident"; args = [| x1 |] } ->
@@ -2242,7 +2242,7 @@ module Case = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "case"
+    | Some { name = "case"
       ; data = Record [| pc_lhs; pc_guard; pc_rhs |]
       } ->
         Option.bind (Data.to_node pc_lhs) ~f:(fun pc_lhs ->
@@ -2291,7 +2291,7 @@ module Value_description = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "value_description"
+    | Some { name = "value_description"
       ; data = Record [| pval_name; pval_type; pval_prim; pval_attributes; pval_loc |]
       } ->
         Option.bind ((Data.to_loc ~f:Data.to_string) pval_name) ~f:(fun pval_name ->
@@ -2348,7 +2348,7 @@ module Type_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "type_declaration"
+    | Some { name = "type_declaration"
       ; data = Record [| ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc |]
       } ->
         Option.bind ((Data.to_loc ~f:Data.to_string) ptype_name) ~f:(fun ptype_name ->
@@ -2416,7 +2416,7 @@ module Type_kind = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "type_kind"; data } ->
+    | Some { name = "type_kind"; data } ->
       begin
         match data with
         | Variant { tag = "Ptype_abstract"; args = [||] } -> Some Ptype_abstract
@@ -2472,7 +2472,7 @@ module Label_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "label_declaration"
+    | Some { name = "label_declaration"
       ; data = Record [| pld_name; pld_mutable; pld_type; pld_loc; pld_attributes |]
       } ->
         Option.bind ((Data.to_loc ~f:Data.to_string) pld_name) ~f:(fun pld_name ->
@@ -2523,7 +2523,7 @@ module Constructor_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "constructor_declaration"
+    | Some { name = "constructor_declaration"
       ; data = Record [| pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes |]
       } ->
         Option.bind ((Data.to_loc ~f:Data.to_string) pcd_name) ~f:(fun pcd_name ->
@@ -2580,7 +2580,7 @@ module Constructor_arguments = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "constructor_arguments"; data } ->
+    | Some { name = "constructor_arguments"; data } ->
       begin
         match data with
         | Variant { tag = "Pcstr_tuple"; args = [| x1 |] } ->
@@ -2634,7 +2634,7 @@ module Type_extension = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "type_extension"
+    | Some { name = "type_extension"
       ; data = Record [| ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes |]
       } ->
         Option.bind (Data.to_node ptyext_path) ~f:(fun ptyext_path ->
@@ -2683,7 +2683,7 @@ module Extension_constructor = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "extension_constructor"
+    | Some { name = "extension_constructor"
       ; data = Record [| pext_name; pext_kind; pext_loc; pext_attributes |]
       } ->
         Option.bind ((Data.to_loc ~f:Data.to_string) pext_name) ~f:(fun pext_name ->
@@ -2740,7 +2740,7 @@ module Extension_constructor_kind = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "extension_constructor_kind"; data } ->
+    | Some { name = "extension_constructor_kind"; data } ->
       begin
         match data with
         | Variant { tag = "Pext_decl"; args = [| x1; x2 |] } ->
@@ -2791,7 +2791,7 @@ module Class_type = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type"
+    | Some { name = "class_type"
       ; data = Record [| pcty_desc; pcty_loc; pcty_attributes |]
       } ->
         Option.bind (Data.to_node pcty_desc) ~f:(fun pcty_desc ->
@@ -2884,7 +2884,7 @@ module Class_type_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type_desc"; data } ->
+    | Some { name = "class_type_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pcty_constr"; args = [| x1; x2 |] } ->
@@ -2949,7 +2949,7 @@ module Class_signature = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_signature"
+    | Some { name = "class_signature"
       ; data = Record [| pcsig_self; pcsig_fields |]
       } ->
         Option.bind (Data.to_node pcsig_self) ~f:(fun pcsig_self ->
@@ -2993,7 +2993,7 @@ module Class_type_field = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type_field"
+    | Some { name = "class_type_field"
       ; data = Record [| pctf_desc; pctf_loc; pctf_attributes |]
       } ->
         Option.bind (Data.to_node pctf_desc) ~f:(fun pctf_desc ->
@@ -3092,7 +3092,7 @@ module Class_type_field_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type_field_desc"; data } ->
+    | Some { name = "class_type_field_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pctf_inherit"; args = [| x1 |] } ->
@@ -3164,7 +3164,7 @@ module Class_infos = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_infos"
+    | Some { name = "class_infos"
       ; data = Record [| pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes |]
       } ->
         Option.bind (Data.to_node pci_virt) ~f:(fun pci_virt ->
@@ -3202,7 +3202,7 @@ module Class_description = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_description"; data } -> Data.to_node data
+    | Some { name = "class_description"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -3230,7 +3230,7 @@ module Class_type_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_type_declaration"; data } -> Data.to_node data
+    | Some { name = "class_type_declaration"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -3268,7 +3268,7 @@ module Class_expr = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_expr"
+    | Some { name = "class_expr"
       ; data = Record [| pcl_desc; pcl_loc; pcl_attributes |]
       } ->
         Option.bind (Data.to_node pcl_desc) ~f:(fun pcl_desc ->
@@ -3399,7 +3399,7 @@ module Class_expr_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_expr_desc"; data } ->
+    | Some { name = "class_expr_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pcl_constr"; args = [| x1; x2 |] } ->
@@ -3481,7 +3481,7 @@ module Class_structure = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_structure"
+    | Some { name = "class_structure"
       ; data = Record [| pcstr_self; pcstr_fields |]
       } ->
         Option.bind (Data.to_node pcstr_self) ~f:(fun pcstr_self ->
@@ -3525,7 +3525,7 @@ module Class_field = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_field"
+    | Some { name = "class_field"
       ; data = Record [| pcf_desc; pcf_loc; pcf_attributes |]
       } ->
         Option.bind (Data.to_node pcf_desc) ~f:(fun pcf_desc ->
@@ -3637,7 +3637,7 @@ module Class_field_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_field_desc"; data } ->
+    | Some { name = "class_field_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pcf_inherit"; args = [| x1; x2; x3 |] } ->
@@ -3720,7 +3720,7 @@ module Class_field_kind = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_field_kind"; data } ->
+    | Some { name = "class_field_kind"; data } ->
       begin
         match data with
         | Variant { tag = "Cfk_virtual"; args = [| x1 |] } ->
@@ -3761,7 +3761,7 @@ module Class_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "class_declaration"; data } -> Data.to_node data
+    | Some { name = "class_declaration"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -3799,7 +3799,7 @@ module Module_type = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_type"
+    | Some { name = "module_type"
       ; data = Record [| pmty_desc; pmty_loc; pmty_attributes |]
       } ->
         Option.bind (Data.to_node pmty_desc) ~f:(fun pmty_desc ->
@@ -3912,7 +3912,7 @@ module Module_type_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_type_desc"; data } ->
+    | Some { name = "module_type_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pmty_ident"; args = [| x1 |] } ->
@@ -3975,7 +3975,7 @@ module Signature = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "signature"; data } -> (Data.to_list ~f:Data.to_node) data
+    | Some { name = "signature"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -4011,7 +4011,7 @@ module Signature_item = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "signature_item"
+    | Some { name = "signature_item"
       ; data = Record [| psig_desc; psig_loc |]
       } ->
         Option.bind (Data.to_node psig_desc) ~f:(fun psig_desc ->
@@ -4188,7 +4188,7 @@ module Signature_item_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "signature_item_desc"; data } ->
+    | Some { name = "signature_item_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Psig_value"; args = [| x1 |] } ->
@@ -4286,7 +4286,7 @@ module Module_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_declaration"
+    | Some { name = "module_declaration"
       ; data = Record [| pmd_name; pmd_type; pmd_attributes; pmd_loc |]
       } ->
         Option.bind ((Data.to_loc ~f:Data.to_string) pmd_name) ~f:(fun pmd_name ->
@@ -4334,7 +4334,7 @@ module Module_type_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_type_declaration"
+    | Some { name = "module_type_declaration"
       ; data = Record [| pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc |]
       } ->
         Option.bind ((Data.to_loc ~f:Data.to_string) pmtd_name) ~f:(fun pmtd_name ->
@@ -4382,7 +4382,7 @@ module Open_description = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "open_description"
+    | Some { name = "open_description"
       ; data = Record [| popen_lid; popen_override; popen_loc; popen_attributes |]
       } ->
         Option.bind (Data.to_node popen_lid) ~f:(fun popen_lid ->
@@ -4428,7 +4428,7 @@ module Include_infos = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "include_infos"
+    | Some { name = "include_infos"
       ; data = Record [| pincl_mod; pincl_loc; pincl_attributes |]
       } ->
         Option.bind (Data.to_node pincl_mod) ~f:(fun pincl_mod ->
@@ -4463,7 +4463,7 @@ module Include_description = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "include_description"; data } -> Data.to_node data
+    | Some { name = "include_description"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -4491,7 +4491,7 @@ module Include_declaration = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "include_declaration"; data } -> Data.to_node data
+    | Some { name = "include_declaration"; data } -> Data.to_node data
     | _ -> None
 
   let to_concrete node =
@@ -4565,7 +4565,7 @@ module With_constraint = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "with_constraint"; data } ->
+    | Some { name = "with_constraint"; data } ->
       begin
         match data with
         | Variant { tag = "Pwith_type"; args = [| x1; x2 |] } ->
@@ -4627,7 +4627,7 @@ module Module_expr = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_expr"
+    | Some { name = "module_expr"
       ; data = Record [| pmod_desc; pmod_loc; pmod_attributes |]
       } ->
         Option.bind (Data.to_node pmod_desc) ~f:(fun pmod_desc ->
@@ -4741,7 +4741,7 @@ module Module_expr_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_expr_desc"; data } ->
+    | Some { name = "module_expr_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pmod_ident"; args = [| x1 |] } ->
@@ -4805,7 +4805,7 @@ module Structure = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "structure"; data } -> (Data.to_list ~f:Data.to_node) data
+    | Some { name = "structure"; data } -> (Data.to_list ~f:Data.to_node) data
     | _ -> None
 
   let to_concrete node =
@@ -4841,7 +4841,7 @@ module Structure_item = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "structure_item"
+    | Some { name = "structure_item"
       ; data = Record [| pstr_desc; pstr_loc |]
       } ->
         Option.bind (Data.to_node pstr_desc) ~f:(fun pstr_desc ->
@@ -5042,7 +5042,7 @@ module Structure_item_desc = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "structure_item_desc"; data } ->
+    | Some { name = "structure_item_desc"; data } ->
       begin
         match data with
         | Variant { tag = "Pstr_eval"; args = [| x1; x2 |] } ->
@@ -5150,7 +5150,7 @@ module Value_binding = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "value_binding"
+    | Some { name = "value_binding"
       ; data = Record [| pvb_pat; pvb_expr; pvb_attributes; pvb_loc |]
       } ->
         Option.bind (Data.to_node pvb_pat) ~f:(fun pvb_pat ->
@@ -5198,7 +5198,7 @@ module Module_binding = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "module_binding"
+    | Some { name = "module_binding"
       ; data = Record [| pmb_name; pmb_expr; pmb_attributes; pmb_loc |]
       } ->
         Option.bind ((Data.to_loc ~f:Data.to_string) pmb_name) ~f:(fun pmb_name ->
@@ -5255,7 +5255,7 @@ module Toplevel_phrase = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "toplevel_phrase"; data } ->
+    | Some { name = "toplevel_phrase"; data } ->
       begin
         match data with
         | Variant { tag = "Ptop_def"; args = [| x1 |] } ->
@@ -5343,7 +5343,7 @@ module Directive_argument = struct
 
   let to_concrete_opt t =
     match Node.unwrap (Unversioned.Private.transparent t) ~version with
-    | { name = "directive_argument"; data } ->
+    | Some { name = "directive_argument"; data } ->
       begin
         match data with
         | Variant { tag = "Pdir_none"; args = [||] } -> Some Pdir_none

--- a/astlib/base/ast.mli
+++ b/astlib/base/ast.mli
@@ -33,3 +33,10 @@ val generator
   :  Grammar.t
   -> wrap:('node t -> 'node)
   -> 'node t Base_quickcheck.Generator.t
+
+module Optional : sig
+  val map
+    :  'a t
+    -> f:('a -> 'b option)
+    -> 'b t option
+end

--- a/astlib/history.mli
+++ b/astlib/history.mli
@@ -10,16 +10,16 @@ val find_grammar : t -> version:Version.t -> Grammar.t
 
 (** Converts the given AST from [src_version]'s grammar to [dst_version]'s grammar, using
     the conversion functions stored in [t]. Converts ['node] to traverse and/or construct
-    subtrees using [to_ast] and [of_ast], which may themselves call [convert] as
+    subtrees using [unwrap] and [wrap], which may themselves call [convert] as
     appropriate. *)
 val convert
   :  t
   -> 'node Ast.t
   -> src_version:Version.t
   -> dst_version:Version.t
-  -> unwrap:(version:Version.t -> 'node -> 'node Ast.t)
+  -> unwrap:(version:Version.t -> 'node -> 'node Ast.t option)
   -> wrap:(version:Version.t -> 'node Ast.t -> 'node)
-  -> 'node Ast.t
+  -> Version.t * 'node Ast.t
 
 (**/**)
 
@@ -27,9 +27,9 @@ val convert
 
 type 'node conversion_function
   = 'node Ast.t
-  -> unwrap:('node -> 'node Ast.t)
+  -> unwrap:('node -> 'node Ast.t option)
   -> wrap:('node Ast.t -> 'node)
-  -> 'node Ast.t
+  -> 'node Ast.t option
 
 type conversion =
   { src_version : Version.t

--- a/astlib/test/test_history.ml
+++ b/astlib/test/test_history.ml
@@ -2,13 +2,28 @@ open! Base
 open Astlib_base
 
 module Versioned_node = struct
-  type t = { version : Version.t; ast : t Ast.t }
+  type t = { version : Version.t; ast : t Ast.t } [@@deriving sexp_of]
 
   let wrap ~version ast = { version; ast }
 
-  let rec unwrap ~version:dst_version { version = src_version; ast } ~history =
-    let unwrap = unwrap ~history in
-    Astlib.History.convert history ast ~src_version ~dst_version ~unwrap ~wrap
+  let rec convert { version = src_version; ast } ~version:dst_version ~history =
+    let version, ast =
+      let unwrap = unwrap ~history in
+      Astlib.History.convert history ast ~src_version ~dst_version ~unwrap ~wrap
+    in
+    { version; ast }
+
+  and unwrap ~history ~version t =
+    let t = convert t ~version ~history in
+    if Version.equal t.version version
+    then Some t.ast
+    else None
+
+  let rec deep_convert t ~version ~history =
+    let t = convert t ~version ~history in
+    if Version.equal t.version version
+    then { t with ast = Ast.map t.ast ~f:(deep_convert ~version ~history) }
+    else t
 end
 
 module Unversioned_node = struct
@@ -16,9 +31,15 @@ module Unversioned_node = struct
 
   let of_versioned_node node ~version ~history =
     let rec f node =
-      { ast = Ast.map (Versioned_node.unwrap node ~version ~history) ~f }
+      node
+      |> Versioned_node.unwrap ~version ~history
+      |> Option.bind ~f:(Ast.Optional.map ~f)
+      |> Option.map ~f:(fun ast -> { ast })
     in
     f node
+
+  let rec of_versioned_node_without_converting (node : Versioned_node.t) =
+    { ast = Ast.map node.ast ~f:of_versioned_node_without_converting }
 
   let to_versioned_node t ~version =
     let rec f { ast } = Versioned_node.wrap ~version (Ast.map ast ~f) in
@@ -63,28 +84,40 @@ let (v3_grammar : Astlib.Grammar.t) = [
   ]);
 ]
 
-let v2_of_v1 x ~unwrap:_ ~wrap:_ = x
-let v1_of_v2 x ~unwrap:_ ~wrap:_ = x
+let v2_of_v1 x ~unwrap:_ ~wrap:_ = Some x
 
-let rec v3_addends_of_v2 ast ~unwrap ~wrap : _ Ast.data list =
+let v1_of_v2 ast ~unwrap:_ ~wrap:_ =
+  match (ast : _ Ast.t) with
+  | { name = "expr"; data = Variant { tag; args = _ } } ->
+    (match tag with
+     | "int" | "add" -> Some ast
+     | "var" -> None
+     | _ -> assert false)
+  | _ -> assert false
+
+let rec v3_addends_of_v2 ast ~unwrap ~wrap : _ Ast.data list option =
   match (ast : _ Ast.t) with
   | { name = "expr"; data = Variant { tag; args } } ->
     (match tag with
-     | "var" | "int" -> [ Node (wrap ast) ]
+     | "var" | "int" -> Some [ Node (wrap ast) ]
      | "add" ->
        (match args with
         | [| Node x; Node y |] ->
-          v3_addends_of_v2 (unwrap x) ~unwrap ~wrap @
-          v3_addends_of_v2 (unwrap y) ~unwrap ~wrap
+          Option.bind (Option.both (unwrap x) (unwrap y)) ~f:(fun (x, y) ->
+            Option.map
+              (Option.both
+                 (v3_addends_of_v2 x ~unwrap ~wrap)
+                 (v3_addends_of_v2 y ~unwrap ~wrap))
+              ~f:(fun (x, y) -> x @ y))
         | [| List _ |] -> assert false
         | _ -> assert false)
      | _ -> assert false)
   | _ -> assert false
 
 let v3_of_v2 ast ~unwrap ~wrap =
-  match v3_addends_of_v2 ast ~unwrap ~wrap with
-  | [ _ ] -> ast
-  | list -> { name = "expr" ; data = Variant { tag = "add" ; args = [| List list |] } }
+  Option.map (v3_addends_of_v2 ast ~unwrap ~wrap) ~f:(function
+    | [ _ ] -> ast
+    | list -> { name = "expr" ; data = Variant { tag = "add" ; args = [| List list |] } })
 
 let v2_zero () : _ Ast.t =
   { name = "expr"
@@ -104,7 +137,7 @@ let v2_of_v3 ast ~unwrap:_ ~wrap =
   match (ast : _ Ast.t) with
   | { name = "expr"; data = Variant { tag; args } } ->
     (match tag with
-     | "var" | "int" -> ast
+     | "var" | "int" -> Some ast
      | "add" ->
        (match args with
         | [| List data |] ->
@@ -115,6 +148,7 @@ let v2_of_v3 ast ~unwrap:_ ~wrap =
           in
           List.fold_right nodes ~init:(v2_zero ()) ~f:(fun node acc ->
             v2_add node (wrap acc))
+          |> Option.return
         | [| Node _; Node _ |] -> assert false
         | _ -> assert false)
      | _ -> assert false)
@@ -149,6 +183,75 @@ let%expect_test "generator consistency" =
         then raise_s [%sexp "invalid AST", { version : Version.t }]));
   [%expect {| |}]
 
+let%expect_test "deep-convert consistency" =
+  List.iter versioned_grammars ~f:(fun (src_version, src_grammar) ->
+    List.iter versioned_grammars ~f:(fun (dst_version, _) ->
+      Base_quickcheck.Test.run_exn
+        (module struct
+          type t = Unversioned_node.t
+          let sexp_of_t = Unversioned_node.sexp_of_t
+          let quickcheck_generator = Unversioned_node.generator src_grammar
+          let quickcheck_shrinker = Unversioned_node.shrinker
+        end)
+        ~f:(fun src ->
+          let src = Unversioned_node.to_versioned_node src ~version:src_version in
+          match
+            Unversioned_node.of_versioned_node src ~version:dst_version ~history
+          with
+          | None -> ()
+          | Some dst ->
+            let dst_via_deep_convert =
+              src
+              |> Versioned_node.deep_convert ~version:dst_version ~history
+              |> Unversioned_node.of_versioned_node_without_converting
+            in
+            if not (Unversioned_node.equal dst dst_via_deep_convert)
+            then
+              raise_s
+                [%sexp
+                  "deep convert failed"
+                , { src_version : Version.t
+                  ; dst_version : Version.t
+                  ; dst : Unversioned_node.t
+                  ; dst_via_deep_convert : Unversioned_node.t
+                  }])));
+  [%expect {| |}]
+
+let%expect_test "history down-conversions either work or else fail gracefully" =
+  List.iteri versioned_grammars ~f:(fun src_index (src_version, src_grammar) ->
+    List.iteri versioned_grammars ~f:(fun dst_index (dst_version, dst_grammar) ->
+      if dst_index < src_index then
+        Base_quickcheck.Test.run_exn
+          (module struct
+            type t = Unversioned_node.t
+            let sexp_of_t = Unversioned_node.sexp_of_t
+            let quickcheck_shrinker = Unversioned_node.shrinker
+            let quickcheck_generator = Unversioned_node.generator src_grammar
+          end)
+          ~f:(fun src ->
+            match
+              src
+              |> Unversioned_node.to_versioned_node ~version:src_version
+              |> Unversioned_node.of_versioned_node ~version:dst_version ~history
+            with
+            | exception exn ->
+              raise_s
+                [%sexp
+                  "conversion raised"
+                , { src_version : Version.t; dst_version : Version.t; exn : exn }]
+            | None -> ()
+            | Some dst ->
+              if not (Unversioned_node.matches dst ~grammar:dst_grammar)
+              then
+                raise_s
+                  [%sexp
+                    "invalid conversion"
+                  , { src_version : Version.t
+                    ; dst_version : Version.t
+                    ; dst : Unversioned_node.t
+                    }])));
+  [%expect {| |}]
+
 (* Down-conversions can fail. We don't currently have a good way to detect when they do,
    so we don't have a good invariant to express about them on their own. *)
 let%expect_test "history up-conversions always work" =
@@ -164,9 +267,22 @@ let%expect_test "history up-conversions always work" =
           end)
           ~f:(fun src ->
             let dst =
-              src
-              |> Unversioned_node.to_versioned_node ~version:src_version
-              |> Unversioned_node.of_versioned_node ~version:dst_version ~history
+              match
+                src
+                |> Unversioned_node.to_versioned_node ~version:src_version
+                |> Unversioned_node.of_versioned_node ~version:dst_version ~history
+              with
+              | Some dst -> dst
+              | None ->
+                raise_s
+                  [%sexp
+                    "conversion failed"
+                  , { src_version : Version.t; dst_version : Version.t }]
+              | exception exn ->
+                raise_s
+                  [%sexp
+                    "conversion raised"
+                  , { src_version : Version.t; dst_version : Version.t; exn : exn }]
             in
             if not (Unversioned_node.matches dst ~grammar:dst_grammar)
             then
@@ -195,31 +311,42 @@ let%expect_test "history round-trips always work" =
         end)
         ~f:(fun original ->
           let converted =
-            try
+            match
               original
               |> Unversioned_node.to_versioned_node ~version:src_version
-              |> Unversioned_node.of_versioned_node ~version:dst_version ~history
-            with exn ->
+              |> Versioned_node.deep_convert ~version:dst_version ~history
+            with
+            | converted -> converted
+            | exception exn ->
               raise_s
                 [%sexp
-                  "first conversion failed"
+                  "first conversion raised"
                 , { src_version : Version.t
                   ; dst_version : Version.t
                   ; exn : exn
                   }]
           in
           let round_trip =
-            try
+            match
               converted
-              |> Unversioned_node.to_versioned_node ~version:dst_version
               |> Unversioned_node.of_versioned_node ~version:src_version ~history
-            with exn ->
+            with
+            | Some round_trip -> round_trip
+            | None ->
               raise_s
                 [%sexp
                   "second conversion failed"
                 , { src_version : Version.t
                   ; dst_version : Version.t
-                  ; converted : Unversioned_node.t
+                  ; converted : Versioned_node.t
+                  }]
+            | exception exn ->
+              raise_s
+                [%sexp
+                  "second conversion raised"
+                , { src_version : Version.t
+                  ; dst_version : Version.t
+                  ; converted : Versioned_node.t
                   ; exn : exn
                   }]
           in
@@ -232,7 +359,7 @@ let%expect_test "history round-trips always work" =
                 "round-trip failed"
               , { src_version : Version.t
                 ; dst_version : Version.t
-                ; converted : Unversioned_node.t
+                ; converted : Versioned_node.t
                 ; round_trip : Unversioned_node.t
                 }])));
   [%expect {| |}]

--- a/astlib/unstable_for_testing.ml
+++ b/astlib/unstable_for_testing.ml
@@ -77,13 +77,13 @@ let update_ast (ast : _ Ast.t) =
 let to_stable : History.conversion =
   { src_version = version
   ; dst_version = Stable.version
-  ; f = fun ast ~unwrap:_ ~wrap:_ -> update_ast ast
+  ; f = fun ast ~unwrap:_ ~wrap:_ -> Some (update_ast ast)
   }
 
 let of_stable : History.conversion =
   { src_version = Stable.version
   ; dst_version = version
-  ; f = fun ast ~unwrap:_ ~wrap:_ -> update_ast ast
+  ; f = fun ast ~unwrap:_ ~wrap:_ -> Some (update_ast ast)
   }
 
 let conversions = [ to_stable; of_stable ]

--- a/astlib/version.ml
+++ b/astlib/version.ml
@@ -1,4 +1,6 @@
 type t = string
 
+let compare = String.compare
+let equal = String.equal
 let of_string t = t
 let to_string t = t

--- a/astlib/version.mli
+++ b/astlib/version.mli
@@ -1,5 +1,8 @@
 (** Represents a version of the OCaml compiler corresponding to a new AST. *)
 type t
 
+val compare : t -> t -> int
+val equal : t -> t -> bool
+
 val to_string : t -> string
 val of_string : string -> t


### PR DESCRIPTION
This is based on #83; once that is merged, this will be ready for proper review.

This PR models conversion failure as an optional return, and leaves intermediate nodes at whatever version they had before failure. This keeps us from associating the wrong version with a node.