### PR TITLE
Add accessors for fields of versioned record types.

### DIFF
--- a/ast/cinaps/ml.ml
+++ b/ast/cinaps/ml.ml
@@ -92,7 +92,7 @@ let declare_type ?(tvars = []) name element =
   print_with_element "type %s" (poly_type name ~tvars) ~between:"=" ~element
 
 let declare_val name element =
-  print_with_element "val %s" name ~between:":" ~element
+  print_with_element "val %s" (id name) ~between:":" ~element
 
 let print_record_type alist ~f =
   List.iteri alist ~f:(fun i (name, x) ->

--- a/ast/version_unstable_for_testing.ml
+++ b/ast/version_unstable_for_testing.ml
@@ -210,6 +210,11 @@ module Module_binding = struct
           node_name = "module_binding";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmb_loc t = (to_concrete t).pmb_loc
+  let pmb_attributes t = (to_concrete t).pmb_attributes
+  let pmb_expr t = (to_concrete t).pmb_expr
+  let pmb_name t = (to_concrete t).pmb_name
 end
 
 module Value_binding = struct
@@ -258,6 +263,11 @@ module Value_binding = struct
           node_name = "value_binding";
           node = Unversioned.Private.transparent node;
         })
+
+  let pvb_loc t = (to_concrete t).pvb_loc
+  let pvb_attributes t = (to_concrete t).pvb_attributes
+  let pvb_expr t = (to_concrete t).pvb_expr
+  let pvb_pat t = (to_concrete t).pvb_pat
 end
 
 module Structure_item_desc = struct
@@ -563,6 +573,9 @@ module Structure_item = struct
           node_name = "structure_item";
           node = Unversioned.Private.transparent node;
         })
+
+  let pstr_loc t = (to_concrete t).pstr_loc
+  let pstr_desc t = (to_concrete t).pstr_desc
 end
 
 module Structure = struct
@@ -779,6 +792,10 @@ module Module_expr = struct
           node_name = "module_expr";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmod_attributes t = (to_concrete t).pmod_attributes
+  let pmod_loc t = (to_concrete t).pmod_loc
+  let pmod_desc t = (to_concrete t).pmod_desc
 end
 
 module With_constraint = struct
@@ -978,6 +995,10 @@ module Include_infos = struct
           node_name = "include_infos";
           node = Unversioned.Private.transparent node;
         })
+
+  let pincl_attributes t = (to_concrete t).pincl_attributes
+  let pincl_loc t = (to_concrete t).pincl_loc
+  let pincl_mod t = (to_concrete t).pincl_mod
 end
 
 module Open_description = struct
@@ -1026,6 +1047,11 @@ module Open_description = struct
           node_name = "open_description";
           node = Unversioned.Private.transparent node;
         })
+
+  let popen_attributes t = (to_concrete t).popen_attributes
+  let popen_loc t = (to_concrete t).popen_loc
+  let popen_override t = (to_concrete t).popen_override
+  let popen_lid t = (to_concrete t).popen_lid
 end
 
 module Module_type_declaration = struct
@@ -1074,6 +1100,11 @@ module Module_type_declaration = struct
           node_name = "module_type_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmtd_loc t = (to_concrete t).pmtd_loc
+  let pmtd_attributes t = (to_concrete t).pmtd_attributes
+  let pmtd_type t = (to_concrete t).pmtd_type
+  let pmtd_name t = (to_concrete t).pmtd_name
 end
 
 module Module_declaration = struct
@@ -1122,6 +1153,11 @@ module Module_declaration = struct
           node_name = "module_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmd_loc t = (to_concrete t).pmd_loc
+  let pmd_attributes t = (to_concrete t).pmd_attributes
+  let pmd_type t = (to_concrete t).pmd_type
+  let pmd_name t = (to_concrete t).pmd_name
 end
 
 module Signature_item_desc = struct
@@ -1393,6 +1429,9 @@ module Signature_item = struct
           node_name = "signature_item";
           node = Unversioned.Private.transparent node;
         })
+
+  let psig_loc t = (to_concrete t).psig_loc
+  let psig_desc t = (to_concrete t).psig_desc
 end
 
 module Signature = struct
@@ -1607,6 +1646,10 @@ module Module_type = struct
           node_name = "module_type";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmty_attributes t = (to_concrete t).pmty_attributes
+  let pmty_loc t = (to_concrete t).pmty_loc
+  let pmty_desc t = (to_concrete t).pmty_desc
 end
 
 module Class_declaration = struct
@@ -1881,6 +1924,10 @@ module Class_field = struct
           node_name = "class_field";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcf_attributes t = (to_concrete t).pcf_attributes
+  let pcf_loc t = (to_concrete t).pcf_loc
+  let pcf_desc t = (to_concrete t).pcf_desc
 end
 
 module Class_structure = struct
@@ -1923,6 +1970,9 @@ module Class_structure = struct
           node_name = "class_structure";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcstr_fields t = (to_concrete t).pcstr_fields
+  let pcstr_self t = (to_concrete t).pcstr_self
 end
 
 module Class_expr_desc = struct
@@ -2138,6 +2188,10 @@ module Class_expr = struct
           node_name = "class_expr";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcl_attributes t = (to_concrete t).pcl_attributes
+  let pcl_loc t = (to_concrete t).pcl_loc
+  let pcl_desc t = (to_concrete t).pcl_desc
 end
 
 module Class_type_declaration = struct
@@ -2248,6 +2302,13 @@ module Class_infos = struct
           node_name = "class_infos";
           node = Unversioned.Private.transparent node;
         })
+
+  let pci_attributes t = (to_concrete t).pci_attributes
+  let pci_loc t = (to_concrete t).pci_loc
+  let pci_expr t = (to_concrete t).pci_expr
+  let pci_name t = (to_concrete t).pci_name
+  let pci_params t = (to_concrete t).pci_params
+  let pci_virt t = (to_concrete t).pci_virt
 end
 
 module Class_type_field_desc = struct
@@ -2413,6 +2474,10 @@ module Class_type_field = struct
           node_name = "class_type_field";
           node = Unversioned.Private.transparent node;
         })
+
+  let pctf_attributes t = (to_concrete t).pctf_attributes
+  let pctf_loc t = (to_concrete t).pctf_loc
+  let pctf_desc t = (to_concrete t).pctf_desc
 end
 
 module Class_signature = struct
@@ -2455,6 +2520,9 @@ module Class_signature = struct
           node_name = "class_signature";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcsig_fields t = (to_concrete t).pcsig_fields
+  let pcsig_self t = (to_concrete t).pcsig_self
 end
 
 module Class_type_desc = struct
@@ -2615,6 +2683,10 @@ module Class_type = struct
           node_name = "class_type";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcty_attributes t = (to_concrete t).pcty_attributes
+  let pcty_loc t = (to_concrete t).pcty_loc
+  let pcty_desc t = (to_concrete t).pcty_desc
 end
 
 module Extension_constructor_kind = struct
@@ -2725,6 +2797,11 @@ module Extension_constructor = struct
           node_name = "extension_constructor";
           node = Unversioned.Private.transparent node;
         })
+
+  let pext_attributes t = (to_concrete t).pext_attributes
+  let pext_loc t = (to_concrete t).pext_loc
+  let pext_kind t = (to_concrete t).pext_kind
+  let pext_name t = (to_concrete t).pext_name
 end
 
 module Type_extension = struct
@@ -2776,6 +2853,12 @@ module Type_extension = struct
           node_name = "type_extension";
           node = Unversioned.Private.transparent node;
         })
+
+  let ptyext_attributes t = (to_concrete t).ptyext_attributes
+  let ptyext_private t = (to_concrete t).ptyext_private
+  let ptyext_constructors t = (to_concrete t).ptyext_constructors
+  let ptyext_params t = (to_concrete t).ptyext_params
+  let ptyext_path t = (to_concrete t).ptyext_path
 end
 
 module Constructor_arguments = struct
@@ -2887,6 +2970,12 @@ module Constructor_declaration = struct
           node_name = "constructor_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcd_attributes t = (to_concrete t).pcd_attributes
+  let pcd_loc t = (to_concrete t).pcd_loc
+  let pcd_res t = (to_concrete t).pcd_res
+  let pcd_args t = (to_concrete t).pcd_args
+  let pcd_name t = (to_concrete t).pcd_name
 end
 
 module Label_declaration = struct
@@ -2938,6 +3027,12 @@ module Label_declaration = struct
           node_name = "label_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let pld_attributes t = (to_concrete t).pld_attributes
+  let pld_loc t = (to_concrete t).pld_loc
+  let pld_type t = (to_concrete t).pld_type
+  let pld_mutable t = (to_concrete t).pld_mutable
+  let pld_name t = (to_concrete t).pld_name
 end
 
 module Type_kind = struct
@@ -3068,6 +3163,15 @@ module Type_declaration = struct
           node_name = "type_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let ptype_loc t = (to_concrete t).ptype_loc
+  let ptype_attributes t = (to_concrete t).ptype_attributes
+  let ptype_manifest t = (to_concrete t).ptype_manifest
+  let ptype_private t = (to_concrete t).ptype_private
+  let ptype_kind t = (to_concrete t).ptype_kind
+  let ptype_cstrs t = (to_concrete t).ptype_cstrs
+  let ptype_params t = (to_concrete t).ptype_params
+  let ptype_name t = (to_concrete t).ptype_name
 end
 
 module Value_description = struct
@@ -3119,6 +3223,12 @@ module Value_description = struct
           node_name = "value_description";
           node = Unversioned.Private.transparent node;
         })
+
+  let pval_loc t = (to_concrete t).pval_loc
+  let pval_attributes t = (to_concrete t).pval_attributes
+  let pval_prim t = (to_concrete t).pval_prim
+  let pval_type t = (to_concrete t).pval_type
+  let pval_name t = (to_concrete t).pval_name
 end
 
 module Case = struct
@@ -3164,6 +3274,10 @@ module Case = struct
           node_name = "case";
           node = Unversioned.Private.transparent node;
         })
+
+  let pc_rhs t = (to_concrete t).pc_rhs
+  let pc_guard t = (to_concrete t).pc_guard
+  let pc_lhs t = (to_concrete t).pc_lhs
 end
 
 module Expression_desc = struct
@@ -3837,6 +3951,10 @@ module Expression = struct
           node_name = "expression";
           node = Unversioned.Private.transparent node;
         })
+
+  let pexp_attributes t = (to_concrete t).pexp_attributes
+  let pexp_loc t = (to_concrete t).pexp_loc
+  let pexp_desc t = (to_concrete t).pexp_desc
 end
 
 module Pattern_desc = struct
@@ -4188,6 +4306,10 @@ module Pattern = struct
           node_name = "pattern";
           node = Unversioned.Private.transparent node;
         })
+
+  let ppat_attributes t = (to_concrete t).ppat_attributes
+  let ppat_loc t = (to_concrete t).ppat_loc
+  let ppat_desc t = (to_concrete t).ppat_desc
 end
 
 module Object_field = struct
@@ -4609,6 +4731,10 @@ module Core_type = struct
           node_name = "core_type";
           node = Unversioned.Private.transparent node;
         })
+
+  let ptyp_attributes t = (to_concrete t).ptyp_attributes
+  let ptyp_loc t = (to_concrete t).ptyp_loc
+  let ptyp_desc t = (to_concrete t).ptyp_desc
 end
 
 module Payload = struct

--- a/ast/version_unstable_for_testing.mli
+++ b/ast/version_unstable_for_testing.mli
@@ -71,6 +71,11 @@ and Module_binding : sig
     -> pmb_expr:Module_expr.t
     -> pmb_name:string Astlib.Loc.t
     -> t
+
+  val pmb_loc : t -> Astlib.Location.t
+  val pmb_attributes : t -> Attributes.t
+  val pmb_expr : t -> Module_expr.t
+  val pmb_name : t -> string Astlib.Loc.t
 end
 
 and Value_binding : sig
@@ -93,6 +98,11 @@ and Value_binding : sig
     -> pvb_expr:Expression.t
     -> pvb_pat:Pattern.t
     -> t
+
+  val pvb_loc : t -> Astlib.Location.t
+  val pvb_attributes : t -> Attributes.t
+  val pvb_expr : t -> Expression.t
+  val pvb_pat : t -> Pattern.t
 end
 
 and Structure_item_desc : sig
@@ -186,6 +196,9 @@ and Structure_item : sig
     pstr_loc:Astlib.Location.t
     -> pstr_desc:Structure_item_desc.t
     -> t
+
+  val pstr_loc : t -> Astlib.Location.t
+  val pstr_desc : t -> Structure_item_desc.t
 end
 
 and Structure : sig
@@ -261,6 +274,10 @@ and Module_expr : sig
     -> pmod_loc:Astlib.Location.t
     -> pmod_desc:Module_expr_desc.t
     -> t
+
+  val pmod_attributes : t -> Attributes.t
+  val pmod_loc : t -> Astlib.Location.t
+  val pmod_desc : t -> Module_expr_desc.t
 end
 
 and With_constraint : sig
@@ -336,6 +353,10 @@ and Include_infos : sig
     -> pincl_loc:Astlib.Location.t
     -> pincl_mod:'a node
     -> 'a node t
+
+  val pincl_attributes : 'a node t -> Attributes.t
+  val pincl_loc : 'a node t -> Astlib.Location.t
+  val pincl_mod : 'a node t -> 'a node
 end
 
 and Open_description : sig
@@ -358,6 +379,11 @@ and Open_description : sig
     -> popen_override:Override_flag.t
     -> popen_lid:Longident_loc.t
     -> t
+
+  val popen_attributes : t -> Attributes.t
+  val popen_loc : t -> Astlib.Location.t
+  val popen_override : t -> Override_flag.t
+  val popen_lid : t -> Longident_loc.t
 end
 
 and Module_type_declaration : sig
@@ -380,6 +406,11 @@ and Module_type_declaration : sig
     -> pmtd_type:Module_type.t option
     -> pmtd_name:string Astlib.Loc.t
     -> t
+
+  val pmtd_loc : t -> Astlib.Location.t
+  val pmtd_attributes : t -> Attributes.t
+  val pmtd_type : t -> Module_type.t option
+  val pmtd_name : t -> string Astlib.Loc.t
 end
 
 and Module_declaration : sig
@@ -402,6 +433,11 @@ and Module_declaration : sig
     -> pmd_type:Module_type.t
     -> pmd_name:string Astlib.Loc.t
     -> t
+
+  val pmd_loc : t -> Astlib.Location.t
+  val pmd_attributes : t -> Attributes.t
+  val pmd_type : t -> Module_type.t
+  val pmd_name : t -> string Astlib.Loc.t
 end
 
 and Signature_item_desc : sig
@@ -485,6 +521,9 @@ and Signature_item : sig
     psig_loc:Astlib.Location.t
     -> psig_desc:Signature_item_desc.t
     -> t
+
+  val psig_loc : t -> Astlib.Location.t
+  val psig_desc : t -> Signature_item_desc.t
 end
 
 and Signature : sig
@@ -559,6 +598,10 @@ and Module_type : sig
     -> pmty_loc:Astlib.Location.t
     -> pmty_desc:Module_type_desc.t
     -> t
+
+  val pmty_attributes : t -> Attributes.t
+  val pmty_loc : t -> Astlib.Location.t
+  val pmty_desc : t -> Module_type_desc.t
 end
 
 and Class_declaration : sig
@@ -652,6 +695,10 @@ and Class_field : sig
     -> pcf_loc:Astlib.Location.t
     -> pcf_desc:Class_field_desc.t
     -> t
+
+  val pcf_attributes : t -> Attributes.t
+  val pcf_loc : t -> Astlib.Location.t
+  val pcf_desc : t -> Class_field_desc.t
 end
 
 and Class_structure : sig
@@ -670,6 +717,9 @@ and Class_structure : sig
     pcstr_fields:Class_field.t list
     -> pcstr_self:Pattern.t
     -> t
+
+  val pcstr_fields : t -> Class_field.t list
+  val pcstr_self : t -> Pattern.t
 end
 
 and Class_expr_desc : sig
@@ -743,6 +793,10 @@ and Class_expr : sig
     -> pcl_loc:Astlib.Location.t
     -> pcl_desc:Class_expr_desc.t
     -> t
+
+  val pcl_attributes : t -> Attributes.t
+  val pcl_loc : t -> Astlib.Location.t
+  val pcl_desc : t -> Class_expr_desc.t
 end
 
 and Class_type_declaration : sig
@@ -793,6 +847,13 @@ and Class_infos : sig
     -> pci_params:(Variance.t * Core_type.t) list
     -> pci_virt:Virtual_flag.t
     -> 'a node t
+
+  val pci_attributes : 'a node t -> Attributes.t
+  val pci_loc : 'a node t -> Astlib.Location.t
+  val pci_expr : 'a node t -> 'a node
+  val pci_name : 'a node t -> string Astlib.Loc.t
+  val pci_params : 'a node t -> (Variance.t * Core_type.t) list
+  val pci_virt : 'a node t -> Virtual_flag.t
 end
 
 and Class_type_field_desc : sig
@@ -848,6 +909,10 @@ and Class_type_field : sig
     -> pctf_loc:Astlib.Location.t
     -> pctf_desc:Class_type_field_desc.t
     -> t
+
+  val pctf_attributes : t -> Attributes.t
+  val pctf_loc : t -> Astlib.Location.t
+  val pctf_desc : t -> Class_type_field_desc.t
 end
 
 and Class_signature : sig
@@ -866,6 +931,9 @@ and Class_signature : sig
     pcsig_fields:Class_type_field.t list
     -> pcsig_self:Core_type.t
     -> t
+
+  val pcsig_fields : t -> Class_type_field.t list
+  val pcsig_self : t -> Core_type.t
 end
 
 and Class_type_desc : sig
@@ -922,6 +990,10 @@ and Class_type : sig
     -> pcty_loc:Astlib.Location.t
     -> pcty_desc:Class_type_desc.t
     -> t
+
+  val pcty_attributes : t -> Attributes.t
+  val pcty_loc : t -> Astlib.Location.t
+  val pcty_desc : t -> Class_type_desc.t
 end
 
 and Extension_constructor_kind : sig
@@ -964,6 +1036,11 @@ and Extension_constructor : sig
     -> pext_kind:Extension_constructor_kind.t
     -> pext_name:string Astlib.Loc.t
     -> t
+
+  val pext_attributes : t -> Attributes.t
+  val pext_loc : t -> Astlib.Location.t
+  val pext_kind : t -> Extension_constructor_kind.t
+  val pext_name : t -> string Astlib.Loc.t
 end
 
 and Type_extension : sig
@@ -988,6 +1065,12 @@ and Type_extension : sig
     -> ptyext_params:(Variance.t * Core_type.t) list
     -> ptyext_path:Longident_loc.t
     -> t
+
+  val ptyext_attributes : t -> Attributes.t
+  val ptyext_private : t -> Private_flag.t
+  val ptyext_constructors : t -> Extension_constructor.t list
+  val ptyext_params : t -> (Variance.t * Core_type.t) list
+  val ptyext_path : t -> Longident_loc.t
 end
 
 and Constructor_arguments : sig
@@ -1031,6 +1114,12 @@ and Constructor_declaration : sig
     -> pcd_args:Constructor_arguments.t
     -> pcd_name:string Astlib.Loc.t
     -> t
+
+  val pcd_attributes : t -> Attributes.t
+  val pcd_loc : t -> Astlib.Location.t
+  val pcd_res : t -> Core_type.t option
+  val pcd_args : t -> Constructor_arguments.t
+  val pcd_name : t -> string Astlib.Loc.t
 end
 
 and Label_declaration : sig
@@ -1055,6 +1144,12 @@ and Label_declaration : sig
     -> pld_mutable:Mutable_flag.t
     -> pld_name:string Astlib.Loc.t
     -> t
+
+  val pld_attributes : t -> Attributes.t
+  val pld_loc : t -> Astlib.Location.t
+  val pld_type : t -> Core_type.t
+  val pld_mutable : t -> Mutable_flag.t
+  val pld_name : t -> string Astlib.Loc.t
 end
 
 and Type_kind : sig
@@ -1108,6 +1203,15 @@ and Type_declaration : sig
     -> ptype_params:(Variance.t * Core_type.t) list
     -> ptype_name:string Astlib.Loc.t
     -> t
+
+  val ptype_loc : t -> Astlib.Location.t
+  val ptype_attributes : t -> Attributes.t
+  val ptype_manifest : t -> Core_type.t option
+  val ptype_private : t -> Private_flag.t
+  val ptype_kind : t -> Type_kind.t
+  val ptype_cstrs : t -> (Astlib.Location.t * Core_type.t * Core_type.t) list
+  val ptype_params : t -> (Variance.t * Core_type.t) list
+  val ptype_name : t -> string Astlib.Loc.t
 end
 
 and Value_description : sig
@@ -1132,6 +1236,12 @@ and Value_description : sig
     -> pval_type:Core_type.t
     -> pval_name:string Astlib.Loc.t
     -> t
+
+  val pval_loc : t -> Astlib.Location.t
+  val pval_attributes : t -> Attributes.t
+  val pval_prim : t -> string list
+  val pval_type : t -> Core_type.t
+  val pval_name : t -> string Astlib.Loc.t
 end
 
 and Case : sig
@@ -1152,6 +1262,10 @@ and Case : sig
     -> pc_guard:Expression.t option
     -> pc_lhs:Pattern.t
     -> t
+
+  val pc_rhs : t -> Expression.t
+  val pc_guard : t -> Expression.t option
+  val pc_lhs : t -> Pattern.t
 end
 
 and Expression_desc : sig
@@ -1359,6 +1473,10 @@ and Expression : sig
     -> pexp_loc:Astlib.Location.t
     -> pexp_desc:Expression_desc.t
     -> t
+
+  val pexp_attributes : t -> Attributes.t
+  val pexp_loc : t -> Astlib.Location.t
+  val pexp_desc : t -> Expression_desc.t
 end
 
 and Pattern_desc : sig
@@ -1468,6 +1586,10 @@ and Pattern : sig
     -> ppat_loc:Astlib.Location.t
     -> ppat_desc:Pattern_desc.t
     -> t
+
+  val ppat_attributes : t -> Attributes.t
+  val ppat_loc : t -> Astlib.Location.t
+  val ppat_desc : t -> Pattern_desc.t
 end
 
 and Object_field : sig
@@ -1609,6 +1731,10 @@ and Core_type : sig
     -> ptyp_loc:Astlib.Location.t
     -> ptyp_desc:Core_type_desc.t
     -> t
+
+  val ptyp_attributes : t -> Attributes.t
+  val ptyp_loc : t -> Astlib.Location.t
+  val ptyp_desc : t -> Core_type_desc.t
 end
 
 and Payload : sig

--- a/ast/version_v4_07.ml
+++ b/ast/version_v4_07.ml
@@ -817,6 +817,10 @@ module Core_type = struct
           node_name = "core_type";
           node = Unversioned.Private.transparent node;
         })
+
+  let ptyp_desc t = (to_concrete t).ptyp_desc
+  let ptyp_loc t = (to_concrete t).ptyp_loc
+  let ptyp_attributes t = (to_concrete t).ptyp_attributes
 end
 
 module Core_type_desc = struct
@@ -1238,6 +1242,10 @@ module Pattern = struct
           node_name = "pattern";
           node = Unversioned.Private.transparent node;
         })
+
+  let ppat_desc t = (to_concrete t).ppat_desc
+  let ppat_loc t = (to_concrete t).ppat_loc
+  let ppat_attributes t = (to_concrete t).ppat_attributes
 end
 
 module Pattern_desc = struct
@@ -1589,6 +1597,10 @@ module Expression = struct
           node_name = "expression";
           node = Unversioned.Private.transparent node;
         })
+
+  let pexp_desc t = (to_concrete t).pexp_desc
+  let pexp_loc t = (to_concrete t).pexp_loc
+  let pexp_attributes t = (to_concrete t).pexp_attributes
 end
 
 module Expression_desc = struct
@@ -2262,6 +2274,10 @@ module Case = struct
           node_name = "case";
           node = Unversioned.Private.transparent node;
         })
+
+  let pc_lhs t = (to_concrete t).pc_lhs
+  let pc_guard t = (to_concrete t).pc_guard
+  let pc_rhs t = (to_concrete t).pc_rhs
 end
 
 module Value_description = struct
@@ -2313,6 +2329,12 @@ module Value_description = struct
           node_name = "value_description";
           node = Unversioned.Private.transparent node;
         })
+
+  let pval_name t = (to_concrete t).pval_name
+  let pval_type t = (to_concrete t).pval_type
+  let pval_prim t = (to_concrete t).pval_prim
+  let pval_attributes t = (to_concrete t).pval_attributes
+  let pval_loc t = (to_concrete t).pval_loc
 end
 
 module Type_declaration = struct
@@ -2373,6 +2395,15 @@ module Type_declaration = struct
           node_name = "type_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let ptype_name t = (to_concrete t).ptype_name
+  let ptype_params t = (to_concrete t).ptype_params
+  let ptype_cstrs t = (to_concrete t).ptype_cstrs
+  let ptype_kind t = (to_concrete t).ptype_kind
+  let ptype_private t = (to_concrete t).ptype_private
+  let ptype_manifest t = (to_concrete t).ptype_manifest
+  let ptype_attributes t = (to_concrete t).ptype_attributes
+  let ptype_loc t = (to_concrete t).ptype_loc
 end
 
 module Type_kind = struct
@@ -2494,6 +2525,12 @@ module Label_declaration = struct
           node_name = "label_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let pld_name t = (to_concrete t).pld_name
+  let pld_mutable t = (to_concrete t).pld_mutable
+  let pld_type t = (to_concrete t).pld_type
+  let pld_loc t = (to_concrete t).pld_loc
+  let pld_attributes t = (to_concrete t).pld_attributes
 end
 
 module Constructor_declaration = struct
@@ -2545,6 +2582,12 @@ module Constructor_declaration = struct
           node_name = "constructor_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcd_name t = (to_concrete t).pcd_name
+  let pcd_args t = (to_concrete t).pcd_args
+  let pcd_res t = (to_concrete t).pcd_res
+  let pcd_loc t = (to_concrete t).pcd_loc
+  let pcd_attributes t = (to_concrete t).pcd_attributes
 end
 
 module Constructor_arguments = struct
@@ -2656,6 +2699,12 @@ module Type_extension = struct
           node_name = "type_extension";
           node = Unversioned.Private.transparent node;
         })
+
+  let ptyext_path t = (to_concrete t).ptyext_path
+  let ptyext_params t = (to_concrete t).ptyext_params
+  let ptyext_constructors t = (to_concrete t).ptyext_constructors
+  let ptyext_private t = (to_concrete t).ptyext_private
+  let ptyext_attributes t = (to_concrete t).ptyext_attributes
 end
 
 module Extension_constructor = struct
@@ -2704,6 +2753,11 @@ module Extension_constructor = struct
           node_name = "extension_constructor";
           node = Unversioned.Private.transparent node;
         })
+
+  let pext_name t = (to_concrete t).pext_name
+  let pext_kind t = (to_concrete t).pext_kind
+  let pext_loc t = (to_concrete t).pext_loc
+  let pext_attributes t = (to_concrete t).pext_attributes
 end
 
 module Extension_constructor_kind = struct
@@ -2811,6 +2865,10 @@ module Class_type = struct
           node_name = "class_type";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcty_desc t = (to_concrete t).pcty_desc
+  let pcty_loc t = (to_concrete t).pcty_loc
+  let pcty_attributes t = (to_concrete t).pcty_attributes
 end
 
 module Class_type_desc = struct
@@ -2968,6 +3026,9 @@ module Class_signature = struct
           node_name = "class_signature";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcsig_self t = (to_concrete t).pcsig_self
+  let pcsig_fields t = (to_concrete t).pcsig_fields
 end
 
 module Class_type_field = struct
@@ -3013,6 +3074,10 @@ module Class_type_field = struct
           node_name = "class_type_field";
           node = Unversioned.Private.transparent node;
         })
+
+  let pctf_desc t = (to_concrete t).pctf_desc
+  let pctf_loc t = (to_concrete t).pctf_loc
+  let pctf_attributes t = (to_concrete t).pctf_attributes
 end
 
 module Class_type_field_desc = struct
@@ -3187,6 +3252,13 @@ module Class_infos = struct
           node_name = "class_infos";
           node = Unversioned.Private.transparent node;
         })
+
+  let pci_virt t = (to_concrete t).pci_virt
+  let pci_params t = (to_concrete t).pci_params
+  let pci_name t = (to_concrete t).pci_name
+  let pci_expr t = (to_concrete t).pci_expr
+  let pci_loc t = (to_concrete t).pci_loc
+  let pci_attributes t = (to_concrete t).pci_attributes
 end
 
 module Class_description = struct
@@ -3288,6 +3360,10 @@ module Class_expr = struct
           node_name = "class_expr";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcl_desc t = (to_concrete t).pcl_desc
+  let pcl_loc t = (to_concrete t).pcl_loc
+  let pcl_attributes t = (to_concrete t).pcl_attributes
 end
 
 module Class_expr_desc = struct
@@ -3500,6 +3576,9 @@ module Class_structure = struct
           node_name = "class_structure";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcstr_self t = (to_concrete t).pcstr_self
+  let pcstr_fields t = (to_concrete t).pcstr_fields
 end
 
 module Class_field = struct
@@ -3545,6 +3624,10 @@ module Class_field = struct
           node_name = "class_field";
           node = Unversioned.Private.transparent node;
         })
+
+  let pcf_desc t = (to_concrete t).pcf_desc
+  let pcf_loc t = (to_concrete t).pcf_loc
+  let pcf_attributes t = (to_concrete t).pcf_attributes
 end
 
 module Class_field_desc = struct
@@ -3819,6 +3902,10 @@ module Module_type = struct
           node_name = "module_type";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmty_desc t = (to_concrete t).pmty_desc
+  let pmty_loc t = (to_concrete t).pmty_loc
+  let pmty_attributes t = (to_concrete t).pmty_attributes
 end
 
 module Module_type_desc = struct
@@ -4030,6 +4117,9 @@ module Signature_item = struct
           node_name = "signature_item";
           node = Unversioned.Private.transparent node;
         })
+
+  let psig_desc t = (to_concrete t).psig_desc
+  let psig_loc t = (to_concrete t).psig_loc
 end
 
 module Signature_item_desc = struct
@@ -4307,6 +4397,11 @@ module Module_declaration = struct
           node_name = "module_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmd_name t = (to_concrete t).pmd_name
+  let pmd_type t = (to_concrete t).pmd_type
+  let pmd_attributes t = (to_concrete t).pmd_attributes
+  let pmd_loc t = (to_concrete t).pmd_loc
 end
 
 module Module_type_declaration = struct
@@ -4355,6 +4450,11 @@ module Module_type_declaration = struct
           node_name = "module_type_declaration";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmtd_name t = (to_concrete t).pmtd_name
+  let pmtd_type t = (to_concrete t).pmtd_type
+  let pmtd_attributes t = (to_concrete t).pmtd_attributes
+  let pmtd_loc t = (to_concrete t).pmtd_loc
 end
 
 module Open_description = struct
@@ -4403,6 +4503,11 @@ module Open_description = struct
           node_name = "open_description";
           node = Unversioned.Private.transparent node;
         })
+
+  let popen_lid t = (to_concrete t).popen_lid
+  let popen_override t = (to_concrete t).popen_override
+  let popen_loc t = (to_concrete t).popen_loc
+  let popen_attributes t = (to_concrete t).popen_attributes
 end
 
 module Include_infos = struct
@@ -4448,6 +4553,10 @@ module Include_infos = struct
           node_name = "include_infos";
           node = Unversioned.Private.transparent node;
         })
+
+  let pincl_mod t = (to_concrete t).pincl_mod
+  let pincl_loc t = (to_concrete t).pincl_loc
+  let pincl_attributes t = (to_concrete t).pincl_attributes
 end
 
 module Include_description = struct
@@ -4647,6 +4756,10 @@ module Module_expr = struct
           node_name = "module_expr";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmod_desc t = (to_concrete t).pmod_desc
+  let pmod_loc t = (to_concrete t).pmod_loc
+  let pmod_attributes t = (to_concrete t).pmod_attributes
 end
 
 module Module_expr_desc = struct
@@ -4860,6 +4973,9 @@ module Structure_item = struct
           node_name = "structure_item";
           node = Unversioned.Private.transparent node;
         })
+
+  let pstr_desc t = (to_concrete t).pstr_desc
+  let pstr_loc t = (to_concrete t).pstr_loc
 end
 
 module Structure_item_desc = struct
@@ -5171,6 +5287,11 @@ module Value_binding = struct
           node_name = "value_binding";
           node = Unversioned.Private.transparent node;
         })
+
+  let pvb_pat t = (to_concrete t).pvb_pat
+  let pvb_expr t = (to_concrete t).pvb_expr
+  let pvb_attributes t = (to_concrete t).pvb_attributes
+  let pvb_loc t = (to_concrete t).pvb_loc
 end
 
 module Module_binding = struct
@@ -5219,6 +5340,11 @@ module Module_binding = struct
           node_name = "module_binding";
           node = Unversioned.Private.transparent node;
         })
+
+  let pmb_name t = (to_concrete t).pmb_name
+  let pmb_expr t = (to_concrete t).pmb_expr
+  let pmb_attributes t = (to_concrete t).pmb_attributes
+  let pmb_loc t = (to_concrete t).pmb_loc
 end
 
 module Toplevel_phrase = struct

--- a/ast/version_v4_07.mli
+++ b/ast/version_v4_07.mli
@@ -293,6 +293,10 @@ and Core_type : sig
     -> ptyp_loc:Astlib.Location.t
     -> ptyp_attributes:Attributes.t
     -> t
+
+  val ptyp_desc : t -> Core_type_desc.t
+  val ptyp_loc : t -> Astlib.Location.t
+  val ptyp_attributes : t -> Attributes.t
 end
 
 and Core_type_desc : sig
@@ -434,6 +438,10 @@ and Pattern : sig
     -> ppat_loc:Astlib.Location.t
     -> ppat_attributes:Attributes.t
     -> t
+
+  val ppat_desc : t -> Pattern_desc.t
+  val ppat_loc : t -> Astlib.Location.t
+  val ppat_attributes : t -> Attributes.t
 end
 
 and Pattern_desc : sig
@@ -543,6 +551,10 @@ and Expression : sig
     -> pexp_loc:Astlib.Location.t
     -> pexp_attributes:Attributes.t
     -> t
+
+  val pexp_desc : t -> Expression_desc.t
+  val pexp_loc : t -> Astlib.Location.t
+  val pexp_attributes : t -> Attributes.t
 end
 
 and Expression_desc : sig
@@ -750,6 +762,10 @@ and Case : sig
     -> pc_guard:Expression.t option
     -> pc_rhs:Expression.t
     -> t
+
+  val pc_lhs : t -> Pattern.t
+  val pc_guard : t -> Expression.t option
+  val pc_rhs : t -> Expression.t
 end
 
 and Value_description : sig
@@ -774,6 +790,12 @@ and Value_description : sig
     -> pval_attributes:Attributes.t
     -> pval_loc:Astlib.Location.t
     -> t
+
+  val pval_name : t -> string Astlib.Loc.t
+  val pval_type : t -> Core_type.t
+  val pval_prim : t -> string list
+  val pval_attributes : t -> Attributes.t
+  val pval_loc : t -> Astlib.Location.t
 end
 
 and Type_declaration : sig
@@ -804,6 +826,15 @@ and Type_declaration : sig
     -> ptype_attributes:Attributes.t
     -> ptype_loc:Astlib.Location.t
     -> t
+
+  val ptype_name : t -> string Astlib.Loc.t
+  val ptype_params : t -> (Core_type.t * Variance.t) list
+  val ptype_cstrs : t -> (Core_type.t * Core_type.t * Astlib.Location.t) list
+  val ptype_kind : t -> Type_kind.t
+  val ptype_private : t -> Private_flag.t
+  val ptype_manifest : t -> Core_type.t option
+  val ptype_attributes : t -> Attributes.t
+  val ptype_loc : t -> Astlib.Location.t
 end
 
 and Type_kind : sig
@@ -851,6 +882,12 @@ and Label_declaration : sig
     -> pld_loc:Astlib.Location.t
     -> pld_attributes:Attributes.t
     -> t
+
+  val pld_name : t -> string Astlib.Loc.t
+  val pld_mutable : t -> Mutable_flag.t
+  val pld_type : t -> Core_type.t
+  val pld_loc : t -> Astlib.Location.t
+  val pld_attributes : t -> Attributes.t
 end
 
 and Constructor_declaration : sig
@@ -875,6 +912,12 @@ and Constructor_declaration : sig
     -> pcd_loc:Astlib.Location.t
     -> pcd_attributes:Attributes.t
     -> t
+
+  val pcd_name : t -> string Astlib.Loc.t
+  val pcd_args : t -> Constructor_arguments.t
+  val pcd_res : t -> Core_type.t option
+  val pcd_loc : t -> Astlib.Location.t
+  val pcd_attributes : t -> Attributes.t
 end
 
 and Constructor_arguments : sig
@@ -918,6 +961,12 @@ and Type_extension : sig
     -> ptyext_private:Private_flag.t
     -> ptyext_attributes:Attributes.t
     -> t
+
+  val ptyext_path : t -> Longident_loc.t
+  val ptyext_params : t -> (Core_type.t * Variance.t) list
+  val ptyext_constructors : t -> Extension_constructor.t list
+  val ptyext_private : t -> Private_flag.t
+  val ptyext_attributes : t -> Attributes.t
 end
 
 and Extension_constructor : sig
@@ -940,6 +989,11 @@ and Extension_constructor : sig
     -> pext_loc:Astlib.Location.t
     -> pext_attributes:Attributes.t
     -> t
+
+  val pext_name : t -> string Astlib.Loc.t
+  val pext_kind : t -> Extension_constructor_kind.t
+  val pext_loc : t -> Astlib.Location.t
+  val pext_attributes : t -> Attributes.t
 end
 
 and Extension_constructor_kind : sig
@@ -980,6 +1034,10 @@ and Class_type : sig
     -> pcty_loc:Astlib.Location.t
     -> pcty_attributes:Attributes.t
     -> t
+
+  val pcty_desc : t -> Class_type_desc.t
+  val pcty_loc : t -> Astlib.Location.t
+  val pcty_attributes : t -> Attributes.t
 end
 
 and Class_type_desc : sig
@@ -1034,6 +1092,9 @@ and Class_signature : sig
     pcsig_self:Core_type.t
     -> pcsig_fields:Class_type_field.t list
     -> t
+
+  val pcsig_self : t -> Core_type.t
+  val pcsig_fields : t -> Class_type_field.t list
 end
 
 and Class_type_field : sig
@@ -1054,6 +1115,10 @@ and Class_type_field : sig
     -> pctf_loc:Astlib.Location.t
     -> pctf_attributes:Attributes.t
     -> t
+
+  val pctf_desc : t -> Class_type_field_desc.t
+  val pctf_loc : t -> Astlib.Location.t
+  val pctf_attributes : t -> Attributes.t
 end
 
 and Class_type_field_desc : sig
@@ -1115,6 +1180,13 @@ and Class_infos : sig
     -> pci_loc:Astlib.Location.t
     -> pci_attributes:Attributes.t
     -> 'a node t
+
+  val pci_virt : 'a node t -> Virtual_flag.t
+  val pci_params : 'a node t -> (Core_type.t * Variance.t) list
+  val pci_name : 'a node t -> string Astlib.Loc.t
+  val pci_expr : 'a node t -> 'a node
+  val pci_loc : 'a node t -> Astlib.Location.t
+  val pci_attributes : 'a node t -> Attributes.t
 end
 
 and Class_description : sig
@@ -1159,6 +1231,10 @@ and Class_expr : sig
     -> pcl_loc:Astlib.Location.t
     -> pcl_attributes:Attributes.t
     -> t
+
+  val pcl_desc : t -> Class_expr_desc.t
+  val pcl_loc : t -> Astlib.Location.t
+  val pcl_attributes : t -> Attributes.t
 end
 
 and Class_expr_desc : sig
@@ -1230,6 +1306,9 @@ and Class_structure : sig
     pcstr_self:Pattern.t
     -> pcstr_fields:Class_field.t list
     -> t
+
+  val pcstr_self : t -> Pattern.t
+  val pcstr_fields : t -> Class_field.t list
 end
 
 and Class_field : sig
@@ -1250,6 +1329,10 @@ and Class_field : sig
     -> pcf_loc:Astlib.Location.t
     -> pcf_attributes:Attributes.t
     -> t
+
+  val pcf_desc : t -> Class_field_desc.t
+  val pcf_loc : t -> Astlib.Location.t
+  val pcf_attributes : t -> Attributes.t
 end
 
 and Class_field_desc : sig
@@ -1343,6 +1426,10 @@ and Module_type : sig
     -> pmty_loc:Astlib.Location.t
     -> pmty_attributes:Attributes.t
     -> t
+
+  val pmty_desc : t -> Module_type_desc.t
+  val pmty_loc : t -> Astlib.Location.t
+  val pmty_attributes : t -> Attributes.t
 end
 
 and Module_type_desc : sig
@@ -1415,6 +1502,9 @@ and Signature_item : sig
     psig_desc:Signature_item_desc.t
     -> psig_loc:Astlib.Location.t
     -> t
+
+  val psig_desc : t -> Signature_item_desc.t
+  val psig_loc : t -> Astlib.Location.t
 end
 
 and Signature_item_desc : sig
@@ -1502,6 +1592,11 @@ and Module_declaration : sig
     -> pmd_attributes:Attributes.t
     -> pmd_loc:Astlib.Location.t
     -> t
+
+  val pmd_name : t -> string Astlib.Loc.t
+  val pmd_type : t -> Module_type.t
+  val pmd_attributes : t -> Attributes.t
+  val pmd_loc : t -> Astlib.Location.t
 end
 
 and Module_type_declaration : sig
@@ -1524,6 +1619,11 @@ and Module_type_declaration : sig
     -> pmtd_attributes:Attributes.t
     -> pmtd_loc:Astlib.Location.t
     -> t
+
+  val pmtd_name : t -> string Astlib.Loc.t
+  val pmtd_type : t -> Module_type.t option
+  val pmtd_attributes : t -> Attributes.t
+  val pmtd_loc : t -> Astlib.Location.t
 end
 
 and Open_description : sig
@@ -1546,6 +1646,11 @@ and Open_description : sig
     -> popen_loc:Astlib.Location.t
     -> popen_attributes:Attributes.t
     -> t
+
+  val popen_lid : t -> Longident_loc.t
+  val popen_override : t -> Override_flag.t
+  val popen_loc : t -> Astlib.Location.t
+  val popen_attributes : t -> Attributes.t
 end
 
 and Include_infos : sig
@@ -1566,6 +1671,10 @@ and Include_infos : sig
     -> pincl_loc:Astlib.Location.t
     -> pincl_attributes:Attributes.t
     -> 'a node t
+
+  val pincl_mod : 'a node t -> 'a node
+  val pincl_loc : 'a node t -> Astlib.Location.t
+  val pincl_attributes : 'a node t -> Attributes.t
 end
 
 and Include_description : sig
@@ -1641,6 +1750,10 @@ and Module_expr : sig
     -> pmod_loc:Astlib.Location.t
     -> pmod_attributes:Attributes.t
     -> t
+
+  val pmod_desc : t -> Module_expr_desc.t
+  val pmod_loc : t -> Astlib.Location.t
+  val pmod_attributes : t -> Attributes.t
 end
 
 and Module_expr_desc : sig
@@ -1714,6 +1827,9 @@ and Structure_item : sig
     pstr_desc:Structure_item_desc.t
     -> pstr_loc:Astlib.Location.t
     -> t
+
+  val pstr_desc : t -> Structure_item_desc.t
+  val pstr_loc : t -> Astlib.Location.t
 end
 
 and Structure_item_desc : sig
@@ -1811,6 +1927,11 @@ and Value_binding : sig
     -> pvb_attributes:Attributes.t
     -> pvb_loc:Astlib.Location.t
     -> t
+
+  val pvb_pat : t -> Pattern.t
+  val pvb_expr : t -> Expression.t
+  val pvb_attributes : t -> Attributes.t
+  val pvb_loc : t -> Astlib.Location.t
 end
 
 and Module_binding : sig
@@ -1833,6 +1954,11 @@ and Module_binding : sig
     -> pmb_attributes:Attributes.t
     -> pmb_loc:Astlib.Location.t
     -> t
+
+  val pmb_name : t -> string Astlib.Loc.t
+  val pmb_expr : t -> Module_expr.t
+  val pmb_attributes : t -> Attributes.t
+  val pmb_loc : t -> Astlib.Location.t
 end
 
 and Toplevel_phrase : sig


### PR DESCRIPTION
These accessors raise if the conversion fails. They perform a full `to_concrete` first; there's room to improve their performance. I left a "TODO" comment.