### PR TITLE
Use polymorphic methods instead of instantiated methods.

### DIFF
--- a/ast/cinaps/ml.ml
+++ b/ast/cinaps/ml.ml
@@ -161,7 +161,7 @@ let declare_method ?(virtual_=false) ~name ~signature () =
   let qualifier = if virtual_ then "virtual " else "" in
   Print.println "method %s%s : %s" qualifier name signature
 
-let define_anon_fun ~args f =
+let print_anon_fun ~args f =
   let args_str = String.concat ~sep:" " args in
   Print.println "fun %s ->" args_str;
   Print.indented f

--- a/ast/cinaps/ml.mli
+++ b/ast/cinaps/ml.mli
@@ -58,4 +58,4 @@ val define_object : ?bind_self: bool -> (unit -> unit) -> unit
 val declare_method : ?virtual_: bool -> name: string -> signature: string -> unit -> unit
 val define_method : ?signature: string -> string -> (unit -> unit) -> unit
 
-val define_anon_fun : args: string list -> (unit -> unit) -> unit
+val print_anon_fun : args: string list -> (unit -> unit) -> unit

--- a/ast/cinaps/poly_env.ml
+++ b/ast/cinaps/poly_env.ml
@@ -1,14 +1,8 @@
 open Stdppx
 
 type env = (string * Astlib.Grammar.targ) list
-type env_table = (string, env list) Hashtbl.t
 
 let empty_env = []
-
-let find env_table name =
-  match Hashtbl.find env_table name with
-  | Some list -> list
-  | None -> failwith (Printf.sprintf "no monomorphic instances found for %s" name)
 
 let args env = List.map env ~f:snd
 
@@ -65,67 +59,3 @@ let subst_decl decl ~env =
   | Ty ty -> Ty (subst_ty ~env ty)
   | Record fields -> Record (subst_fields ~env fields)
   | Variant variants -> Variant (subst_variants ~env variants)
-
-let rec ty_instances ty =
-  match (ty : Astlib.Grammar.ty) with
-  | Var _ | Name _ | Bool | Char | Int | String | Location -> []
-  | Loc ty | List ty | Option ty -> ty_instances ty
-  | Tuple tuple -> tuple_instances tuple
-  | Instance (poly, args) -> [(poly, args)]
-
-and tuple_instances tuple =
-  List.concat (List.map tuple ~f:ty_instances)
-
-let record_instances record =
-  List.concat (List.map record ~f:(fun (_, ty) -> ty_instances ty))
-
-let clause_instances clause =
-  match (clause : Astlib.Grammar.clause) with
-  | Empty -> []
-  | Tuple tuple -> tuple_instances tuple
-  | Record record -> record_instances record
-
-let variant_instances variant =
-  List.concat (List.map variant ~f:(fun (_, clause) -> clause_instances clause))
-
-let decl_instances decl =
-  match (decl : Astlib.Grammar.decl) with
-  | Ty ty -> ty_instances ty
-  | Record record -> record_instances record
-  | Variant variant -> variant_instances variant
-
-let rec transitive_instances decl ~grammar_table =
-  let instances = decl_instances decl in
-  let transitive =
-    List.map instances ~f:(fun (poly, args) ->
-      match (Hashtbl.find_exn grammar_table poly : Astlib.Grammar.kind) with
-      | Mono _ -> assert false
-      | Poly (vars, decl) ->
-        let instances = transitive_instances decl ~grammar_table in
-        let env = List.combine vars args in
-        List.map instances ~f:(fun (poly, args) ->
-          (poly, subst_targs args ~env)))
-  in
-  instances @ List.concat transitive
-
-let grammar_instances grammar ~grammar_table =
-  List.concat
-    (List.map grammar ~f:(fun (_, kind) ->
-       match (kind : Astlib.Grammar.kind) with
-       | Poly _ -> []
-       | Mono decl -> transitive_instances decl ~grammar_table))
-
-let grammar_envs grammar ~grammar_table =
-  List.map (grammar_instances grammar ~grammar_table) ~f:(fun (poly, args) ->
-    let vars =
-      match (Hashtbl.find_exn grammar_table poly : Astlib.Grammar.kind) with
-      | Mono _ -> []
-      | Poly (vars, _) -> vars
-    in
-    poly, List.combine vars args)
-
-let env_table grammar =
-  let grammar_table = Hashtbl.of_list_exn grammar in
-  Hashtbl.map ~f:(List.sort_uniq ~compare)
-    (Hashtbl.of_list_multi
-       (grammar_envs grammar ~grammar_table))

--- a/ast/cinaps/poly_env.mli
+++ b/ast/cinaps/poly_env.mli
@@ -1,8 +1,4 @@
 type env
-type env_table
-
-val env_table : Astlib.Grammar.t -> env_table
-val find : env_table -> string -> env list
 
 val create : vars:string list -> args:Astlib.Grammar.targ list -> env
 

--- a/ast/conversion.ml
+++ b/ast/conversion.ml
@@ -1,2386 +1,2800 @@
 open Stdppx
 
 (*$ Ppx_ast_cinaps.print_conversion_ml () *)
-let rec ast_of_longident x =
-  Versions.V4_07.Longident.of_concrete (concrete_of_longident x)
-
-and concrete_of_longident x : Versions.V4_07.Longident.concrete =
-  match (x : Compiler_types.longident) with
-  | Lident (x1) ->
-    Lident (x1)
-  | Ldot (x1, x2) ->
-    let x1 = ast_of_longident x1 in
-    Ldot (x1, x2)
-  | Lapply (x1, x2) ->
-    let x1 = ast_of_longident x1 in
-    let x2 = ast_of_longident x2 in
-    Lapply (x1, x2)
-
-and ast_to_longident x =
-  let concrete = Versions.V4_07.Longident.to_concrete x in
-  concrete_to_longident concrete
-
-and concrete_to_longident x : Compiler_types.longident =
-  match (x : Versions.V4_07.Longident.concrete) with
-  | Lident (x1) ->
-    Lident (x1)
-  | Ldot (x1, x2) ->
-    let x1 = ast_to_longident x1 in
-    Ldot (x1, x2)
-  | Lapply (x1, x2) ->
-    let x1 = ast_to_longident x1 in
-    let x2 = ast_to_longident x2 in
-    Lapply (x1, x2)
-
-and ast_of_longident_loc x =
-  Versions.V4_07.Longident_loc.of_concrete (concrete_of_longident_loc x)
-
-and concrete_of_longident_loc x =
-  (Astlib.Loc.map ~f:ast_of_longident) x
-
-and ast_to_longident_loc x =
-  let concrete = Versions.V4_07.Longident_loc.to_concrete x in
-  concrete_to_longident_loc concrete
-
-and concrete_to_longident_loc x =
-  (Astlib.Loc.map ~f:ast_to_longident) x
-
-and ast_of_rec_flag x =
-  Versions.V4_07.Rec_flag.of_concrete (concrete_of_rec_flag x)
-
-and concrete_of_rec_flag x : Versions.V4_07.Rec_flag.concrete =
-  match (x : Compiler_types.rec_flag) with
-  | Nonrecursive -> Nonrecursive
-  | Recursive -> Recursive
-
-and ast_to_rec_flag x =
-  let concrete = Versions.V4_07.Rec_flag.to_concrete x in
-  concrete_to_rec_flag concrete
-
-and concrete_to_rec_flag x : Compiler_types.rec_flag =
-  match (x : Versions.V4_07.Rec_flag.concrete) with
-  | Nonrecursive -> Nonrecursive
-  | Recursive -> Recursive
-
-and ast_of_direction_flag x =
-  Versions.V4_07.Direction_flag.of_concrete (concrete_of_direction_flag x)
-
-and concrete_of_direction_flag x : Versions.V4_07.Direction_flag.concrete =
-  match (x : Compiler_types.direction_flag) with
-  | Upto -> Upto
-  | Downto -> Downto
-
-and ast_to_direction_flag x =
-  let concrete = Versions.V4_07.Direction_flag.to_concrete x in
-  concrete_to_direction_flag concrete
-
-and concrete_to_direction_flag x : Compiler_types.direction_flag =
-  match (x : Versions.V4_07.Direction_flag.concrete) with
-  | Upto -> Upto
-  | Downto -> Downto
-
-and ast_of_private_flag x =
-  Versions.V4_07.Private_flag.of_concrete (concrete_of_private_flag x)
-
-and concrete_of_private_flag x : Versions.V4_07.Private_flag.concrete =
-  match (x : Compiler_types.private_flag) with
-  | Private -> Private
-  | Public -> Public
-
-and ast_to_private_flag x =
-  let concrete = Versions.V4_07.Private_flag.to_concrete x in
-  concrete_to_private_flag concrete
-
-and concrete_to_private_flag x : Compiler_types.private_flag =
-  match (x : Versions.V4_07.Private_flag.concrete) with
-  | Private -> Private
-  | Public -> Public
-
-and ast_of_mutable_flag x =
-  Versions.V4_07.Mutable_flag.of_concrete (concrete_of_mutable_flag x)
-
-and concrete_of_mutable_flag x : Versions.V4_07.Mutable_flag.concrete =
-  match (x : Compiler_types.mutable_flag) with
-  | Immutable -> Immutable
-  | Mutable -> Mutable
-
-and ast_to_mutable_flag x =
-  let concrete = Versions.V4_07.Mutable_flag.to_concrete x in
-  concrete_to_mutable_flag concrete
-
-and concrete_to_mutable_flag x : Compiler_types.mutable_flag =
-  match (x : Versions.V4_07.Mutable_flag.concrete) with
-  | Immutable -> Immutable
-  | Mutable -> Mutable
-
-and ast_of_virtual_flag x =
-  Versions.V4_07.Virtual_flag.of_concrete (concrete_of_virtual_flag x)
-
-and concrete_of_virtual_flag x : Versions.V4_07.Virtual_flag.concrete =
-  match (x : Compiler_types.virtual_flag) with
-  | Virtual -> Virtual
-  | Concrete -> Concrete
-
-and ast_to_virtual_flag x =
-  let concrete = Versions.V4_07.Virtual_flag.to_concrete x in
-  concrete_to_virtual_flag concrete
-
-and concrete_to_virtual_flag x : Compiler_types.virtual_flag =
-  match (x : Versions.V4_07.Virtual_flag.concrete) with
-  | Virtual -> Virtual
-  | Concrete -> Concrete
-
-and ast_of_override_flag x =
-  Versions.V4_07.Override_flag.of_concrete (concrete_of_override_flag x)
-
-and concrete_of_override_flag x : Versions.V4_07.Override_flag.concrete =
-  match (x : Compiler_types.override_flag) with
-  | Override -> Override
-  | Fresh -> Fresh
-
-and ast_to_override_flag x =
-  let concrete = Versions.V4_07.Override_flag.to_concrete x in
-  concrete_to_override_flag concrete
-
-and concrete_to_override_flag x : Compiler_types.override_flag =
-  match (x : Versions.V4_07.Override_flag.concrete) with
-  | Override -> Override
-  | Fresh -> Fresh
-
-and ast_of_closed_flag x =
-  Versions.V4_07.Closed_flag.of_concrete (concrete_of_closed_flag x)
-
-and concrete_of_closed_flag x : Versions.V4_07.Closed_flag.concrete =
-  match (x : Compiler_types.closed_flag) with
-  | Closed -> Closed
-  | Open -> Open
-
-and ast_to_closed_flag x =
-  let concrete = Versions.V4_07.Closed_flag.to_concrete x in
-  concrete_to_closed_flag concrete
-
-and concrete_to_closed_flag x : Compiler_types.closed_flag =
-  match (x : Versions.V4_07.Closed_flag.concrete) with
-  | Closed -> Closed
-  | Open -> Open
-
-and ast_of_arg_label x =
-  Versions.V4_07.Arg_label.of_concrete (concrete_of_arg_label x)
-
-and concrete_of_arg_label x : Versions.V4_07.Arg_label.concrete =
-  match (x : Compiler_types.arg_label) with
-  | Nolabel -> Nolabel
-  | Labelled (x1) ->
-    Labelled (x1)
-  | Optional (x1) ->
-    Optional (x1)
-
-and ast_to_arg_label x =
-  let concrete = Versions.V4_07.Arg_label.to_concrete x in
-  concrete_to_arg_label concrete
-
-and concrete_to_arg_label x : Compiler_types.arg_label =
-  match (x : Versions.V4_07.Arg_label.concrete) with
-  | Nolabel -> Nolabel
-  | Labelled (x1) ->
-    Labelled (x1)
-  | Optional (x1) ->
-    Optional (x1)
-
-and ast_of_variance x =
-  Versions.V4_07.Variance.of_concrete (concrete_of_variance x)
-
-and concrete_of_variance x : Versions.V4_07.Variance.concrete =
-  match (x : Compiler_types.variance) with
-  | Covariant -> Covariant
-  | Contravariant -> Contravariant
-  | Invariant -> Invariant
-
-and ast_to_variance x =
-  let concrete = Versions.V4_07.Variance.to_concrete x in
-  concrete_to_variance concrete
-
-and concrete_to_variance x : Compiler_types.variance =
-  match (x : Versions.V4_07.Variance.concrete) with
-  | Covariant -> Covariant
-  | Contravariant -> Contravariant
-  | Invariant -> Invariant
-
-and ast_of_constant x =
-  Versions.V4_07.Constant.of_concrete (concrete_of_constant x)
-
-and concrete_of_constant x : Versions.V4_07.Constant.concrete =
-  match (x : Compiler_types.constant) with
-  | Pconst_integer (x1, x2) ->
-    Pconst_integer (x1, x2)
-  | Pconst_char (x1) ->
-    Pconst_char (x1)
-  | Pconst_string (x1, x2) ->
-    Pconst_string (x1, x2)
-  | Pconst_float (x1, x2) ->
-    Pconst_float (x1, x2)
-
-and ast_to_constant x =
-  let concrete = Versions.V4_07.Constant.to_concrete x in
-  concrete_to_constant concrete
-
-and concrete_to_constant x : Compiler_types.constant =
-  match (x : Versions.V4_07.Constant.concrete) with
-  | Pconst_integer (x1, x2) ->
-    Pconst_integer (x1, x2)
-  | Pconst_char (x1) ->
-    Pconst_char (x1)
-  | Pconst_string (x1, x2) ->
-    Pconst_string (x1, x2)
-  | Pconst_float (x1, x2) ->
-    Pconst_float (x1, x2)
-
-and ast_of_attribute x =
-  Versions.V4_07.Attribute.of_concrete (concrete_of_attribute x)
-
-and concrete_of_attribute x =
-  (Tuple.map2 ~f1:Fn.id ~f2:ast_of_payload) x
-
-and ast_to_attribute x =
-  let concrete = Versions.V4_07.Attribute.to_concrete x in
-  concrete_to_attribute concrete
-
-and concrete_to_attribute x =
-  (Tuple.map2 ~f1:Fn.id ~f2:ast_to_payload) x
-
-and ast_of_extension x =
-  Versions.V4_07.Extension.of_concrete (concrete_of_extension x)
-
-and concrete_of_extension x =
-  (Tuple.map2 ~f1:Fn.id ~f2:ast_of_payload) x
-
-and ast_to_extension x =
-  let concrete = Versions.V4_07.Extension.to_concrete x in
-  concrete_to_extension concrete
-
-and concrete_to_extension x =
-  (Tuple.map2 ~f1:Fn.id ~f2:ast_to_payload) x
-
-and ast_of_attributes x =
-  Versions.V4_07.Attributes.of_concrete (concrete_of_attributes x)
-
-and concrete_of_attributes x =
-  (List.map ~f:ast_of_attribute) x
-
-and ast_to_attributes x =
-  let concrete = Versions.V4_07.Attributes.to_concrete x in
-  concrete_to_attributes concrete
-
-and concrete_to_attributes x =
-  (List.map ~f:ast_to_attribute) x
-
-and ast_of_payload x =
-  Versions.V4_07.Payload.of_concrete (concrete_of_payload x)
-
-and concrete_of_payload x : Versions.V4_07.Payload.concrete =
-  match (x : Compiler_types.payload) with
-  | PStr (x1) ->
-    let x1 = ast_of_structure x1 in
-    PStr (x1)
-  | PSig (x1) ->
-    let x1 = ast_of_signature x1 in
-    PSig (x1)
-  | PTyp (x1) ->
-    let x1 = ast_of_core_type x1 in
-    PTyp (x1)
-  | PPat (x1, x2) ->
-    let x1 = ast_of_pattern x1 in
-    let x2 = (Option.map ~f:ast_of_expression) x2 in
-    PPat (x1, x2)
-
-and ast_to_payload x =
-  let concrete = Versions.V4_07.Payload.to_concrete x in
-  concrete_to_payload concrete
-
-and concrete_to_payload x : Compiler_types.payload =
-  match (x : Versions.V4_07.Payload.concrete) with
-  | PStr (x1) ->
-    let x1 = ast_to_structure x1 in
-    PStr (x1)
-  | PSig (x1) ->
-    let x1 = ast_to_signature x1 in
-    PSig (x1)
-  | PTyp (x1) ->
-    let x1 = ast_to_core_type x1 in
-    PTyp (x1)
-  | PPat (x1, x2) ->
-    let x1 = ast_to_pattern x1 in
-    let x2 = (Option.map ~f:ast_to_expression) x2 in
-    PPat (x1, x2)
-
-and ast_of_core_type x =
-  Versions.V4_07.Core_type.of_concrete (concrete_of_core_type x)
+let rec ast_of_longident
+  : Compiler_types.longident -> Versions.V4_07.Longident.t
+  = fun x ->
+    Versions.V4_07.Longident.of_concrete (concrete_of_longident x)
+
+and concrete_of_longident
+  : Compiler_types.longident -> Versions.V4_07.Longident.concrete
+  = fun x ->
+    match (x : Compiler_types.longident) with
+    | Lident (x1) ->
+      Lident (x1)
+    | Ldot (x1, x2) ->
+      let x1 = ast_of_longident x1 in
+      Ldot (x1, x2)
+    | Lapply (x1, x2) ->
+      let x1 = ast_of_longident x1 in
+      let x2 = ast_of_longident x2 in
+      Lapply (x1, x2)
+
+and ast_to_longident
+  : Versions.V4_07.Longident.t -> Compiler_types.longident
+  = fun x ->
+    let concrete = Versions.V4_07.Longident.to_concrete x in
+    concrete_to_longident concrete
+
+and concrete_to_longident
+  : Versions.V4_07.Longident.concrete -> Compiler_types.longident
+  = fun x ->
+    match (x : Versions.V4_07.Longident.concrete) with
+    | Lident (x1) ->
+      Lident (x1)
+    | Ldot (x1, x2) ->
+      let x1 = ast_to_longident x1 in
+      Ldot (x1, x2)
+    | Lapply (x1, x2) ->
+      let x1 = ast_to_longident x1 in
+      let x2 = ast_to_longident x2 in
+      Lapply (x1, x2)
+
+and ast_of_longident_loc
+  : Compiler_types.longident_loc -> Versions.V4_07.Longident_loc.t
+  = fun x ->
+    Versions.V4_07.Longident_loc.of_concrete (concrete_of_longident_loc x)
+
+and concrete_of_longident_loc
+  : Compiler_types.longident_loc -> Versions.V4_07.Longident_loc.concrete
+  = fun x ->
+    (Astlib.Loc.map ~f:ast_of_longident) x
+
+and ast_to_longident_loc
+  : Versions.V4_07.Longident_loc.t -> Compiler_types.longident_loc
+  = fun x ->
+    let concrete = Versions.V4_07.Longident_loc.to_concrete x in
+    concrete_to_longident_loc concrete
+
+and concrete_to_longident_loc
+  : Versions.V4_07.Longident_loc.concrete -> Compiler_types.longident_loc
+  = fun x ->
+    (Astlib.Loc.map ~f:ast_to_longident) x
+
+and ast_of_rec_flag
+  : Compiler_types.rec_flag -> Versions.V4_07.Rec_flag.t
+  = fun x ->
+    Versions.V4_07.Rec_flag.of_concrete (concrete_of_rec_flag x)
+
+and concrete_of_rec_flag
+  : Compiler_types.rec_flag -> Versions.V4_07.Rec_flag.concrete
+  = fun x ->
+    match (x : Compiler_types.rec_flag) with
+    | Nonrecursive -> Nonrecursive
+    | Recursive -> Recursive
+
+and ast_to_rec_flag
+  : Versions.V4_07.Rec_flag.t -> Compiler_types.rec_flag
+  = fun x ->
+    let concrete = Versions.V4_07.Rec_flag.to_concrete x in
+    concrete_to_rec_flag concrete
+
+and concrete_to_rec_flag
+  : Versions.V4_07.Rec_flag.concrete -> Compiler_types.rec_flag
+  = fun x ->
+    match (x : Versions.V4_07.Rec_flag.concrete) with
+    | Nonrecursive -> Nonrecursive
+    | Recursive -> Recursive
+
+and ast_of_direction_flag
+  : Compiler_types.direction_flag -> Versions.V4_07.Direction_flag.t
+  = fun x ->
+    Versions.V4_07.Direction_flag.of_concrete (concrete_of_direction_flag x)
+
+and concrete_of_direction_flag
+  : Compiler_types.direction_flag -> Versions.V4_07.Direction_flag.concrete
+  = fun x ->
+    match (x : Compiler_types.direction_flag) with
+    | Upto -> Upto
+    | Downto -> Downto
+
+and ast_to_direction_flag
+  : Versions.V4_07.Direction_flag.t -> Compiler_types.direction_flag
+  = fun x ->
+    let concrete = Versions.V4_07.Direction_flag.to_concrete x in
+    concrete_to_direction_flag concrete
+
+and concrete_to_direction_flag
+  : Versions.V4_07.Direction_flag.concrete -> Compiler_types.direction_flag
+  = fun x ->
+    match (x : Versions.V4_07.Direction_flag.concrete) with
+    | Upto -> Upto
+    | Downto -> Downto
+
+and ast_of_private_flag
+  : Compiler_types.private_flag -> Versions.V4_07.Private_flag.t
+  = fun x ->
+    Versions.V4_07.Private_flag.of_concrete (concrete_of_private_flag x)
+
+and concrete_of_private_flag
+  : Compiler_types.private_flag -> Versions.V4_07.Private_flag.concrete
+  = fun x ->
+    match (x : Compiler_types.private_flag) with
+    | Private -> Private
+    | Public -> Public
+
+and ast_to_private_flag
+  : Versions.V4_07.Private_flag.t -> Compiler_types.private_flag
+  = fun x ->
+    let concrete = Versions.V4_07.Private_flag.to_concrete x in
+    concrete_to_private_flag concrete
+
+and concrete_to_private_flag
+  : Versions.V4_07.Private_flag.concrete -> Compiler_types.private_flag
+  = fun x ->
+    match (x : Versions.V4_07.Private_flag.concrete) with
+    | Private -> Private
+    | Public -> Public
+
+and ast_of_mutable_flag
+  : Compiler_types.mutable_flag -> Versions.V4_07.Mutable_flag.t
+  = fun x ->
+    Versions.V4_07.Mutable_flag.of_concrete (concrete_of_mutable_flag x)
+
+and concrete_of_mutable_flag
+  : Compiler_types.mutable_flag -> Versions.V4_07.Mutable_flag.concrete
+  = fun x ->
+    match (x : Compiler_types.mutable_flag) with
+    | Immutable -> Immutable
+    | Mutable -> Mutable
+
+and ast_to_mutable_flag
+  : Versions.V4_07.Mutable_flag.t -> Compiler_types.mutable_flag
+  = fun x ->
+    let concrete = Versions.V4_07.Mutable_flag.to_concrete x in
+    concrete_to_mutable_flag concrete
+
+and concrete_to_mutable_flag
+  : Versions.V4_07.Mutable_flag.concrete -> Compiler_types.mutable_flag
+  = fun x ->
+    match (x : Versions.V4_07.Mutable_flag.concrete) with
+    | Immutable -> Immutable
+    | Mutable -> Mutable
+
+and ast_of_virtual_flag
+  : Compiler_types.virtual_flag -> Versions.V4_07.Virtual_flag.t
+  = fun x ->
+    Versions.V4_07.Virtual_flag.of_concrete (concrete_of_virtual_flag x)
+
+and concrete_of_virtual_flag
+  : Compiler_types.virtual_flag -> Versions.V4_07.Virtual_flag.concrete
+  = fun x ->
+    match (x : Compiler_types.virtual_flag) with
+    | Virtual -> Virtual
+    | Concrete -> Concrete
+
+and ast_to_virtual_flag
+  : Versions.V4_07.Virtual_flag.t -> Compiler_types.virtual_flag
+  = fun x ->
+    let concrete = Versions.V4_07.Virtual_flag.to_concrete x in
+    concrete_to_virtual_flag concrete
+
+and concrete_to_virtual_flag
+  : Versions.V4_07.Virtual_flag.concrete -> Compiler_types.virtual_flag
+  = fun x ->
+    match (x : Versions.V4_07.Virtual_flag.concrete) with
+    | Virtual -> Virtual
+    | Concrete -> Concrete
+
+and ast_of_override_flag
+  : Compiler_types.override_flag -> Versions.V4_07.Override_flag.t
+  = fun x ->
+    Versions.V4_07.Override_flag.of_concrete (concrete_of_override_flag x)
+
+and concrete_of_override_flag
+  : Compiler_types.override_flag -> Versions.V4_07.Override_flag.concrete
+  = fun x ->
+    match (x : Compiler_types.override_flag) with
+    | Override -> Override
+    | Fresh -> Fresh
+
+and ast_to_override_flag
+  : Versions.V4_07.Override_flag.t -> Compiler_types.override_flag
+  = fun x ->
+    let concrete = Versions.V4_07.Override_flag.to_concrete x in
+    concrete_to_override_flag concrete
+
+and concrete_to_override_flag
+  : Versions.V4_07.Override_flag.concrete -> Compiler_types.override_flag
+  = fun x ->
+    match (x : Versions.V4_07.Override_flag.concrete) with
+    | Override -> Override
+    | Fresh -> Fresh
+
+and ast_of_closed_flag
+  : Compiler_types.closed_flag -> Versions.V4_07.Closed_flag.t
+  = fun x ->
+    Versions.V4_07.Closed_flag.of_concrete (concrete_of_closed_flag x)
+
+and concrete_of_closed_flag
+  : Compiler_types.closed_flag -> Versions.V4_07.Closed_flag.concrete
+  = fun x ->
+    match (x : Compiler_types.closed_flag) with
+    | Closed -> Closed
+    | Open -> Open
+
+and ast_to_closed_flag
+  : Versions.V4_07.Closed_flag.t -> Compiler_types.closed_flag
+  = fun x ->
+    let concrete = Versions.V4_07.Closed_flag.to_concrete x in
+    concrete_to_closed_flag concrete
+
+and concrete_to_closed_flag
+  : Versions.V4_07.Closed_flag.concrete -> Compiler_types.closed_flag
+  = fun x ->
+    match (x : Versions.V4_07.Closed_flag.concrete) with
+    | Closed -> Closed
+    | Open -> Open
+
+and ast_of_arg_label
+  : Compiler_types.arg_label -> Versions.V4_07.Arg_label.t
+  = fun x ->
+    Versions.V4_07.Arg_label.of_concrete (concrete_of_arg_label x)
+
+and concrete_of_arg_label
+  : Compiler_types.arg_label -> Versions.V4_07.Arg_label.concrete
+  = fun x ->
+    match (x : Compiler_types.arg_label) with
+    | Nolabel -> Nolabel
+    | Labelled (x1) ->
+      Labelled (x1)
+    | Optional (x1) ->
+      Optional (x1)
+
+and ast_to_arg_label
+  : Versions.V4_07.Arg_label.t -> Compiler_types.arg_label
+  = fun x ->
+    let concrete = Versions.V4_07.Arg_label.to_concrete x in
+    concrete_to_arg_label concrete
+
+and concrete_to_arg_label
+  : Versions.V4_07.Arg_label.concrete -> Compiler_types.arg_label
+  = fun x ->
+    match (x : Versions.V4_07.Arg_label.concrete) with
+    | Nolabel -> Nolabel
+    | Labelled (x1) ->
+      Labelled (x1)
+    | Optional (x1) ->
+      Optional (x1)
+
+and ast_of_variance
+  : Compiler_types.variance -> Versions.V4_07.Variance.t
+  = fun x ->
+    Versions.V4_07.Variance.of_concrete (concrete_of_variance x)
+
+and concrete_of_variance
+  : Compiler_types.variance -> Versions.V4_07.Variance.concrete
+  = fun x ->
+    match (x : Compiler_types.variance) with
+    | Covariant -> Covariant
+    | Contravariant -> Contravariant
+    | Invariant -> Invariant
+
+and ast_to_variance
+  : Versions.V4_07.Variance.t -> Compiler_types.variance
+  = fun x ->
+    let concrete = Versions.V4_07.Variance.to_concrete x in
+    concrete_to_variance concrete
+
+and concrete_to_variance
+  : Versions.V4_07.Variance.concrete -> Compiler_types.variance
+  = fun x ->
+    match (x : Versions.V4_07.Variance.concrete) with
+    | Covariant -> Covariant
+    | Contravariant -> Contravariant
+    | Invariant -> Invariant
+
+and ast_of_constant
+  : Compiler_types.constant -> Versions.V4_07.Constant.t
+  = fun x ->
+    Versions.V4_07.Constant.of_concrete (concrete_of_constant x)
+
+and concrete_of_constant
+  : Compiler_types.constant -> Versions.V4_07.Constant.concrete
+  = fun x ->
+    match (x : Compiler_types.constant) with
+    | Pconst_integer (x1, x2) ->
+      Pconst_integer (x1, x2)
+    | Pconst_char (x1) ->
+      Pconst_char (x1)
+    | Pconst_string (x1, x2) ->
+      Pconst_string (x1, x2)
+    | Pconst_float (x1, x2) ->
+      Pconst_float (x1, x2)
+
+and ast_to_constant
+  : Versions.V4_07.Constant.t -> Compiler_types.constant
+  = fun x ->
+    let concrete = Versions.V4_07.Constant.to_concrete x in
+    concrete_to_constant concrete
+
+and concrete_to_constant
+  : Versions.V4_07.Constant.concrete -> Compiler_types.constant
+  = fun x ->
+    match (x : Versions.V4_07.Constant.concrete) with
+    | Pconst_integer (x1, x2) ->
+      Pconst_integer (x1, x2)
+    | Pconst_char (x1) ->
+      Pconst_char (x1)
+    | Pconst_string (x1, x2) ->
+      Pconst_string (x1, x2)
+    | Pconst_float (x1, x2) ->
+      Pconst_float (x1, x2)
+
+and ast_of_attribute
+  : Compiler_types.attribute -> Versions.V4_07.Attribute.t
+  = fun x ->
+    Versions.V4_07.Attribute.of_concrete (concrete_of_attribute x)
+
+and concrete_of_attribute
+  : Compiler_types.attribute -> Versions.V4_07.Attribute.concrete
+  = fun x ->
+    (Tuple.map2 ~f1:Fn.id ~f2:ast_of_payload) x
+
+and ast_to_attribute
+  : Versions.V4_07.Attribute.t -> Compiler_types.attribute
+  = fun x ->
+    let concrete = Versions.V4_07.Attribute.to_concrete x in
+    concrete_to_attribute concrete
+
+and concrete_to_attribute
+  : Versions.V4_07.Attribute.concrete -> Compiler_types.attribute
+  = fun x ->
+    (Tuple.map2 ~f1:Fn.id ~f2:ast_to_payload) x
+
+and ast_of_extension
+  : Compiler_types.extension -> Versions.V4_07.Extension.t
+  = fun x ->
+    Versions.V4_07.Extension.of_concrete (concrete_of_extension x)
+
+and concrete_of_extension
+  : Compiler_types.extension -> Versions.V4_07.Extension.concrete
+  = fun x ->
+    (Tuple.map2 ~f1:Fn.id ~f2:ast_of_payload) x
+
+and ast_to_extension
+  : Versions.V4_07.Extension.t -> Compiler_types.extension
+  = fun x ->
+    let concrete = Versions.V4_07.Extension.to_concrete x in
+    concrete_to_extension concrete
+
+and concrete_to_extension
+  : Versions.V4_07.Extension.concrete -> Compiler_types.extension
+  = fun x ->
+    (Tuple.map2 ~f1:Fn.id ~f2:ast_to_payload) x
+
+and ast_of_attributes
+  : Compiler_types.attributes -> Versions.V4_07.Attributes.t
+  = fun x ->
+    Versions.V4_07.Attributes.of_concrete (concrete_of_attributes x)
+
+and concrete_of_attributes
+  : Compiler_types.attributes -> Versions.V4_07.Attributes.concrete
+  = fun x ->
+    (List.map ~f:ast_of_attribute) x
+
+and ast_to_attributes
+  : Versions.V4_07.Attributes.t -> Compiler_types.attributes
+  = fun x ->
+    let concrete = Versions.V4_07.Attributes.to_concrete x in
+    concrete_to_attributes concrete
+
+and concrete_to_attributes
+  : Versions.V4_07.Attributes.concrete -> Compiler_types.attributes
+  = fun x ->
+    (List.map ~f:ast_to_attribute) x
+
+and ast_of_payload
+  : Compiler_types.payload -> Versions.V4_07.Payload.t
+  = fun x ->
+    Versions.V4_07.Payload.of_concrete (concrete_of_payload x)
+
+and concrete_of_payload
+  : Compiler_types.payload -> Versions.V4_07.Payload.concrete
+  = fun x ->
+    match (x : Compiler_types.payload) with
+    | PStr (x1) ->
+      let x1 = ast_of_structure x1 in
+      PStr (x1)
+    | PSig (x1) ->
+      let x1 = ast_of_signature x1 in
+      PSig (x1)
+    | PTyp (x1) ->
+      let x1 = ast_of_core_type x1 in
+      PTyp (x1)
+    | PPat (x1, x2) ->
+      let x1 = ast_of_pattern x1 in
+      let x2 = (Option.map ~f:ast_of_expression) x2 in
+      PPat (x1, x2)
+
+and ast_to_payload
+  : Versions.V4_07.Payload.t -> Compiler_types.payload
+  = fun x ->
+    let concrete = Versions.V4_07.Payload.to_concrete x in
+    concrete_to_payload concrete
+
+and concrete_to_payload
+  : Versions.V4_07.Payload.concrete -> Compiler_types.payload
+  = fun x ->
+    match (x : Versions.V4_07.Payload.concrete) with
+    | PStr (x1) ->
+      let x1 = ast_to_structure x1 in
+      PStr (x1)
+    | PSig (x1) ->
+      let x1 = ast_to_signature x1 in
+      PSig (x1)
+    | PTyp (x1) ->
+      let x1 = ast_to_core_type x1 in
+      PTyp (x1)
+    | PPat (x1, x2) ->
+      let x1 = ast_to_pattern x1 in
+      let x2 = (Option.map ~f:ast_to_expression) x2 in
+      PPat (x1, x2)
+
+and ast_of_core_type
+  : Compiler_types.core_type -> Versions.V4_07.Core_type.t
+  = fun x ->
+    Versions.V4_07.Core_type.of_concrete (concrete_of_core_type x)
 
 and concrete_of_core_type
-  ({ ptyp_desc; ptyp_loc; ptyp_attributes } : Compiler_types.core_type)
-=
-  let ptyp_desc = ast_of_core_type_desc ptyp_desc in
-  let ptyp_attributes = ast_of_attributes ptyp_attributes in
-  ({ ptyp_desc; ptyp_loc; ptyp_attributes } : Versions.V4_07.Core_type.concrete)
+  : Compiler_types.core_type -> Versions.V4_07.Core_type.concrete
+  = fun { ptyp_desc; ptyp_loc; ptyp_attributes } ->
+      let ptyp_desc = ast_of_core_type_desc ptyp_desc in
+      let ptyp_attributes = ast_of_attributes ptyp_attributes in
+      { ptyp_desc; ptyp_loc; ptyp_attributes }
 
-and ast_to_core_type x =
-  let concrete = Versions.V4_07.Core_type.to_concrete x in
-  concrete_to_core_type concrete
+and ast_to_core_type
+  : Versions.V4_07.Core_type.t -> Compiler_types.core_type
+  = fun x ->
+    let concrete = Versions.V4_07.Core_type.to_concrete x in
+    concrete_to_core_type concrete
 
 and concrete_to_core_type
-  ({ ptyp_desc; ptyp_loc; ptyp_attributes } : Versions.V4_07.Core_type.concrete)
-=
-  let ptyp_desc = ast_to_core_type_desc ptyp_desc in
-  let ptyp_attributes = ast_to_attributes ptyp_attributes in
-  ({ ptyp_desc; ptyp_loc; ptyp_attributes } : Compiler_types.core_type)
+  : Versions.V4_07.Core_type.concrete -> Compiler_types.core_type
+  = fun { ptyp_desc; ptyp_loc; ptyp_attributes } ->
+      let ptyp_desc = ast_to_core_type_desc ptyp_desc in
+      let ptyp_attributes = ast_to_attributes ptyp_attributes in
+      { ptyp_desc; ptyp_loc; ptyp_attributes }
 
-and ast_of_core_type_desc x =
-  Versions.V4_07.Core_type_desc.of_concrete (concrete_of_core_type_desc x)
+and ast_of_core_type_desc
+  : Compiler_types.core_type_desc -> Versions.V4_07.Core_type_desc.t
+  = fun x ->
+    Versions.V4_07.Core_type_desc.of_concrete (concrete_of_core_type_desc x)
 
-and concrete_of_core_type_desc x : Versions.V4_07.Core_type_desc.concrete =
-  match (x : Compiler_types.core_type_desc) with
-  | Ptyp_any -> Ptyp_any
-  | Ptyp_var (x1) ->
-    Ptyp_var (x1)
-  | Ptyp_arrow (x1, x2, x3) ->
-    let x1 = ast_of_arg_label x1 in
-    let x2 = ast_of_core_type x2 in
-    let x3 = ast_of_core_type x3 in
-    Ptyp_arrow (x1, x2, x3)
-  | Ptyp_tuple (x1) ->
-    let x1 = (List.map ~f:ast_of_core_type) x1 in
-    Ptyp_tuple (x1)
-  | Ptyp_constr (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = (List.map ~f:ast_of_core_type) x2 in
-    Ptyp_constr (x1, x2)
-  | Ptyp_object (x1, x2) ->
-    let x1 = (List.map ~f:ast_of_object_field) x1 in
-    let x2 = ast_of_closed_flag x2 in
-    Ptyp_object (x1, x2)
-  | Ptyp_class (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = (List.map ~f:ast_of_core_type) x2 in
-    Ptyp_class (x1, x2)
-  | Ptyp_alias (x1, x2) ->
-    let x1 = ast_of_core_type x1 in
-    Ptyp_alias (x1, x2)
-  | Ptyp_variant (x1, x2, x3) ->
-    let x1 = (List.map ~f:ast_of_row_field) x1 in
-    let x2 = ast_of_closed_flag x2 in
-    Ptyp_variant (x1, x2, x3)
-  | Ptyp_poly (x1, x2) ->
-    let x2 = ast_of_core_type x2 in
-    Ptyp_poly (x1, x2)
-  | Ptyp_package (x1) ->
-    let x1 = ast_of_package_type x1 in
-    Ptyp_package (x1)
-  | Ptyp_extension (x1) ->
-    let x1 = ast_of_extension x1 in
-    Ptyp_extension (x1)
+and concrete_of_core_type_desc
+  : Compiler_types.core_type_desc -> Versions.V4_07.Core_type_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.core_type_desc) with
+    | Ptyp_any -> Ptyp_any
+    | Ptyp_var (x1) ->
+      Ptyp_var (x1)
+    | Ptyp_arrow (x1, x2, x3) ->
+      let x1 = ast_of_arg_label x1 in
+      let x2 = ast_of_core_type x2 in
+      let x3 = ast_of_core_type x3 in
+      Ptyp_arrow (x1, x2, x3)
+    | Ptyp_tuple (x1) ->
+      let x1 = (List.map ~f:ast_of_core_type) x1 in
+      Ptyp_tuple (x1)
+    | Ptyp_constr (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = (List.map ~f:ast_of_core_type) x2 in
+      Ptyp_constr (x1, x2)
+    | Ptyp_object (x1, x2) ->
+      let x1 = (List.map ~f:ast_of_object_field) x1 in
+      let x2 = ast_of_closed_flag x2 in
+      Ptyp_object (x1, x2)
+    | Ptyp_class (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = (List.map ~f:ast_of_core_type) x2 in
+      Ptyp_class (x1, x2)
+    | Ptyp_alias (x1, x2) ->
+      let x1 = ast_of_core_type x1 in
+      Ptyp_alias (x1, x2)
+    | Ptyp_variant (x1, x2, x3) ->
+      let x1 = (List.map ~f:ast_of_row_field) x1 in
+      let x2 = ast_of_closed_flag x2 in
+      Ptyp_variant (x1, x2, x3)
+    | Ptyp_poly (x1, x2) ->
+      let x2 = ast_of_core_type x2 in
+      Ptyp_poly (x1, x2)
+    | Ptyp_package (x1) ->
+      let x1 = ast_of_package_type x1 in
+      Ptyp_package (x1)
+    | Ptyp_extension (x1) ->
+      let x1 = ast_of_extension x1 in
+      Ptyp_extension (x1)
 
-and ast_to_core_type_desc x =
-  let concrete = Versions.V4_07.Core_type_desc.to_concrete x in
-  concrete_to_core_type_desc concrete
+and ast_to_core_type_desc
+  : Versions.V4_07.Core_type_desc.t -> Compiler_types.core_type_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Core_type_desc.to_concrete x in
+    concrete_to_core_type_desc concrete
 
-and concrete_to_core_type_desc x : Compiler_types.core_type_desc =
-  match (x : Versions.V4_07.Core_type_desc.concrete) with
-  | Ptyp_any -> Ptyp_any
-  | Ptyp_var (x1) ->
-    Ptyp_var (x1)
-  | Ptyp_arrow (x1, x2, x3) ->
-    let x1 = ast_to_arg_label x1 in
-    let x2 = ast_to_core_type x2 in
-    let x3 = ast_to_core_type x3 in
-    Ptyp_arrow (x1, x2, x3)
-  | Ptyp_tuple (x1) ->
-    let x1 = (List.map ~f:ast_to_core_type) x1 in
-    Ptyp_tuple (x1)
-  | Ptyp_constr (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = (List.map ~f:ast_to_core_type) x2 in
-    Ptyp_constr (x1, x2)
-  | Ptyp_object (x1, x2) ->
-    let x1 = (List.map ~f:ast_to_object_field) x1 in
-    let x2 = ast_to_closed_flag x2 in
-    Ptyp_object (x1, x2)
-  | Ptyp_class (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = (List.map ~f:ast_to_core_type) x2 in
-    Ptyp_class (x1, x2)
-  | Ptyp_alias (x1, x2) ->
-    let x1 = ast_to_core_type x1 in
-    Ptyp_alias (x1, x2)
-  | Ptyp_variant (x1, x2, x3) ->
-    let x1 = (List.map ~f:ast_to_row_field) x1 in
-    let x2 = ast_to_closed_flag x2 in
-    Ptyp_variant (x1, x2, x3)
-  | Ptyp_poly (x1, x2) ->
-    let x2 = ast_to_core_type x2 in
-    Ptyp_poly (x1, x2)
-  | Ptyp_package (x1) ->
-    let x1 = ast_to_package_type x1 in
-    Ptyp_package (x1)
-  | Ptyp_extension (x1) ->
-    let x1 = ast_to_extension x1 in
-    Ptyp_extension (x1)
+and concrete_to_core_type_desc
+  : Versions.V4_07.Core_type_desc.concrete -> Compiler_types.core_type_desc
+  = fun x ->
+    match (x : Versions.V4_07.Core_type_desc.concrete) with
+    | Ptyp_any -> Ptyp_any
+    | Ptyp_var (x1) ->
+      Ptyp_var (x1)
+    | Ptyp_arrow (x1, x2, x3) ->
+      let x1 = ast_to_arg_label x1 in
+      let x2 = ast_to_core_type x2 in
+      let x3 = ast_to_core_type x3 in
+      Ptyp_arrow (x1, x2, x3)
+    | Ptyp_tuple (x1) ->
+      let x1 = (List.map ~f:ast_to_core_type) x1 in
+      Ptyp_tuple (x1)
+    | Ptyp_constr (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = (List.map ~f:ast_to_core_type) x2 in
+      Ptyp_constr (x1, x2)
+    | Ptyp_object (x1, x2) ->
+      let x1 = (List.map ~f:ast_to_object_field) x1 in
+      let x2 = ast_to_closed_flag x2 in
+      Ptyp_object (x1, x2)
+    | Ptyp_class (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = (List.map ~f:ast_to_core_type) x2 in
+      Ptyp_class (x1, x2)
+    | Ptyp_alias (x1, x2) ->
+      let x1 = ast_to_core_type x1 in
+      Ptyp_alias (x1, x2)
+    | Ptyp_variant (x1, x2, x3) ->
+      let x1 = (List.map ~f:ast_to_row_field) x1 in
+      let x2 = ast_to_closed_flag x2 in
+      Ptyp_variant (x1, x2, x3)
+    | Ptyp_poly (x1, x2) ->
+      let x2 = ast_to_core_type x2 in
+      Ptyp_poly (x1, x2)
+    | Ptyp_package (x1) ->
+      let x1 = ast_to_package_type x1 in
+      Ptyp_package (x1)
+    | Ptyp_extension (x1) ->
+      let x1 = ast_to_extension x1 in
+      Ptyp_extension (x1)
 
-and ast_of_package_type x =
-  Versions.V4_07.Package_type.of_concrete (concrete_of_package_type x)
+and ast_of_package_type
+  : Compiler_types.package_type -> Versions.V4_07.Package_type.t
+  = fun x ->
+    Versions.V4_07.Package_type.of_concrete (concrete_of_package_type x)
 
-and concrete_of_package_type x =
-  (Tuple.map2 ~f1:ast_of_longident_loc ~f2:(List.map ~f:(Tuple.map2 ~f1:ast_of_longident_loc ~f2:ast_of_core_type))) x
+and concrete_of_package_type
+  : Compiler_types.package_type -> Versions.V4_07.Package_type.concrete
+  = fun x ->
+    (Tuple.map2 ~f1:ast_of_longident_loc ~f2:(List.map ~f:(Tuple.map2 ~f1:ast_of_longident_loc ~f2:ast_of_core_type))) x
 
-and ast_to_package_type x =
-  let concrete = Versions.V4_07.Package_type.to_concrete x in
-  concrete_to_package_type concrete
+and ast_to_package_type
+  : Versions.V4_07.Package_type.t -> Compiler_types.package_type
+  = fun x ->
+    let concrete = Versions.V4_07.Package_type.to_concrete x in
+    concrete_to_package_type concrete
 
-and concrete_to_package_type x =
-  (Tuple.map2 ~f1:ast_to_longident_loc ~f2:(List.map ~f:(Tuple.map2 ~f1:ast_to_longident_loc ~f2:ast_to_core_type))) x
+and concrete_to_package_type
+  : Versions.V4_07.Package_type.concrete -> Compiler_types.package_type
+  = fun x ->
+    (Tuple.map2 ~f1:ast_to_longident_loc ~f2:(List.map ~f:(Tuple.map2 ~f1:ast_to_longident_loc ~f2:ast_to_core_type))) x
 
-and ast_of_row_field x =
-  Versions.V4_07.Row_field.of_concrete (concrete_of_row_field x)
+and ast_of_row_field
+  : Compiler_types.row_field -> Versions.V4_07.Row_field.t
+  = fun x ->
+    Versions.V4_07.Row_field.of_concrete (concrete_of_row_field x)
 
-and concrete_of_row_field x : Versions.V4_07.Row_field.concrete =
-  match (x : Compiler_types.row_field) with
-  | Rtag (x1, x2, x3, x4) ->
-    let x2 = ast_of_attributes x2 in
-    let x4 = (List.map ~f:ast_of_core_type) x4 in
-    Rtag (x1, x2, x3, x4)
-  | Rinherit (x1) ->
-    let x1 = ast_of_core_type x1 in
-    Rinherit (x1)
+and concrete_of_row_field
+  : Compiler_types.row_field -> Versions.V4_07.Row_field.concrete
+  = fun x ->
+    match (x : Compiler_types.row_field) with
+    | Rtag (x1, x2, x3, x4) ->
+      let x2 = ast_of_attributes x2 in
+      let x4 = (List.map ~f:ast_of_core_type) x4 in
+      Rtag (x1, x2, x3, x4)
+    | Rinherit (x1) ->
+      let x1 = ast_of_core_type x1 in
+      Rinherit (x1)
 
-and ast_to_row_field x =
-  let concrete = Versions.V4_07.Row_field.to_concrete x in
-  concrete_to_row_field concrete
+and ast_to_row_field
+  : Versions.V4_07.Row_field.t -> Compiler_types.row_field
+  = fun x ->
+    let concrete = Versions.V4_07.Row_field.to_concrete x in
+    concrete_to_row_field concrete
 
-and concrete_to_row_field x : Compiler_types.row_field =
-  match (x : Versions.V4_07.Row_field.concrete) with
-  | Rtag (x1, x2, x3, x4) ->
-    let x2 = ast_to_attributes x2 in
-    let x4 = (List.map ~f:ast_to_core_type) x4 in
-    Rtag (x1, x2, x3, x4)
-  | Rinherit (x1) ->
-    let x1 = ast_to_core_type x1 in
-    Rinherit (x1)
+and concrete_to_row_field
+  : Versions.V4_07.Row_field.concrete -> Compiler_types.row_field
+  = fun x ->
+    match (x : Versions.V4_07.Row_field.concrete) with
+    | Rtag (x1, x2, x3, x4) ->
+      let x2 = ast_to_attributes x2 in
+      let x4 = (List.map ~f:ast_to_core_type) x4 in
+      Rtag (x1, x2, x3, x4)
+    | Rinherit (x1) ->
+      let x1 = ast_to_core_type x1 in
+      Rinherit (x1)
 
-and ast_of_object_field x =
-  Versions.V4_07.Object_field.of_concrete (concrete_of_object_field x)
+and ast_of_object_field
+  : Compiler_types.object_field -> Versions.V4_07.Object_field.t
+  = fun x ->
+    Versions.V4_07.Object_field.of_concrete (concrete_of_object_field x)
 
-and concrete_of_object_field x : Versions.V4_07.Object_field.concrete =
-  match (x : Compiler_types.object_field) with
-  | Otag (x1, x2, x3) ->
-    let x2 = ast_of_attributes x2 in
-    let x3 = ast_of_core_type x3 in
-    Otag (x1, x2, x3)
-  | Oinherit (x1) ->
-    let x1 = ast_of_core_type x1 in
-    Oinherit (x1)
+and concrete_of_object_field
+  : Compiler_types.object_field -> Versions.V4_07.Object_field.concrete
+  = fun x ->
+    match (x : Compiler_types.object_field) with
+    | Otag (x1, x2, x3) ->
+      let x2 = ast_of_attributes x2 in
+      let x3 = ast_of_core_type x3 in
+      Otag (x1, x2, x3)
+    | Oinherit (x1) ->
+      let x1 = ast_of_core_type x1 in
+      Oinherit (x1)
 
-and ast_to_object_field x =
-  let concrete = Versions.V4_07.Object_field.to_concrete x in
-  concrete_to_object_field concrete
+and ast_to_object_field
+  : Versions.V4_07.Object_field.t -> Compiler_types.object_field
+  = fun x ->
+    let concrete = Versions.V4_07.Object_field.to_concrete x in
+    concrete_to_object_field concrete
 
-and concrete_to_object_field x : Compiler_types.object_field =
-  match (x : Versions.V4_07.Object_field.concrete) with
-  | Otag (x1, x2, x3) ->
-    let x2 = ast_to_attributes x2 in
-    let x3 = ast_to_core_type x3 in
-    Otag (x1, x2, x3)
-  | Oinherit (x1) ->
-    let x1 = ast_to_core_type x1 in
-    Oinherit (x1)
+and concrete_to_object_field
+  : Versions.V4_07.Object_field.concrete -> Compiler_types.object_field
+  = fun x ->
+    match (x : Versions.V4_07.Object_field.concrete) with
+    | Otag (x1, x2, x3) ->
+      let x2 = ast_to_attributes x2 in
+      let x3 = ast_to_core_type x3 in
+      Otag (x1, x2, x3)
+    | Oinherit (x1) ->
+      let x1 = ast_to_core_type x1 in
+      Oinherit (x1)
 
-and ast_of_pattern x =
-  Versions.V4_07.Pattern.of_concrete (concrete_of_pattern x)
+and ast_of_pattern
+  : Compiler_types.pattern -> Versions.V4_07.Pattern.t
+  = fun x ->
+    Versions.V4_07.Pattern.of_concrete (concrete_of_pattern x)
 
 and concrete_of_pattern
-  ({ ppat_desc; ppat_loc; ppat_attributes } : Compiler_types.pattern)
-=
-  let ppat_desc = ast_of_pattern_desc ppat_desc in
-  let ppat_attributes = ast_of_attributes ppat_attributes in
-  ({ ppat_desc; ppat_loc; ppat_attributes } : Versions.V4_07.Pattern.concrete)
+  : Compiler_types.pattern -> Versions.V4_07.Pattern.concrete
+  = fun { ppat_desc; ppat_loc; ppat_attributes } ->
+      let ppat_desc = ast_of_pattern_desc ppat_desc in
+      let ppat_attributes = ast_of_attributes ppat_attributes in
+      { ppat_desc; ppat_loc; ppat_attributes }
 
-and ast_to_pattern x =
-  let concrete = Versions.V4_07.Pattern.to_concrete x in
-  concrete_to_pattern concrete
+and ast_to_pattern
+  : Versions.V4_07.Pattern.t -> Compiler_types.pattern
+  = fun x ->
+    let concrete = Versions.V4_07.Pattern.to_concrete x in
+    concrete_to_pattern concrete
 
 and concrete_to_pattern
-  ({ ppat_desc; ppat_loc; ppat_attributes } : Versions.V4_07.Pattern.concrete)
-=
-  let ppat_desc = ast_to_pattern_desc ppat_desc in
-  let ppat_attributes = ast_to_attributes ppat_attributes in
-  ({ ppat_desc; ppat_loc; ppat_attributes } : Compiler_types.pattern)
+  : Versions.V4_07.Pattern.concrete -> Compiler_types.pattern
+  = fun { ppat_desc; ppat_loc; ppat_attributes } ->
+      let ppat_desc = ast_to_pattern_desc ppat_desc in
+      let ppat_attributes = ast_to_attributes ppat_attributes in
+      { ppat_desc; ppat_loc; ppat_attributes }
 
-and ast_of_pattern_desc x =
-  Versions.V4_07.Pattern_desc.of_concrete (concrete_of_pattern_desc x)
+and ast_of_pattern_desc
+  : Compiler_types.pattern_desc -> Versions.V4_07.Pattern_desc.t
+  = fun x ->
+    Versions.V4_07.Pattern_desc.of_concrete (concrete_of_pattern_desc x)
 
-and concrete_of_pattern_desc x : Versions.V4_07.Pattern_desc.concrete =
-  match (x : Compiler_types.pattern_desc) with
-  | Ppat_any -> Ppat_any
-  | Ppat_var (x1) ->
-    Ppat_var (x1)
-  | Ppat_alias (x1, x2) ->
-    let x1 = ast_of_pattern x1 in
-    Ppat_alias (x1, x2)
-  | Ppat_constant (x1) ->
-    let x1 = ast_of_constant x1 in
-    Ppat_constant (x1)
-  | Ppat_interval (x1, x2) ->
-    let x1 = ast_of_constant x1 in
-    let x2 = ast_of_constant x2 in
-    Ppat_interval (x1, x2)
-  | Ppat_tuple (x1) ->
-    let x1 = (List.map ~f:ast_of_pattern) x1 in
-    Ppat_tuple (x1)
-  | Ppat_construct (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = (Option.map ~f:ast_of_pattern) x2 in
-    Ppat_construct (x1, x2)
-  | Ppat_variant (x1, x2) ->
-    let x2 = (Option.map ~f:ast_of_pattern) x2 in
-    Ppat_variant (x1, x2)
-  | Ppat_record (x1, x2) ->
-    let x1 = (List.map ~f:(Tuple.map2 ~f1:ast_of_longident_loc ~f2:ast_of_pattern)) x1 in
-    let x2 = ast_of_closed_flag x2 in
-    Ppat_record (x1, x2)
-  | Ppat_array (x1) ->
-    let x1 = (List.map ~f:ast_of_pattern) x1 in
-    Ppat_array (x1)
-  | Ppat_or (x1, x2) ->
-    let x1 = ast_of_pattern x1 in
-    let x2 = ast_of_pattern x2 in
-    Ppat_or (x1, x2)
-  | Ppat_constraint (x1, x2) ->
-    let x1 = ast_of_pattern x1 in
-    let x2 = ast_of_core_type x2 in
-    Ppat_constraint (x1, x2)
-  | Ppat_type (x1) ->
-    let x1 = ast_of_longident_loc x1 in
-    Ppat_type (x1)
-  | Ppat_lazy (x1) ->
-    let x1 = ast_of_pattern x1 in
-    Ppat_lazy (x1)
-  | Ppat_unpack (x1) ->
-    Ppat_unpack (x1)
-  | Ppat_exception (x1) ->
-    let x1 = ast_of_pattern x1 in
-    Ppat_exception (x1)
-  | Ppat_extension (x1) ->
-    let x1 = ast_of_extension x1 in
-    Ppat_extension (x1)
-  | Ppat_open (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = ast_of_pattern x2 in
-    Ppat_open (x1, x2)
+and concrete_of_pattern_desc
+  : Compiler_types.pattern_desc -> Versions.V4_07.Pattern_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.pattern_desc) with
+    | Ppat_any -> Ppat_any
+    | Ppat_var (x1) ->
+      Ppat_var (x1)
+    | Ppat_alias (x1, x2) ->
+      let x1 = ast_of_pattern x1 in
+      Ppat_alias (x1, x2)
+    | Ppat_constant (x1) ->
+      let x1 = ast_of_constant x1 in
+      Ppat_constant (x1)
+    | Ppat_interval (x1, x2) ->
+      let x1 = ast_of_constant x1 in
+      let x2 = ast_of_constant x2 in
+      Ppat_interval (x1, x2)
+    | Ppat_tuple (x1) ->
+      let x1 = (List.map ~f:ast_of_pattern) x1 in
+      Ppat_tuple (x1)
+    | Ppat_construct (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = (Option.map ~f:ast_of_pattern) x2 in
+      Ppat_construct (x1, x2)
+    | Ppat_variant (x1, x2) ->
+      let x2 = (Option.map ~f:ast_of_pattern) x2 in
+      Ppat_variant (x1, x2)
+    | Ppat_record (x1, x2) ->
+      let x1 = (List.map ~f:(Tuple.map2 ~f1:ast_of_longident_loc ~f2:ast_of_pattern)) x1 in
+      let x2 = ast_of_closed_flag x2 in
+      Ppat_record (x1, x2)
+    | Ppat_array (x1) ->
+      let x1 = (List.map ~f:ast_of_pattern) x1 in
+      Ppat_array (x1)
+    | Ppat_or (x1, x2) ->
+      let x1 = ast_of_pattern x1 in
+      let x2 = ast_of_pattern x2 in
+      Ppat_or (x1, x2)
+    | Ppat_constraint (x1, x2) ->
+      let x1 = ast_of_pattern x1 in
+      let x2 = ast_of_core_type x2 in
+      Ppat_constraint (x1, x2)
+    | Ppat_type (x1) ->
+      let x1 = ast_of_longident_loc x1 in
+      Ppat_type (x1)
+    | Ppat_lazy (x1) ->
+      let x1 = ast_of_pattern x1 in
+      Ppat_lazy (x1)
+    | Ppat_unpack (x1) ->
+      Ppat_unpack (x1)
+    | Ppat_exception (x1) ->
+      let x1 = ast_of_pattern x1 in
+      Ppat_exception (x1)
+    | Ppat_extension (x1) ->
+      let x1 = ast_of_extension x1 in
+      Ppat_extension (x1)
+    | Ppat_open (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = ast_of_pattern x2 in
+      Ppat_open (x1, x2)
 
-and ast_to_pattern_desc x =
-  let concrete = Versions.V4_07.Pattern_desc.to_concrete x in
-  concrete_to_pattern_desc concrete
+and ast_to_pattern_desc
+  : Versions.V4_07.Pattern_desc.t -> Compiler_types.pattern_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Pattern_desc.to_concrete x in
+    concrete_to_pattern_desc concrete
 
-and concrete_to_pattern_desc x : Compiler_types.pattern_desc =
-  match (x : Versions.V4_07.Pattern_desc.concrete) with
-  | Ppat_any -> Ppat_any
-  | Ppat_var (x1) ->
-    Ppat_var (x1)
-  | Ppat_alias (x1, x2) ->
-    let x1 = ast_to_pattern x1 in
-    Ppat_alias (x1, x2)
-  | Ppat_constant (x1) ->
-    let x1 = ast_to_constant x1 in
-    Ppat_constant (x1)
-  | Ppat_interval (x1, x2) ->
-    let x1 = ast_to_constant x1 in
-    let x2 = ast_to_constant x2 in
-    Ppat_interval (x1, x2)
-  | Ppat_tuple (x1) ->
-    let x1 = (List.map ~f:ast_to_pattern) x1 in
-    Ppat_tuple (x1)
-  | Ppat_construct (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = (Option.map ~f:ast_to_pattern) x2 in
-    Ppat_construct (x1, x2)
-  | Ppat_variant (x1, x2) ->
-    let x2 = (Option.map ~f:ast_to_pattern) x2 in
-    Ppat_variant (x1, x2)
-  | Ppat_record (x1, x2) ->
-    let x1 = (List.map ~f:(Tuple.map2 ~f1:ast_to_longident_loc ~f2:ast_to_pattern)) x1 in
-    let x2 = ast_to_closed_flag x2 in
-    Ppat_record (x1, x2)
-  | Ppat_array (x1) ->
-    let x1 = (List.map ~f:ast_to_pattern) x1 in
-    Ppat_array (x1)
-  | Ppat_or (x1, x2) ->
-    let x1 = ast_to_pattern x1 in
-    let x2 = ast_to_pattern x2 in
-    Ppat_or (x1, x2)
-  | Ppat_constraint (x1, x2) ->
-    let x1 = ast_to_pattern x1 in
-    let x2 = ast_to_core_type x2 in
-    Ppat_constraint (x1, x2)
-  | Ppat_type (x1) ->
-    let x1 = ast_to_longident_loc x1 in
-    Ppat_type (x1)
-  | Ppat_lazy (x1) ->
-    let x1 = ast_to_pattern x1 in
-    Ppat_lazy (x1)
-  | Ppat_unpack (x1) ->
-    Ppat_unpack (x1)
-  | Ppat_exception (x1) ->
-    let x1 = ast_to_pattern x1 in
-    Ppat_exception (x1)
-  | Ppat_extension (x1) ->
-    let x1 = ast_to_extension x1 in
-    Ppat_extension (x1)
-  | Ppat_open (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = ast_to_pattern x2 in
-    Ppat_open (x1, x2)
+and concrete_to_pattern_desc
+  : Versions.V4_07.Pattern_desc.concrete -> Compiler_types.pattern_desc
+  = fun x ->
+    match (x : Versions.V4_07.Pattern_desc.concrete) with
+    | Ppat_any -> Ppat_any
+    | Ppat_var (x1) ->
+      Ppat_var (x1)
+    | Ppat_alias (x1, x2) ->
+      let x1 = ast_to_pattern x1 in
+      Ppat_alias (x1, x2)
+    | Ppat_constant (x1) ->
+      let x1 = ast_to_constant x1 in
+      Ppat_constant (x1)
+    | Ppat_interval (x1, x2) ->
+      let x1 = ast_to_constant x1 in
+      let x2 = ast_to_constant x2 in
+      Ppat_interval (x1, x2)
+    | Ppat_tuple (x1) ->
+      let x1 = (List.map ~f:ast_to_pattern) x1 in
+      Ppat_tuple (x1)
+    | Ppat_construct (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = (Option.map ~f:ast_to_pattern) x2 in
+      Ppat_construct (x1, x2)
+    | Ppat_variant (x1, x2) ->
+      let x2 = (Option.map ~f:ast_to_pattern) x2 in
+      Ppat_variant (x1, x2)
+    | Ppat_record (x1, x2) ->
+      let x1 = (List.map ~f:(Tuple.map2 ~f1:ast_to_longident_loc ~f2:ast_to_pattern)) x1 in
+      let x2 = ast_to_closed_flag x2 in
+      Ppat_record (x1, x2)
+    | Ppat_array (x1) ->
+      let x1 = (List.map ~f:ast_to_pattern) x1 in
+      Ppat_array (x1)
+    | Ppat_or (x1, x2) ->
+      let x1 = ast_to_pattern x1 in
+      let x2 = ast_to_pattern x2 in
+      Ppat_or (x1, x2)
+    | Ppat_constraint (x1, x2) ->
+      let x1 = ast_to_pattern x1 in
+      let x2 = ast_to_core_type x2 in
+      Ppat_constraint (x1, x2)
+    | Ppat_type (x1) ->
+      let x1 = ast_to_longident_loc x1 in
+      Ppat_type (x1)
+    | Ppat_lazy (x1) ->
+      let x1 = ast_to_pattern x1 in
+      Ppat_lazy (x1)
+    | Ppat_unpack (x1) ->
+      Ppat_unpack (x1)
+    | Ppat_exception (x1) ->
+      let x1 = ast_to_pattern x1 in
+      Ppat_exception (x1)
+    | Ppat_extension (x1) ->
+      let x1 = ast_to_extension x1 in
+      Ppat_extension (x1)
+    | Ppat_open (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = ast_to_pattern x2 in
+      Ppat_open (x1, x2)
 
-and ast_of_expression x =
-  Versions.V4_07.Expression.of_concrete (concrete_of_expression x)
+and ast_of_expression
+  : Compiler_types.expression -> Versions.V4_07.Expression.t
+  = fun x ->
+    Versions.V4_07.Expression.of_concrete (concrete_of_expression x)
 
 and concrete_of_expression
-  ({ pexp_desc; pexp_loc; pexp_attributes } : Compiler_types.expression)
-=
-  let pexp_desc = ast_of_expression_desc pexp_desc in
-  let pexp_attributes = ast_of_attributes pexp_attributes in
-  ({ pexp_desc; pexp_loc; pexp_attributes } : Versions.V4_07.Expression.concrete)
+  : Compiler_types.expression -> Versions.V4_07.Expression.concrete
+  = fun { pexp_desc; pexp_loc; pexp_attributes } ->
+      let pexp_desc = ast_of_expression_desc pexp_desc in
+      let pexp_attributes = ast_of_attributes pexp_attributes in
+      { pexp_desc; pexp_loc; pexp_attributes }
 
-and ast_to_expression x =
-  let concrete = Versions.V4_07.Expression.to_concrete x in
-  concrete_to_expression concrete
+and ast_to_expression
+  : Versions.V4_07.Expression.t -> Compiler_types.expression
+  = fun x ->
+    let concrete = Versions.V4_07.Expression.to_concrete x in
+    concrete_to_expression concrete
 
 and concrete_to_expression
-  ({ pexp_desc; pexp_loc; pexp_attributes } : Versions.V4_07.Expression.concrete)
-=
-  let pexp_desc = ast_to_expression_desc pexp_desc in
-  let pexp_attributes = ast_to_attributes pexp_attributes in
-  ({ pexp_desc; pexp_loc; pexp_attributes } : Compiler_types.expression)
+  : Versions.V4_07.Expression.concrete -> Compiler_types.expression
+  = fun { pexp_desc; pexp_loc; pexp_attributes } ->
+      let pexp_desc = ast_to_expression_desc pexp_desc in
+      let pexp_attributes = ast_to_attributes pexp_attributes in
+      { pexp_desc; pexp_loc; pexp_attributes }
 
-and ast_of_expression_desc x =
-  Versions.V4_07.Expression_desc.of_concrete (concrete_of_expression_desc x)
+and ast_of_expression_desc
+  : Compiler_types.expression_desc -> Versions.V4_07.Expression_desc.t
+  = fun x ->
+    Versions.V4_07.Expression_desc.of_concrete (concrete_of_expression_desc x)
 
-and concrete_of_expression_desc x : Versions.V4_07.Expression_desc.concrete =
-  match (x : Compiler_types.expression_desc) with
-  | Pexp_ident (x1) ->
-    let x1 = ast_of_longident_loc x1 in
-    Pexp_ident (x1)
-  | Pexp_constant (x1) ->
-    let x1 = ast_of_constant x1 in
-    Pexp_constant (x1)
-  | Pexp_let (x1, x2, x3) ->
-    let x1 = ast_of_rec_flag x1 in
-    let x2 = (List.map ~f:ast_of_value_binding) x2 in
-    let x3 = ast_of_expression x3 in
-    Pexp_let (x1, x2, x3)
-  | Pexp_function (x1) ->
-    let x1 = (List.map ~f:ast_of_case) x1 in
-    Pexp_function (x1)
-  | Pexp_fun (x1, x2, x3, x4) ->
-    let x1 = ast_of_arg_label x1 in
-    let x2 = (Option.map ~f:ast_of_expression) x2 in
-    let x3 = ast_of_pattern x3 in
-    let x4 = ast_of_expression x4 in
-    Pexp_fun (x1, x2, x3, x4)
-  | Pexp_apply (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = (List.map ~f:(Tuple.map2 ~f1:ast_of_arg_label ~f2:ast_of_expression)) x2 in
-    Pexp_apply (x1, x2)
-  | Pexp_match (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = (List.map ~f:ast_of_case) x2 in
-    Pexp_match (x1, x2)
-  | Pexp_try (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = (List.map ~f:ast_of_case) x2 in
-    Pexp_try (x1, x2)
-  | Pexp_tuple (x1) ->
-    let x1 = (List.map ~f:ast_of_expression) x1 in
-    Pexp_tuple (x1)
-  | Pexp_construct (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = (Option.map ~f:ast_of_expression) x2 in
-    Pexp_construct (x1, x2)
-  | Pexp_variant (x1, x2) ->
-    let x2 = (Option.map ~f:ast_of_expression) x2 in
-    Pexp_variant (x1, x2)
-  | Pexp_record (x1, x2) ->
-    let x1 = (List.map ~f:(Tuple.map2 ~f1:ast_of_longident_loc ~f2:ast_of_expression)) x1 in
-    let x2 = (Option.map ~f:ast_of_expression) x2 in
-    Pexp_record (x1, x2)
-  | Pexp_field (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = ast_of_longident_loc x2 in
-    Pexp_field (x1, x2)
-  | Pexp_setfield (x1, x2, x3) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = ast_of_longident_loc x2 in
-    let x3 = ast_of_expression x3 in
-    Pexp_setfield (x1, x2, x3)
-  | Pexp_array (x1) ->
-    let x1 = (List.map ~f:ast_of_expression) x1 in
-    Pexp_array (x1)
-  | Pexp_ifthenelse (x1, x2, x3) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = ast_of_expression x2 in
-    let x3 = (Option.map ~f:ast_of_expression) x3 in
-    Pexp_ifthenelse (x1, x2, x3)
-  | Pexp_sequence (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = ast_of_expression x2 in
-    Pexp_sequence (x1, x2)
-  | Pexp_while (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = ast_of_expression x2 in
-    Pexp_while (x1, x2)
-  | Pexp_for (x1, x2, x3, x4, x5) ->
-    let x1 = ast_of_pattern x1 in
-    let x2 = ast_of_expression x2 in
-    let x3 = ast_of_expression x3 in
-    let x4 = ast_of_direction_flag x4 in
-    let x5 = ast_of_expression x5 in
-    Pexp_for (x1, x2, x3, x4, x5)
-  | Pexp_constraint (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = ast_of_core_type x2 in
-    Pexp_constraint (x1, x2)
-  | Pexp_coerce (x1, x2, x3) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = (Option.map ~f:ast_of_core_type) x2 in
-    let x3 = ast_of_core_type x3 in
-    Pexp_coerce (x1, x2, x3)
-  | Pexp_send (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    Pexp_send (x1, x2)
-  | Pexp_new (x1) ->
-    let x1 = ast_of_longident_loc x1 in
-    Pexp_new (x1)
-  | Pexp_setinstvar (x1, x2) ->
-    let x2 = ast_of_expression x2 in
-    Pexp_setinstvar (x1, x2)
-  | Pexp_override (x1) ->
-    let x1 = (List.map ~f:(Tuple.map2 ~f1:Fn.id ~f2:ast_of_expression)) x1 in
-    Pexp_override (x1)
-  | Pexp_letmodule (x1, x2, x3) ->
-    let x2 = ast_of_module_expr x2 in
-    let x3 = ast_of_expression x3 in
-    Pexp_letmodule (x1, x2, x3)
-  | Pexp_letexception (x1, x2) ->
-    let x1 = ast_of_extension_constructor x1 in
-    let x2 = ast_of_expression x2 in
-    Pexp_letexception (x1, x2)
-  | Pexp_assert (x1) ->
-    let x1 = ast_of_expression x1 in
-    Pexp_assert (x1)
-  | Pexp_lazy (x1) ->
-    let x1 = ast_of_expression x1 in
-    Pexp_lazy (x1)
-  | Pexp_poly (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = (Option.map ~f:ast_of_core_type) x2 in
-    Pexp_poly (x1, x2)
-  | Pexp_object (x1) ->
-    let x1 = ast_of_class_structure x1 in
-    Pexp_object (x1)
-  | Pexp_newtype (x1, x2) ->
-    let x2 = ast_of_expression x2 in
-    Pexp_newtype (x1, x2)
-  | Pexp_pack (x1) ->
-    let x1 = ast_of_module_expr x1 in
-    Pexp_pack (x1)
-  | Pexp_open (x1, x2, x3) ->
-    let x1 = ast_of_override_flag x1 in
-    let x2 = ast_of_longident_loc x2 in
-    let x3 = ast_of_expression x3 in
-    Pexp_open (x1, x2, x3)
-  | Pexp_extension (x1) ->
-    let x1 = ast_of_extension x1 in
-    Pexp_extension (x1)
-  | Pexp_unreachable -> Pexp_unreachable
+and concrete_of_expression_desc
+  : Compiler_types.expression_desc -> Versions.V4_07.Expression_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.expression_desc) with
+    | Pexp_ident (x1) ->
+      let x1 = ast_of_longident_loc x1 in
+      Pexp_ident (x1)
+    | Pexp_constant (x1) ->
+      let x1 = ast_of_constant x1 in
+      Pexp_constant (x1)
+    | Pexp_let (x1, x2, x3) ->
+      let x1 = ast_of_rec_flag x1 in
+      let x2 = (List.map ~f:ast_of_value_binding) x2 in
+      let x3 = ast_of_expression x3 in
+      Pexp_let (x1, x2, x3)
+    | Pexp_function (x1) ->
+      let x1 = (List.map ~f:ast_of_case) x1 in
+      Pexp_function (x1)
+    | Pexp_fun (x1, x2, x3, x4) ->
+      let x1 = ast_of_arg_label x1 in
+      let x2 = (Option.map ~f:ast_of_expression) x2 in
+      let x3 = ast_of_pattern x3 in
+      let x4 = ast_of_expression x4 in
+      Pexp_fun (x1, x2, x3, x4)
+    | Pexp_apply (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = (List.map ~f:(Tuple.map2 ~f1:ast_of_arg_label ~f2:ast_of_expression)) x2 in
+      Pexp_apply (x1, x2)
+    | Pexp_match (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = (List.map ~f:ast_of_case) x2 in
+      Pexp_match (x1, x2)
+    | Pexp_try (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = (List.map ~f:ast_of_case) x2 in
+      Pexp_try (x1, x2)
+    | Pexp_tuple (x1) ->
+      let x1 = (List.map ~f:ast_of_expression) x1 in
+      Pexp_tuple (x1)
+    | Pexp_construct (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = (Option.map ~f:ast_of_expression) x2 in
+      Pexp_construct (x1, x2)
+    | Pexp_variant (x1, x2) ->
+      let x2 = (Option.map ~f:ast_of_expression) x2 in
+      Pexp_variant (x1, x2)
+    | Pexp_record (x1, x2) ->
+      let x1 = (List.map ~f:(Tuple.map2 ~f1:ast_of_longident_loc ~f2:ast_of_expression)) x1 in
+      let x2 = (Option.map ~f:ast_of_expression) x2 in
+      Pexp_record (x1, x2)
+    | Pexp_field (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = ast_of_longident_loc x2 in
+      Pexp_field (x1, x2)
+    | Pexp_setfield (x1, x2, x3) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = ast_of_longident_loc x2 in
+      let x3 = ast_of_expression x3 in
+      Pexp_setfield (x1, x2, x3)
+    | Pexp_array (x1) ->
+      let x1 = (List.map ~f:ast_of_expression) x1 in
+      Pexp_array (x1)
+    | Pexp_ifthenelse (x1, x2, x3) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = ast_of_expression x2 in
+      let x3 = (Option.map ~f:ast_of_expression) x3 in
+      Pexp_ifthenelse (x1, x2, x3)
+    | Pexp_sequence (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = ast_of_expression x2 in
+      Pexp_sequence (x1, x2)
+    | Pexp_while (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = ast_of_expression x2 in
+      Pexp_while (x1, x2)
+    | Pexp_for (x1, x2, x3, x4, x5) ->
+      let x1 = ast_of_pattern x1 in
+      let x2 = ast_of_expression x2 in
+      let x3 = ast_of_expression x3 in
+      let x4 = ast_of_direction_flag x4 in
+      let x5 = ast_of_expression x5 in
+      Pexp_for (x1, x2, x3, x4, x5)
+    | Pexp_constraint (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = ast_of_core_type x2 in
+      Pexp_constraint (x1, x2)
+    | Pexp_coerce (x1, x2, x3) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = (Option.map ~f:ast_of_core_type) x2 in
+      let x3 = ast_of_core_type x3 in
+      Pexp_coerce (x1, x2, x3)
+    | Pexp_send (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      Pexp_send (x1, x2)
+    | Pexp_new (x1) ->
+      let x1 = ast_of_longident_loc x1 in
+      Pexp_new (x1)
+    | Pexp_setinstvar (x1, x2) ->
+      let x2 = ast_of_expression x2 in
+      Pexp_setinstvar (x1, x2)
+    | Pexp_override (x1) ->
+      let x1 = (List.map ~f:(Tuple.map2 ~f1:Fn.id ~f2:ast_of_expression)) x1 in
+      Pexp_override (x1)
+    | Pexp_letmodule (x1, x2, x3) ->
+      let x2 = ast_of_module_expr x2 in
+      let x3 = ast_of_expression x3 in
+      Pexp_letmodule (x1, x2, x3)
+    | Pexp_letexception (x1, x2) ->
+      let x1 = ast_of_extension_constructor x1 in
+      let x2 = ast_of_expression x2 in
+      Pexp_letexception (x1, x2)
+    | Pexp_assert (x1) ->
+      let x1 = ast_of_expression x1 in
+      Pexp_assert (x1)
+    | Pexp_lazy (x1) ->
+      let x1 = ast_of_expression x1 in
+      Pexp_lazy (x1)
+    | Pexp_poly (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = (Option.map ~f:ast_of_core_type) x2 in
+      Pexp_poly (x1, x2)
+    | Pexp_object (x1) ->
+      let x1 = ast_of_class_structure x1 in
+      Pexp_object (x1)
+    | Pexp_newtype (x1, x2) ->
+      let x2 = ast_of_expression x2 in
+      Pexp_newtype (x1, x2)
+    | Pexp_pack (x1) ->
+      let x1 = ast_of_module_expr x1 in
+      Pexp_pack (x1)
+    | Pexp_open (x1, x2, x3) ->
+      let x1 = ast_of_override_flag x1 in
+      let x2 = ast_of_longident_loc x2 in
+      let x3 = ast_of_expression x3 in
+      Pexp_open (x1, x2, x3)
+    | Pexp_extension (x1) ->
+      let x1 = ast_of_extension x1 in
+      Pexp_extension (x1)
+    | Pexp_unreachable -> Pexp_unreachable
 
-and ast_to_expression_desc x =
-  let concrete = Versions.V4_07.Expression_desc.to_concrete x in
-  concrete_to_expression_desc concrete
+and ast_to_expression_desc
+  : Versions.V4_07.Expression_desc.t -> Compiler_types.expression_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Expression_desc.to_concrete x in
+    concrete_to_expression_desc concrete
 
-and concrete_to_expression_desc x : Compiler_types.expression_desc =
-  match (x : Versions.V4_07.Expression_desc.concrete) with
-  | Pexp_ident (x1) ->
-    let x1 = ast_to_longident_loc x1 in
-    Pexp_ident (x1)
-  | Pexp_constant (x1) ->
-    let x1 = ast_to_constant x1 in
-    Pexp_constant (x1)
-  | Pexp_let (x1, x2, x3) ->
-    let x1 = ast_to_rec_flag x1 in
-    let x2 = (List.map ~f:ast_to_value_binding) x2 in
-    let x3 = ast_to_expression x3 in
-    Pexp_let (x1, x2, x3)
-  | Pexp_function (x1) ->
-    let x1 = (List.map ~f:ast_to_case) x1 in
-    Pexp_function (x1)
-  | Pexp_fun (x1, x2, x3, x4) ->
-    let x1 = ast_to_arg_label x1 in
-    let x2 = (Option.map ~f:ast_to_expression) x2 in
-    let x3 = ast_to_pattern x3 in
-    let x4 = ast_to_expression x4 in
-    Pexp_fun (x1, x2, x3, x4)
-  | Pexp_apply (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = (List.map ~f:(Tuple.map2 ~f1:ast_to_arg_label ~f2:ast_to_expression)) x2 in
-    Pexp_apply (x1, x2)
-  | Pexp_match (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = (List.map ~f:ast_to_case) x2 in
-    Pexp_match (x1, x2)
-  | Pexp_try (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = (List.map ~f:ast_to_case) x2 in
-    Pexp_try (x1, x2)
-  | Pexp_tuple (x1) ->
-    let x1 = (List.map ~f:ast_to_expression) x1 in
-    Pexp_tuple (x1)
-  | Pexp_construct (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = (Option.map ~f:ast_to_expression) x2 in
-    Pexp_construct (x1, x2)
-  | Pexp_variant (x1, x2) ->
-    let x2 = (Option.map ~f:ast_to_expression) x2 in
-    Pexp_variant (x1, x2)
-  | Pexp_record (x1, x2) ->
-    let x1 = (List.map ~f:(Tuple.map2 ~f1:ast_to_longident_loc ~f2:ast_to_expression)) x1 in
-    let x2 = (Option.map ~f:ast_to_expression) x2 in
-    Pexp_record (x1, x2)
-  | Pexp_field (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = ast_to_longident_loc x2 in
-    Pexp_field (x1, x2)
-  | Pexp_setfield (x1, x2, x3) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = ast_to_longident_loc x2 in
-    let x3 = ast_to_expression x3 in
-    Pexp_setfield (x1, x2, x3)
-  | Pexp_array (x1) ->
-    let x1 = (List.map ~f:ast_to_expression) x1 in
-    Pexp_array (x1)
-  | Pexp_ifthenelse (x1, x2, x3) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = ast_to_expression x2 in
-    let x3 = (Option.map ~f:ast_to_expression) x3 in
-    Pexp_ifthenelse (x1, x2, x3)
-  | Pexp_sequence (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = ast_to_expression x2 in
-    Pexp_sequence (x1, x2)
-  | Pexp_while (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = ast_to_expression x2 in
-    Pexp_while (x1, x2)
-  | Pexp_for (x1, x2, x3, x4, x5) ->
-    let x1 = ast_to_pattern x1 in
-    let x2 = ast_to_expression x2 in
-    let x3 = ast_to_expression x3 in
-    let x4 = ast_to_direction_flag x4 in
-    let x5 = ast_to_expression x5 in
-    Pexp_for (x1, x2, x3, x4, x5)
-  | Pexp_constraint (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = ast_to_core_type x2 in
-    Pexp_constraint (x1, x2)
-  | Pexp_coerce (x1, x2, x3) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = (Option.map ~f:ast_to_core_type) x2 in
-    let x3 = ast_to_core_type x3 in
-    Pexp_coerce (x1, x2, x3)
-  | Pexp_send (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    Pexp_send (x1, x2)
-  | Pexp_new (x1) ->
-    let x1 = ast_to_longident_loc x1 in
-    Pexp_new (x1)
-  | Pexp_setinstvar (x1, x2) ->
-    let x2 = ast_to_expression x2 in
-    Pexp_setinstvar (x1, x2)
-  | Pexp_override (x1) ->
-    let x1 = (List.map ~f:(Tuple.map2 ~f1:Fn.id ~f2:ast_to_expression)) x1 in
-    Pexp_override (x1)
-  | Pexp_letmodule (x1, x2, x3) ->
-    let x2 = ast_to_module_expr x2 in
-    let x3 = ast_to_expression x3 in
-    Pexp_letmodule (x1, x2, x3)
-  | Pexp_letexception (x1, x2) ->
-    let x1 = ast_to_extension_constructor x1 in
-    let x2 = ast_to_expression x2 in
-    Pexp_letexception (x1, x2)
-  | Pexp_assert (x1) ->
-    let x1 = ast_to_expression x1 in
-    Pexp_assert (x1)
-  | Pexp_lazy (x1) ->
-    let x1 = ast_to_expression x1 in
-    Pexp_lazy (x1)
-  | Pexp_poly (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = (Option.map ~f:ast_to_core_type) x2 in
-    Pexp_poly (x1, x2)
-  | Pexp_object (x1) ->
-    let x1 = ast_to_class_structure x1 in
-    Pexp_object (x1)
-  | Pexp_newtype (x1, x2) ->
-    let x2 = ast_to_expression x2 in
-    Pexp_newtype (x1, x2)
-  | Pexp_pack (x1) ->
-    let x1 = ast_to_module_expr x1 in
-    Pexp_pack (x1)
-  | Pexp_open (x1, x2, x3) ->
-    let x1 = ast_to_override_flag x1 in
-    let x2 = ast_to_longident_loc x2 in
-    let x3 = ast_to_expression x3 in
-    Pexp_open (x1, x2, x3)
-  | Pexp_extension (x1) ->
-    let x1 = ast_to_extension x1 in
-    Pexp_extension (x1)
-  | Pexp_unreachable -> Pexp_unreachable
+and concrete_to_expression_desc
+  : Versions.V4_07.Expression_desc.concrete -> Compiler_types.expression_desc
+  = fun x ->
+    match (x : Versions.V4_07.Expression_desc.concrete) with
+    | Pexp_ident (x1) ->
+      let x1 = ast_to_longident_loc x1 in
+      Pexp_ident (x1)
+    | Pexp_constant (x1) ->
+      let x1 = ast_to_constant x1 in
+      Pexp_constant (x1)
+    | Pexp_let (x1, x2, x3) ->
+      let x1 = ast_to_rec_flag x1 in
+      let x2 = (List.map ~f:ast_to_value_binding) x2 in
+      let x3 = ast_to_expression x3 in
+      Pexp_let (x1, x2, x3)
+    | Pexp_function (x1) ->
+      let x1 = (List.map ~f:ast_to_case) x1 in
+      Pexp_function (x1)
+    | Pexp_fun (x1, x2, x3, x4) ->
+      let x1 = ast_to_arg_label x1 in
+      let x2 = (Option.map ~f:ast_to_expression) x2 in
+      let x3 = ast_to_pattern x3 in
+      let x4 = ast_to_expression x4 in
+      Pexp_fun (x1, x2, x3, x4)
+    | Pexp_apply (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = (List.map ~f:(Tuple.map2 ~f1:ast_to_arg_label ~f2:ast_to_expression)) x2 in
+      Pexp_apply (x1, x2)
+    | Pexp_match (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = (List.map ~f:ast_to_case) x2 in
+      Pexp_match (x1, x2)
+    | Pexp_try (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = (List.map ~f:ast_to_case) x2 in
+      Pexp_try (x1, x2)
+    | Pexp_tuple (x1) ->
+      let x1 = (List.map ~f:ast_to_expression) x1 in
+      Pexp_tuple (x1)
+    | Pexp_construct (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = (Option.map ~f:ast_to_expression) x2 in
+      Pexp_construct (x1, x2)
+    | Pexp_variant (x1, x2) ->
+      let x2 = (Option.map ~f:ast_to_expression) x2 in
+      Pexp_variant (x1, x2)
+    | Pexp_record (x1, x2) ->
+      let x1 = (List.map ~f:(Tuple.map2 ~f1:ast_to_longident_loc ~f2:ast_to_expression)) x1 in
+      let x2 = (Option.map ~f:ast_to_expression) x2 in
+      Pexp_record (x1, x2)
+    | Pexp_field (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = ast_to_longident_loc x2 in
+      Pexp_field (x1, x2)
+    | Pexp_setfield (x1, x2, x3) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = ast_to_longident_loc x2 in
+      let x3 = ast_to_expression x3 in
+      Pexp_setfield (x1, x2, x3)
+    | Pexp_array (x1) ->
+      let x1 = (List.map ~f:ast_to_expression) x1 in
+      Pexp_array (x1)
+    | Pexp_ifthenelse (x1, x2, x3) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = ast_to_expression x2 in
+      let x3 = (Option.map ~f:ast_to_expression) x3 in
+      Pexp_ifthenelse (x1, x2, x3)
+    | Pexp_sequence (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = ast_to_expression x2 in
+      Pexp_sequence (x1, x2)
+    | Pexp_while (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = ast_to_expression x2 in
+      Pexp_while (x1, x2)
+    | Pexp_for (x1, x2, x3, x4, x5) ->
+      let x1 = ast_to_pattern x1 in
+      let x2 = ast_to_expression x2 in
+      let x3 = ast_to_expression x3 in
+      let x4 = ast_to_direction_flag x4 in
+      let x5 = ast_to_expression x5 in
+      Pexp_for (x1, x2, x3, x4, x5)
+    | Pexp_constraint (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = ast_to_core_type x2 in
+      Pexp_constraint (x1, x2)
+    | Pexp_coerce (x1, x2, x3) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = (Option.map ~f:ast_to_core_type) x2 in
+      let x3 = ast_to_core_type x3 in
+      Pexp_coerce (x1, x2, x3)
+    | Pexp_send (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      Pexp_send (x1, x2)
+    | Pexp_new (x1) ->
+      let x1 = ast_to_longident_loc x1 in
+      Pexp_new (x1)
+    | Pexp_setinstvar (x1, x2) ->
+      let x2 = ast_to_expression x2 in
+      Pexp_setinstvar (x1, x2)
+    | Pexp_override (x1) ->
+      let x1 = (List.map ~f:(Tuple.map2 ~f1:Fn.id ~f2:ast_to_expression)) x1 in
+      Pexp_override (x1)
+    | Pexp_letmodule (x1, x2, x3) ->
+      let x2 = ast_to_module_expr x2 in
+      let x3 = ast_to_expression x3 in
+      Pexp_letmodule (x1, x2, x3)
+    | Pexp_letexception (x1, x2) ->
+      let x1 = ast_to_extension_constructor x1 in
+      let x2 = ast_to_expression x2 in
+      Pexp_letexception (x1, x2)
+    | Pexp_assert (x1) ->
+      let x1 = ast_to_expression x1 in
+      Pexp_assert (x1)
+    | Pexp_lazy (x1) ->
+      let x1 = ast_to_expression x1 in
+      Pexp_lazy (x1)
+    | Pexp_poly (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = (Option.map ~f:ast_to_core_type) x2 in
+      Pexp_poly (x1, x2)
+    | Pexp_object (x1) ->
+      let x1 = ast_to_class_structure x1 in
+      Pexp_object (x1)
+    | Pexp_newtype (x1, x2) ->
+      let x2 = ast_to_expression x2 in
+      Pexp_newtype (x1, x2)
+    | Pexp_pack (x1) ->
+      let x1 = ast_to_module_expr x1 in
+      Pexp_pack (x1)
+    | Pexp_open (x1, x2, x3) ->
+      let x1 = ast_to_override_flag x1 in
+      let x2 = ast_to_longident_loc x2 in
+      let x3 = ast_to_expression x3 in
+      Pexp_open (x1, x2, x3)
+    | Pexp_extension (x1) ->
+      let x1 = ast_to_extension x1 in
+      Pexp_extension (x1)
+    | Pexp_unreachable -> Pexp_unreachable
 
-and ast_of_case x =
-  Versions.V4_07.Case.of_concrete (concrete_of_case x)
+and ast_of_case
+  : Compiler_types.case -> Versions.V4_07.Case.t
+  = fun x ->
+    Versions.V4_07.Case.of_concrete (concrete_of_case x)
 
 and concrete_of_case
-  ({ pc_lhs; pc_guard; pc_rhs } : Compiler_types.case)
-=
-  let pc_lhs = ast_of_pattern pc_lhs in
-  let pc_guard = (Option.map ~f:ast_of_expression) pc_guard in
-  let pc_rhs = ast_of_expression pc_rhs in
-  ({ pc_lhs; pc_guard; pc_rhs } : Versions.V4_07.Case.concrete)
+  : Compiler_types.case -> Versions.V4_07.Case.concrete
+  = fun { pc_lhs; pc_guard; pc_rhs } ->
+      let pc_lhs = ast_of_pattern pc_lhs in
+      let pc_guard = (Option.map ~f:ast_of_expression) pc_guard in
+      let pc_rhs = ast_of_expression pc_rhs in
+      { pc_lhs; pc_guard; pc_rhs }
 
-and ast_to_case x =
-  let concrete = Versions.V4_07.Case.to_concrete x in
-  concrete_to_case concrete
+and ast_to_case
+  : Versions.V4_07.Case.t -> Compiler_types.case
+  = fun x ->
+    let concrete = Versions.V4_07.Case.to_concrete x in
+    concrete_to_case concrete
 
 and concrete_to_case
-  ({ pc_lhs; pc_guard; pc_rhs } : Versions.V4_07.Case.concrete)
-=
-  let pc_lhs = ast_to_pattern pc_lhs in
-  let pc_guard = (Option.map ~f:ast_to_expression) pc_guard in
-  let pc_rhs = ast_to_expression pc_rhs in
-  ({ pc_lhs; pc_guard; pc_rhs } : Compiler_types.case)
+  : Versions.V4_07.Case.concrete -> Compiler_types.case
+  = fun { pc_lhs; pc_guard; pc_rhs } ->
+      let pc_lhs = ast_to_pattern pc_lhs in
+      let pc_guard = (Option.map ~f:ast_to_expression) pc_guard in
+      let pc_rhs = ast_to_expression pc_rhs in
+      { pc_lhs; pc_guard; pc_rhs }
 
-and ast_of_value_description x =
-  Versions.V4_07.Value_description.of_concrete (concrete_of_value_description x)
+and ast_of_value_description
+  : Compiler_types.value_description -> Versions.V4_07.Value_description.t
+  = fun x ->
+    Versions.V4_07.Value_description.of_concrete (concrete_of_value_description x)
 
 and concrete_of_value_description
-  ({ pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Compiler_types.value_description)
-=
-  let pval_type = ast_of_core_type pval_type in
-  let pval_attributes = ast_of_attributes pval_attributes in
-  ({ pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Versions.V4_07.Value_description.concrete)
+  : Compiler_types.value_description -> Versions.V4_07.Value_description.concrete
+  = fun { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } ->
+      let pval_type = ast_of_core_type pval_type in
+      let pval_attributes = ast_of_attributes pval_attributes in
+      { pval_name; pval_type; pval_prim; pval_attributes; pval_loc }
 
-and ast_to_value_description x =
-  let concrete = Versions.V4_07.Value_description.to_concrete x in
-  concrete_to_value_description concrete
+and ast_to_value_description
+  : Versions.V4_07.Value_description.t -> Compiler_types.value_description
+  = fun x ->
+    let concrete = Versions.V4_07.Value_description.to_concrete x in
+    concrete_to_value_description concrete
 
 and concrete_to_value_description
-  ({ pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Versions.V4_07.Value_description.concrete)
-=
-  let pval_type = ast_to_core_type pval_type in
-  let pval_attributes = ast_to_attributes pval_attributes in
-  ({ pval_name; pval_type; pval_prim; pval_attributes; pval_loc } : Compiler_types.value_description)
+  : Versions.V4_07.Value_description.concrete -> Compiler_types.value_description
+  = fun { pval_name; pval_type; pval_prim; pval_attributes; pval_loc } ->
+      let pval_type = ast_to_core_type pval_type in
+      let pval_attributes = ast_to_attributes pval_attributes in
+      { pval_name; pval_type; pval_prim; pval_attributes; pval_loc }
 
-and ast_of_type_declaration x =
-  Versions.V4_07.Type_declaration.of_concrete (concrete_of_type_declaration x)
+and ast_of_type_declaration
+  : Compiler_types.type_declaration -> Versions.V4_07.Type_declaration.t
+  = fun x ->
+    Versions.V4_07.Type_declaration.of_concrete (concrete_of_type_declaration x)
 
 and concrete_of_type_declaration
-  ({ ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Compiler_types.type_declaration)
-=
-  let ptype_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) ptype_params in
-  let ptype_cstrs = (List.map ~f:(Tuple.map3 ~f1:ast_of_core_type ~f2:ast_of_core_type ~f3:Fn.id)) ptype_cstrs in
-  let ptype_kind = ast_of_type_kind ptype_kind in
-  let ptype_private = ast_of_private_flag ptype_private in
-  let ptype_manifest = (Option.map ~f:ast_of_core_type) ptype_manifest in
-  let ptype_attributes = ast_of_attributes ptype_attributes in
-  ({ ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Versions.V4_07.Type_declaration.concrete)
+  : Compiler_types.type_declaration -> Versions.V4_07.Type_declaration.concrete
+  = fun { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } ->
+      let ptype_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) ptype_params in
+      let ptype_cstrs = (List.map ~f:(Tuple.map3 ~f1:ast_of_core_type ~f2:ast_of_core_type ~f3:Fn.id)) ptype_cstrs in
+      let ptype_kind = ast_of_type_kind ptype_kind in
+      let ptype_private = ast_of_private_flag ptype_private in
+      let ptype_manifest = (Option.map ~f:ast_of_core_type) ptype_manifest in
+      let ptype_attributes = ast_of_attributes ptype_attributes in
+      { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc }
 
-and ast_to_type_declaration x =
-  let concrete = Versions.V4_07.Type_declaration.to_concrete x in
-  concrete_to_type_declaration concrete
+and ast_to_type_declaration
+  : Versions.V4_07.Type_declaration.t -> Compiler_types.type_declaration
+  = fun x ->
+    let concrete = Versions.V4_07.Type_declaration.to_concrete x in
+    concrete_to_type_declaration concrete
 
 and concrete_to_type_declaration
-  ({ ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Versions.V4_07.Type_declaration.concrete)
-=
-  let ptype_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) ptype_params in
-  let ptype_cstrs = (List.map ~f:(Tuple.map3 ~f1:ast_to_core_type ~f2:ast_to_core_type ~f3:Fn.id)) ptype_cstrs in
-  let ptype_kind = ast_to_type_kind ptype_kind in
-  let ptype_private = ast_to_private_flag ptype_private in
-  let ptype_manifest = (Option.map ~f:ast_to_core_type) ptype_manifest in
-  let ptype_attributes = ast_to_attributes ptype_attributes in
-  ({ ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } : Compiler_types.type_declaration)
+  : Versions.V4_07.Type_declaration.concrete -> Compiler_types.type_declaration
+  = fun { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc } ->
+      let ptype_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) ptype_params in
+      let ptype_cstrs = (List.map ~f:(Tuple.map3 ~f1:ast_to_core_type ~f2:ast_to_core_type ~f3:Fn.id)) ptype_cstrs in
+      let ptype_kind = ast_to_type_kind ptype_kind in
+      let ptype_private = ast_to_private_flag ptype_private in
+      let ptype_manifest = (Option.map ~f:ast_to_core_type) ptype_manifest in
+      let ptype_attributes = ast_to_attributes ptype_attributes in
+      { ptype_name; ptype_params; ptype_cstrs; ptype_kind; ptype_private; ptype_manifest; ptype_attributes; ptype_loc }
 
-and ast_of_type_kind x =
-  Versions.V4_07.Type_kind.of_concrete (concrete_of_type_kind x)
+and ast_of_type_kind
+  : Compiler_types.type_kind -> Versions.V4_07.Type_kind.t
+  = fun x ->
+    Versions.V4_07.Type_kind.of_concrete (concrete_of_type_kind x)
 
-and concrete_of_type_kind x : Versions.V4_07.Type_kind.concrete =
-  match (x : Compiler_types.type_kind) with
-  | Ptype_abstract -> Ptype_abstract
-  | Ptype_variant (x1) ->
-    let x1 = (List.map ~f:ast_of_constructor_declaration) x1 in
-    Ptype_variant (x1)
-  | Ptype_record (x1) ->
-    let x1 = (List.map ~f:ast_of_label_declaration) x1 in
-    Ptype_record (x1)
-  | Ptype_open -> Ptype_open
+and concrete_of_type_kind
+  : Compiler_types.type_kind -> Versions.V4_07.Type_kind.concrete
+  = fun x ->
+    match (x : Compiler_types.type_kind) with
+    | Ptype_abstract -> Ptype_abstract
+    | Ptype_variant (x1) ->
+      let x1 = (List.map ~f:ast_of_constructor_declaration) x1 in
+      Ptype_variant (x1)
+    | Ptype_record (x1) ->
+      let x1 = (List.map ~f:ast_of_label_declaration) x1 in
+      Ptype_record (x1)
+    | Ptype_open -> Ptype_open
 
-and ast_to_type_kind x =
-  let concrete = Versions.V4_07.Type_kind.to_concrete x in
-  concrete_to_type_kind concrete
+and ast_to_type_kind
+  : Versions.V4_07.Type_kind.t -> Compiler_types.type_kind
+  = fun x ->
+    let concrete = Versions.V4_07.Type_kind.to_concrete x in
+    concrete_to_type_kind concrete
 
-and concrete_to_type_kind x : Compiler_types.type_kind =
-  match (x : Versions.V4_07.Type_kind.concrete) with
-  | Ptype_abstract -> Ptype_abstract
-  | Ptype_variant (x1) ->
-    let x1 = (List.map ~f:ast_to_constructor_declaration) x1 in
-    Ptype_variant (x1)
-  | Ptype_record (x1) ->
-    let x1 = (List.map ~f:ast_to_label_declaration) x1 in
-    Ptype_record (x1)
-  | Ptype_open -> Ptype_open
+and concrete_to_type_kind
+  : Versions.V4_07.Type_kind.concrete -> Compiler_types.type_kind
+  = fun x ->
+    match (x : Versions.V4_07.Type_kind.concrete) with
+    | Ptype_abstract -> Ptype_abstract
+    | Ptype_variant (x1) ->
+      let x1 = (List.map ~f:ast_to_constructor_declaration) x1 in
+      Ptype_variant (x1)
+    | Ptype_record (x1) ->
+      let x1 = (List.map ~f:ast_to_label_declaration) x1 in
+      Ptype_record (x1)
+    | Ptype_open -> Ptype_open
 
-and ast_of_label_declaration x =
-  Versions.V4_07.Label_declaration.of_concrete (concrete_of_label_declaration x)
+and ast_of_label_declaration
+  : Compiler_types.label_declaration -> Versions.V4_07.Label_declaration.t
+  = fun x ->
+    Versions.V4_07.Label_declaration.of_concrete (concrete_of_label_declaration x)
 
 and concrete_of_label_declaration
-  ({ pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Compiler_types.label_declaration)
-=
-  let pld_mutable = ast_of_mutable_flag pld_mutable in
-  let pld_type = ast_of_core_type pld_type in
-  let pld_attributes = ast_of_attributes pld_attributes in
-  ({ pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Versions.V4_07.Label_declaration.concrete)
+  : Compiler_types.label_declaration -> Versions.V4_07.Label_declaration.concrete
+  = fun { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } ->
+      let pld_mutable = ast_of_mutable_flag pld_mutable in
+      let pld_type = ast_of_core_type pld_type in
+      let pld_attributes = ast_of_attributes pld_attributes in
+      { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes }
 
-and ast_to_label_declaration x =
-  let concrete = Versions.V4_07.Label_declaration.to_concrete x in
-  concrete_to_label_declaration concrete
+and ast_to_label_declaration
+  : Versions.V4_07.Label_declaration.t -> Compiler_types.label_declaration
+  = fun x ->
+    let concrete = Versions.V4_07.Label_declaration.to_concrete x in
+    concrete_to_label_declaration concrete
 
 and concrete_to_label_declaration
-  ({ pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Versions.V4_07.Label_declaration.concrete)
-=
-  let pld_mutable = ast_to_mutable_flag pld_mutable in
-  let pld_type = ast_to_core_type pld_type in
-  let pld_attributes = ast_to_attributes pld_attributes in
-  ({ pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } : Compiler_types.label_declaration)
+  : Versions.V4_07.Label_declaration.concrete -> Compiler_types.label_declaration
+  = fun { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes } ->
+      let pld_mutable = ast_to_mutable_flag pld_mutable in
+      let pld_type = ast_to_core_type pld_type in
+      let pld_attributes = ast_to_attributes pld_attributes in
+      { pld_name; pld_mutable; pld_type; pld_loc; pld_attributes }
 
-and ast_of_constructor_declaration x =
-  Versions.V4_07.Constructor_declaration.of_concrete (concrete_of_constructor_declaration x)
+and ast_of_constructor_declaration
+  : Compiler_types.constructor_declaration -> Versions.V4_07.Constructor_declaration.t
+  = fun x ->
+    Versions.V4_07.Constructor_declaration.of_concrete (concrete_of_constructor_declaration x)
 
 and concrete_of_constructor_declaration
-  ({ pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Compiler_types.constructor_declaration)
-=
-  let pcd_args = ast_of_constructor_arguments pcd_args in
-  let pcd_res = (Option.map ~f:ast_of_core_type) pcd_res in
-  let pcd_attributes = ast_of_attributes pcd_attributes in
-  ({ pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Versions.V4_07.Constructor_declaration.concrete)
+  : Compiler_types.constructor_declaration -> Versions.V4_07.Constructor_declaration.concrete
+  = fun { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } ->
+      let pcd_args = ast_of_constructor_arguments pcd_args in
+      let pcd_res = (Option.map ~f:ast_of_core_type) pcd_res in
+      let pcd_attributes = ast_of_attributes pcd_attributes in
+      { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes }
 
-and ast_to_constructor_declaration x =
-  let concrete = Versions.V4_07.Constructor_declaration.to_concrete x in
-  concrete_to_constructor_declaration concrete
+and ast_to_constructor_declaration
+  : Versions.V4_07.Constructor_declaration.t -> Compiler_types.constructor_declaration
+  = fun x ->
+    let concrete = Versions.V4_07.Constructor_declaration.to_concrete x in
+    concrete_to_constructor_declaration concrete
 
 and concrete_to_constructor_declaration
-  ({ pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Versions.V4_07.Constructor_declaration.concrete)
-=
-  let pcd_args = ast_to_constructor_arguments pcd_args in
-  let pcd_res = (Option.map ~f:ast_to_core_type) pcd_res in
-  let pcd_attributes = ast_to_attributes pcd_attributes in
-  ({ pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } : Compiler_types.constructor_declaration)
+  : Versions.V4_07.Constructor_declaration.concrete -> Compiler_types.constructor_declaration
+  = fun { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes } ->
+      let pcd_args = ast_to_constructor_arguments pcd_args in
+      let pcd_res = (Option.map ~f:ast_to_core_type) pcd_res in
+      let pcd_attributes = ast_to_attributes pcd_attributes in
+      { pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes }
 
-and ast_of_constructor_arguments x =
-  Versions.V4_07.Constructor_arguments.of_concrete (concrete_of_constructor_arguments x)
+and ast_of_constructor_arguments
+  : Compiler_types.constructor_arguments -> Versions.V4_07.Constructor_arguments.t
+  = fun x ->
+    Versions.V4_07.Constructor_arguments.of_concrete (concrete_of_constructor_arguments x)
 
-and concrete_of_constructor_arguments x : Versions.V4_07.Constructor_arguments.concrete =
-  match (x : Compiler_types.constructor_arguments) with
-  | Pcstr_tuple (x1) ->
-    let x1 = (List.map ~f:ast_of_core_type) x1 in
-    Pcstr_tuple (x1)
-  | Pcstr_record (x1) ->
-    let x1 = (List.map ~f:ast_of_label_declaration) x1 in
-    Pcstr_record (x1)
+and concrete_of_constructor_arguments
+  : Compiler_types.constructor_arguments -> Versions.V4_07.Constructor_arguments.concrete
+  = fun x ->
+    match (x : Compiler_types.constructor_arguments) with
+    | Pcstr_tuple (x1) ->
+      let x1 = (List.map ~f:ast_of_core_type) x1 in
+      Pcstr_tuple (x1)
+    | Pcstr_record (x1) ->
+      let x1 = (List.map ~f:ast_of_label_declaration) x1 in
+      Pcstr_record (x1)
 
-and ast_to_constructor_arguments x =
-  let concrete = Versions.V4_07.Constructor_arguments.to_concrete x in
-  concrete_to_constructor_arguments concrete
+and ast_to_constructor_arguments
+  : Versions.V4_07.Constructor_arguments.t -> Compiler_types.constructor_arguments
+  = fun x ->
+    let concrete = Versions.V4_07.Constructor_arguments.to_concrete x in
+    concrete_to_constructor_arguments concrete
 
-and concrete_to_constructor_arguments x : Compiler_types.constructor_arguments =
-  match (x : Versions.V4_07.Constructor_arguments.concrete) with
-  | Pcstr_tuple (x1) ->
-    let x1 = (List.map ~f:ast_to_core_type) x1 in
-    Pcstr_tuple (x1)
-  | Pcstr_record (x1) ->
-    let x1 = (List.map ~f:ast_to_label_declaration) x1 in
-    Pcstr_record (x1)
+and concrete_to_constructor_arguments
+  : Versions.V4_07.Constructor_arguments.concrete -> Compiler_types.constructor_arguments
+  = fun x ->
+    match (x : Versions.V4_07.Constructor_arguments.concrete) with
+    | Pcstr_tuple (x1) ->
+      let x1 = (List.map ~f:ast_to_core_type) x1 in
+      Pcstr_tuple (x1)
+    | Pcstr_record (x1) ->
+      let x1 = (List.map ~f:ast_to_label_declaration) x1 in
+      Pcstr_record (x1)
 
-and ast_of_type_extension x =
-  Versions.V4_07.Type_extension.of_concrete (concrete_of_type_extension x)
+and ast_of_type_extension
+  : Compiler_types.type_extension -> Versions.V4_07.Type_extension.t
+  = fun x ->
+    Versions.V4_07.Type_extension.of_concrete (concrete_of_type_extension x)
 
 and concrete_of_type_extension
-  ({ ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Compiler_types.type_extension)
-=
-  let ptyext_path = ast_of_longident_loc ptyext_path in
-  let ptyext_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) ptyext_params in
-  let ptyext_constructors = (List.map ~f:ast_of_extension_constructor) ptyext_constructors in
-  let ptyext_private = ast_of_private_flag ptyext_private in
-  let ptyext_attributes = ast_of_attributes ptyext_attributes in
-  ({ ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Versions.V4_07.Type_extension.concrete)
+  : Compiler_types.type_extension -> Versions.V4_07.Type_extension.concrete
+  = fun { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } ->
+      let ptyext_path = ast_of_longident_loc ptyext_path in
+      let ptyext_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) ptyext_params in
+      let ptyext_constructors = (List.map ~f:ast_of_extension_constructor) ptyext_constructors in
+      let ptyext_private = ast_of_private_flag ptyext_private in
+      let ptyext_attributes = ast_of_attributes ptyext_attributes in
+      { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes }
 
-and ast_to_type_extension x =
-  let concrete = Versions.V4_07.Type_extension.to_concrete x in
-  concrete_to_type_extension concrete
+and ast_to_type_extension
+  : Versions.V4_07.Type_extension.t -> Compiler_types.type_extension
+  = fun x ->
+    let concrete = Versions.V4_07.Type_extension.to_concrete x in
+    concrete_to_type_extension concrete
 
 and concrete_to_type_extension
-  ({ ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Versions.V4_07.Type_extension.concrete)
-=
-  let ptyext_path = ast_to_longident_loc ptyext_path in
-  let ptyext_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) ptyext_params in
-  let ptyext_constructors = (List.map ~f:ast_to_extension_constructor) ptyext_constructors in
-  let ptyext_private = ast_to_private_flag ptyext_private in
-  let ptyext_attributes = ast_to_attributes ptyext_attributes in
-  ({ ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } : Compiler_types.type_extension)
+  : Versions.V4_07.Type_extension.concrete -> Compiler_types.type_extension
+  = fun { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes } ->
+      let ptyext_path = ast_to_longident_loc ptyext_path in
+      let ptyext_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) ptyext_params in
+      let ptyext_constructors = (List.map ~f:ast_to_extension_constructor) ptyext_constructors in
+      let ptyext_private = ast_to_private_flag ptyext_private in
+      let ptyext_attributes = ast_to_attributes ptyext_attributes in
+      { ptyext_path; ptyext_params; ptyext_constructors; ptyext_private; ptyext_attributes }
 
-and ast_of_extension_constructor x =
-  Versions.V4_07.Extension_constructor.of_concrete (concrete_of_extension_constructor x)
+and ast_of_extension_constructor
+  : Compiler_types.extension_constructor -> Versions.V4_07.Extension_constructor.t
+  = fun x ->
+    Versions.V4_07.Extension_constructor.of_concrete (concrete_of_extension_constructor x)
 
 and concrete_of_extension_constructor
-  ({ pext_name; pext_kind; pext_loc; pext_attributes } : Compiler_types.extension_constructor)
-=
-  let pext_kind = ast_of_extension_constructor_kind pext_kind in
-  let pext_attributes = ast_of_attributes pext_attributes in
-  ({ pext_name; pext_kind; pext_loc; pext_attributes } : Versions.V4_07.Extension_constructor.concrete)
+  : Compiler_types.extension_constructor -> Versions.V4_07.Extension_constructor.concrete
+  = fun { pext_name; pext_kind; pext_loc; pext_attributes } ->
+      let pext_kind = ast_of_extension_constructor_kind pext_kind in
+      let pext_attributes = ast_of_attributes pext_attributes in
+      { pext_name; pext_kind; pext_loc; pext_attributes }
 
-and ast_to_extension_constructor x =
-  let concrete = Versions.V4_07.Extension_constructor.to_concrete x in
-  concrete_to_extension_constructor concrete
+and ast_to_extension_constructor
+  : Versions.V4_07.Extension_constructor.t -> Compiler_types.extension_constructor
+  = fun x ->
+    let concrete = Versions.V4_07.Extension_constructor.to_concrete x in
+    concrete_to_extension_constructor concrete
 
 and concrete_to_extension_constructor
-  ({ pext_name; pext_kind; pext_loc; pext_attributes } : Versions.V4_07.Extension_constructor.concrete)
-=
-  let pext_kind = ast_to_extension_constructor_kind pext_kind in
-  let pext_attributes = ast_to_attributes pext_attributes in
-  ({ pext_name; pext_kind; pext_loc; pext_attributes } : Compiler_types.extension_constructor)
+  : Versions.V4_07.Extension_constructor.concrete -> Compiler_types.extension_constructor
+  = fun { pext_name; pext_kind; pext_loc; pext_attributes } ->
+      let pext_kind = ast_to_extension_constructor_kind pext_kind in
+      let pext_attributes = ast_to_attributes pext_attributes in
+      { pext_name; pext_kind; pext_loc; pext_attributes }
 
-and ast_of_extension_constructor_kind x =
-  Versions.V4_07.Extension_constructor_kind.of_concrete (concrete_of_extension_constructor_kind x)
+and ast_of_extension_constructor_kind
+  : Compiler_types.extension_constructor_kind -> Versions.V4_07.Extension_constructor_kind.t
+  = fun x ->
+    Versions.V4_07.Extension_constructor_kind.of_concrete (concrete_of_extension_constructor_kind x)
 
-and concrete_of_extension_constructor_kind x : Versions.V4_07.Extension_constructor_kind.concrete =
-  match (x : Compiler_types.extension_constructor_kind) with
-  | Pext_decl (x1, x2) ->
-    let x1 = ast_of_constructor_arguments x1 in
-    let x2 = (Option.map ~f:ast_of_core_type) x2 in
-    Pext_decl (x1, x2)
-  | Pext_rebind (x1) ->
-    let x1 = ast_of_longident_loc x1 in
-    Pext_rebind (x1)
+and concrete_of_extension_constructor_kind
+  : Compiler_types.extension_constructor_kind -> Versions.V4_07.Extension_constructor_kind.concrete
+  = fun x ->
+    match (x : Compiler_types.extension_constructor_kind) with
+    | Pext_decl (x1, x2) ->
+      let x1 = ast_of_constructor_arguments x1 in
+      let x2 = (Option.map ~f:ast_of_core_type) x2 in
+      Pext_decl (x1, x2)
+    | Pext_rebind (x1) ->
+      let x1 = ast_of_longident_loc x1 in
+      Pext_rebind (x1)
 
-and ast_to_extension_constructor_kind x =
-  let concrete = Versions.V4_07.Extension_constructor_kind.to_concrete x in
-  concrete_to_extension_constructor_kind concrete
+and ast_to_extension_constructor_kind
+  : Versions.V4_07.Extension_constructor_kind.t -> Compiler_types.extension_constructor_kind
+  = fun x ->
+    let concrete = Versions.V4_07.Extension_constructor_kind.to_concrete x in
+    concrete_to_extension_constructor_kind concrete
 
-and concrete_to_extension_constructor_kind x : Compiler_types.extension_constructor_kind =
-  match (x : Versions.V4_07.Extension_constructor_kind.concrete) with
-  | Pext_decl (x1, x2) ->
-    let x1 = ast_to_constructor_arguments x1 in
-    let x2 = (Option.map ~f:ast_to_core_type) x2 in
-    Pext_decl (x1, x2)
-  | Pext_rebind (x1) ->
-    let x1 = ast_to_longident_loc x1 in
-    Pext_rebind (x1)
+and concrete_to_extension_constructor_kind
+  : Versions.V4_07.Extension_constructor_kind.concrete -> Compiler_types.extension_constructor_kind
+  = fun x ->
+    match (x : Versions.V4_07.Extension_constructor_kind.concrete) with
+    | Pext_decl (x1, x2) ->
+      let x1 = ast_to_constructor_arguments x1 in
+      let x2 = (Option.map ~f:ast_to_core_type) x2 in
+      Pext_decl (x1, x2)
+    | Pext_rebind (x1) ->
+      let x1 = ast_to_longident_loc x1 in
+      Pext_rebind (x1)
 
-and ast_of_class_type x =
-  Versions.V4_07.Class_type.of_concrete (concrete_of_class_type x)
+and ast_of_class_type
+  : Compiler_types.class_type -> Versions.V4_07.Class_type.t
+  = fun x ->
+    Versions.V4_07.Class_type.of_concrete (concrete_of_class_type x)
 
 and concrete_of_class_type
-  ({ pcty_desc; pcty_loc; pcty_attributes } : Compiler_types.class_type)
-=
-  let pcty_desc = ast_of_class_type_desc pcty_desc in
-  let pcty_attributes = ast_of_attributes pcty_attributes in
-  ({ pcty_desc; pcty_loc; pcty_attributes } : Versions.V4_07.Class_type.concrete)
+  : Compiler_types.class_type -> Versions.V4_07.Class_type.concrete
+  = fun { pcty_desc; pcty_loc; pcty_attributes } ->
+      let pcty_desc = ast_of_class_type_desc pcty_desc in
+      let pcty_attributes = ast_of_attributes pcty_attributes in
+      { pcty_desc; pcty_loc; pcty_attributes }
 
-and ast_to_class_type x =
-  let concrete = Versions.V4_07.Class_type.to_concrete x in
-  concrete_to_class_type concrete
+and ast_to_class_type
+  : Versions.V4_07.Class_type.t -> Compiler_types.class_type
+  = fun x ->
+    let concrete = Versions.V4_07.Class_type.to_concrete x in
+    concrete_to_class_type concrete
 
 and concrete_to_class_type
-  ({ pcty_desc; pcty_loc; pcty_attributes } : Versions.V4_07.Class_type.concrete)
-=
-  let pcty_desc = ast_to_class_type_desc pcty_desc in
-  let pcty_attributes = ast_to_attributes pcty_attributes in
-  ({ pcty_desc; pcty_loc; pcty_attributes } : Compiler_types.class_type)
+  : Versions.V4_07.Class_type.concrete -> Compiler_types.class_type
+  = fun { pcty_desc; pcty_loc; pcty_attributes } ->
+      let pcty_desc = ast_to_class_type_desc pcty_desc in
+      let pcty_attributes = ast_to_attributes pcty_attributes in
+      { pcty_desc; pcty_loc; pcty_attributes }
 
-and ast_of_class_type_desc x =
-  Versions.V4_07.Class_type_desc.of_concrete (concrete_of_class_type_desc x)
+and ast_of_class_type_desc
+  : Compiler_types.class_type_desc -> Versions.V4_07.Class_type_desc.t
+  = fun x ->
+    Versions.V4_07.Class_type_desc.of_concrete (concrete_of_class_type_desc x)
 
-and concrete_of_class_type_desc x : Versions.V4_07.Class_type_desc.concrete =
-  match (x : Compiler_types.class_type_desc) with
-  | Pcty_constr (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = (List.map ~f:ast_of_core_type) x2 in
-    Pcty_constr (x1, x2)
-  | Pcty_signature (x1) ->
-    let x1 = ast_of_class_signature x1 in
-    Pcty_signature (x1)
-  | Pcty_arrow (x1, x2, x3) ->
-    let x1 = ast_of_arg_label x1 in
-    let x2 = ast_of_core_type x2 in
-    let x3 = ast_of_class_type x3 in
-    Pcty_arrow (x1, x2, x3)
-  | Pcty_extension (x1) ->
-    let x1 = ast_of_extension x1 in
-    Pcty_extension (x1)
-  | Pcty_open (x1, x2, x3) ->
-    let x1 = ast_of_override_flag x1 in
-    let x2 = ast_of_longident_loc x2 in
-    let x3 = ast_of_class_type x3 in
-    Pcty_open (x1, x2, x3)
+and concrete_of_class_type_desc
+  : Compiler_types.class_type_desc -> Versions.V4_07.Class_type_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.class_type_desc) with
+    | Pcty_constr (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = (List.map ~f:ast_of_core_type) x2 in
+      Pcty_constr (x1, x2)
+    | Pcty_signature (x1) ->
+      let x1 = ast_of_class_signature x1 in
+      Pcty_signature (x1)
+    | Pcty_arrow (x1, x2, x3) ->
+      let x1 = ast_of_arg_label x1 in
+      let x2 = ast_of_core_type x2 in
+      let x3 = ast_of_class_type x3 in
+      Pcty_arrow (x1, x2, x3)
+    | Pcty_extension (x1) ->
+      let x1 = ast_of_extension x1 in
+      Pcty_extension (x1)
+    | Pcty_open (x1, x2, x3) ->
+      let x1 = ast_of_override_flag x1 in
+      let x2 = ast_of_longident_loc x2 in
+      let x3 = ast_of_class_type x3 in
+      Pcty_open (x1, x2, x3)
 
-and ast_to_class_type_desc x =
-  let concrete = Versions.V4_07.Class_type_desc.to_concrete x in
-  concrete_to_class_type_desc concrete
+and ast_to_class_type_desc
+  : Versions.V4_07.Class_type_desc.t -> Compiler_types.class_type_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Class_type_desc.to_concrete x in
+    concrete_to_class_type_desc concrete
 
-and concrete_to_class_type_desc x : Compiler_types.class_type_desc =
-  match (x : Versions.V4_07.Class_type_desc.concrete) with
-  | Pcty_constr (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = (List.map ~f:ast_to_core_type) x2 in
-    Pcty_constr (x1, x2)
-  | Pcty_signature (x1) ->
-    let x1 = ast_to_class_signature x1 in
-    Pcty_signature (x1)
-  | Pcty_arrow (x1, x2, x3) ->
-    let x1 = ast_to_arg_label x1 in
-    let x2 = ast_to_core_type x2 in
-    let x3 = ast_to_class_type x3 in
-    Pcty_arrow (x1, x2, x3)
-  | Pcty_extension (x1) ->
-    let x1 = ast_to_extension x1 in
-    Pcty_extension (x1)
-  | Pcty_open (x1, x2, x3) ->
-    let x1 = ast_to_override_flag x1 in
-    let x2 = ast_to_longident_loc x2 in
-    let x3 = ast_to_class_type x3 in
-    Pcty_open (x1, x2, x3)
+and concrete_to_class_type_desc
+  : Versions.V4_07.Class_type_desc.concrete -> Compiler_types.class_type_desc
+  = fun x ->
+    match (x : Versions.V4_07.Class_type_desc.concrete) with
+    | Pcty_constr (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = (List.map ~f:ast_to_core_type) x2 in
+      Pcty_constr (x1, x2)
+    | Pcty_signature (x1) ->
+      let x1 = ast_to_class_signature x1 in
+      Pcty_signature (x1)
+    | Pcty_arrow (x1, x2, x3) ->
+      let x1 = ast_to_arg_label x1 in
+      let x2 = ast_to_core_type x2 in
+      let x3 = ast_to_class_type x3 in
+      Pcty_arrow (x1, x2, x3)
+    | Pcty_extension (x1) ->
+      let x1 = ast_to_extension x1 in
+      Pcty_extension (x1)
+    | Pcty_open (x1, x2, x3) ->
+      let x1 = ast_to_override_flag x1 in
+      let x2 = ast_to_longident_loc x2 in
+      let x3 = ast_to_class_type x3 in
+      Pcty_open (x1, x2, x3)
 
-and ast_of_class_signature x =
-  Versions.V4_07.Class_signature.of_concrete (concrete_of_class_signature x)
+and ast_of_class_signature
+  : Compiler_types.class_signature -> Versions.V4_07.Class_signature.t
+  = fun x ->
+    Versions.V4_07.Class_signature.of_concrete (concrete_of_class_signature x)
 
 and concrete_of_class_signature
-  ({ pcsig_self; pcsig_fields } : Compiler_types.class_signature)
-=
-  let pcsig_self = ast_of_core_type pcsig_self in
-  let pcsig_fields = (List.map ~f:ast_of_class_type_field) pcsig_fields in
-  ({ pcsig_self; pcsig_fields } : Versions.V4_07.Class_signature.concrete)
+  : Compiler_types.class_signature -> Versions.V4_07.Class_signature.concrete
+  = fun { pcsig_self; pcsig_fields } ->
+      let pcsig_self = ast_of_core_type pcsig_self in
+      let pcsig_fields = (List.map ~f:ast_of_class_type_field) pcsig_fields in
+      { pcsig_self; pcsig_fields }
 
-and ast_to_class_signature x =
-  let concrete = Versions.V4_07.Class_signature.to_concrete x in
-  concrete_to_class_signature concrete
+and ast_to_class_signature
+  : Versions.V4_07.Class_signature.t -> Compiler_types.class_signature
+  = fun x ->
+    let concrete = Versions.V4_07.Class_signature.to_concrete x in
+    concrete_to_class_signature concrete
 
 and concrete_to_class_signature
-  ({ pcsig_self; pcsig_fields } : Versions.V4_07.Class_signature.concrete)
-=
-  let pcsig_self = ast_to_core_type pcsig_self in
-  let pcsig_fields = (List.map ~f:ast_to_class_type_field) pcsig_fields in
-  ({ pcsig_self; pcsig_fields } : Compiler_types.class_signature)
+  : Versions.V4_07.Class_signature.concrete -> Compiler_types.class_signature
+  = fun { pcsig_self; pcsig_fields } ->
+      let pcsig_self = ast_to_core_type pcsig_self in
+      let pcsig_fields = (List.map ~f:ast_to_class_type_field) pcsig_fields in
+      { pcsig_self; pcsig_fields }
 
-and ast_of_class_type_field x =
-  Versions.V4_07.Class_type_field.of_concrete (concrete_of_class_type_field x)
+and ast_of_class_type_field
+  : Compiler_types.class_type_field -> Versions.V4_07.Class_type_field.t
+  = fun x ->
+    Versions.V4_07.Class_type_field.of_concrete (concrete_of_class_type_field x)
 
 and concrete_of_class_type_field
-  ({ pctf_desc; pctf_loc; pctf_attributes } : Compiler_types.class_type_field)
-=
-  let pctf_desc = ast_of_class_type_field_desc pctf_desc in
-  let pctf_attributes = ast_of_attributes pctf_attributes in
-  ({ pctf_desc; pctf_loc; pctf_attributes } : Versions.V4_07.Class_type_field.concrete)
+  : Compiler_types.class_type_field -> Versions.V4_07.Class_type_field.concrete
+  = fun { pctf_desc; pctf_loc; pctf_attributes } ->
+      let pctf_desc = ast_of_class_type_field_desc pctf_desc in
+      let pctf_attributes = ast_of_attributes pctf_attributes in
+      { pctf_desc; pctf_loc; pctf_attributes }
 
-and ast_to_class_type_field x =
-  let concrete = Versions.V4_07.Class_type_field.to_concrete x in
-  concrete_to_class_type_field concrete
+and ast_to_class_type_field
+  : Versions.V4_07.Class_type_field.t -> Compiler_types.class_type_field
+  = fun x ->
+    let concrete = Versions.V4_07.Class_type_field.to_concrete x in
+    concrete_to_class_type_field concrete
 
 and concrete_to_class_type_field
-  ({ pctf_desc; pctf_loc; pctf_attributes } : Versions.V4_07.Class_type_field.concrete)
-=
-  let pctf_desc = ast_to_class_type_field_desc pctf_desc in
-  let pctf_attributes = ast_to_attributes pctf_attributes in
-  ({ pctf_desc; pctf_loc; pctf_attributes } : Compiler_types.class_type_field)
+  : Versions.V4_07.Class_type_field.concrete -> Compiler_types.class_type_field
+  = fun { pctf_desc; pctf_loc; pctf_attributes } ->
+      let pctf_desc = ast_to_class_type_field_desc pctf_desc in
+      let pctf_attributes = ast_to_attributes pctf_attributes in
+      { pctf_desc; pctf_loc; pctf_attributes }
 
-and ast_of_class_type_field_desc x =
-  Versions.V4_07.Class_type_field_desc.of_concrete (concrete_of_class_type_field_desc x)
+and ast_of_class_type_field_desc
+  : Compiler_types.class_type_field_desc -> Versions.V4_07.Class_type_field_desc.t
+  = fun x ->
+    Versions.V4_07.Class_type_field_desc.of_concrete (concrete_of_class_type_field_desc x)
 
-and concrete_of_class_type_field_desc x : Versions.V4_07.Class_type_field_desc.concrete =
-  match (x : Compiler_types.class_type_field_desc) with
-  | Pctf_inherit (x1) ->
-    let x1 = ast_of_class_type x1 in
-    Pctf_inherit (x1)
-  | Pctf_val (x1) ->
-    let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_of_mutable_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
-    Pctf_val (x1)
-  | Pctf_method (x1) ->
-    let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_of_private_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
-    Pctf_method (x1)
-  | Pctf_constraint (x1) ->
-    let x1 = (Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_core_type) x1 in
-    Pctf_constraint (x1)
-  | Pctf_attribute (x1) ->
-    let x1 = ast_of_attribute x1 in
-    Pctf_attribute (x1)
-  | Pctf_extension (x1) ->
-    let x1 = ast_of_extension x1 in
-    Pctf_extension (x1)
+and concrete_of_class_type_field_desc
+  : Compiler_types.class_type_field_desc -> Versions.V4_07.Class_type_field_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.class_type_field_desc) with
+    | Pctf_inherit (x1) ->
+      let x1 = ast_of_class_type x1 in
+      Pctf_inherit (x1)
+    | Pctf_val (x1) ->
+      let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_of_mutable_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
+      Pctf_val (x1)
+    | Pctf_method (x1) ->
+      let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_of_private_flag ~f3:ast_of_virtual_flag ~f4:ast_of_core_type) x1 in
+      Pctf_method (x1)
+    | Pctf_constraint (x1) ->
+      let x1 = (Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_core_type) x1 in
+      Pctf_constraint (x1)
+    | Pctf_attribute (x1) ->
+      let x1 = ast_of_attribute x1 in
+      Pctf_attribute (x1)
+    | Pctf_extension (x1) ->
+      let x1 = ast_of_extension x1 in
+      Pctf_extension (x1)
 
-and ast_to_class_type_field_desc x =
-  let concrete = Versions.V4_07.Class_type_field_desc.to_concrete x in
-  concrete_to_class_type_field_desc concrete
+and ast_to_class_type_field_desc
+  : Versions.V4_07.Class_type_field_desc.t -> Compiler_types.class_type_field_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Class_type_field_desc.to_concrete x in
+    concrete_to_class_type_field_desc concrete
 
-and concrete_to_class_type_field_desc x : Compiler_types.class_type_field_desc =
-  match (x : Versions.V4_07.Class_type_field_desc.concrete) with
-  | Pctf_inherit (x1) ->
-    let x1 = ast_to_class_type x1 in
-    Pctf_inherit (x1)
-  | Pctf_val (x1) ->
-    let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_to_mutable_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
-    Pctf_val (x1)
-  | Pctf_method (x1) ->
-    let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_to_private_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
-    Pctf_method (x1)
-  | Pctf_constraint (x1) ->
-    let x1 = (Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_core_type) x1 in
-    Pctf_constraint (x1)
-  | Pctf_attribute (x1) ->
-    let x1 = ast_to_attribute x1 in
-    Pctf_attribute (x1)
-  | Pctf_extension (x1) ->
-    let x1 = ast_to_extension x1 in
-    Pctf_extension (x1)
+and concrete_to_class_type_field_desc
+  : Versions.V4_07.Class_type_field_desc.concrete -> Compiler_types.class_type_field_desc
+  = fun x ->
+    match (x : Versions.V4_07.Class_type_field_desc.concrete) with
+    | Pctf_inherit (x1) ->
+      let x1 = ast_to_class_type x1 in
+      Pctf_inherit (x1)
+    | Pctf_val (x1) ->
+      let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_to_mutable_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
+      Pctf_val (x1)
+    | Pctf_method (x1) ->
+      let x1 = (Tuple.map4 ~f1:Fn.id ~f2:ast_to_private_flag ~f3:ast_to_virtual_flag ~f4:ast_to_core_type) x1 in
+      Pctf_method (x1)
+    | Pctf_constraint (x1) ->
+      let x1 = (Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_core_type) x1 in
+      Pctf_constraint (x1)
+    | Pctf_attribute (x1) ->
+      let x1 = ast_to_attribute x1 in
+      Pctf_attribute (x1)
+    | Pctf_extension (x1) ->
+      let x1 = ast_to_extension x1 in
+      Pctf_extension (x1)
 
-and ast_of_class_infos_class_expr x =
-  Versions.V4_07.Class_infos.of_concrete (concrete_of_class_infos_class_expr x)
+and ast_of_class_infos
+  : type a a_ .(a_ -> a Unversioned.Types.node) -> a_ Compiler_types.class_infos -> a Unversioned.Types.node Versions.V4_07.Class_infos.t
+  = fun ast_of_a x ->
+    Versions.V4_07.Class_infos.of_concrete (concrete_of_class_infos ast_of_a x)
 
-and concrete_of_class_infos_class_expr
-  ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Compiler_types.class_expr Compiler_types.class_infos)
-=
-  let pci_virt = ast_of_virtual_flag pci_virt in
-  let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) pci_params in
-  let pci_expr = ast_of_class_expr pci_expr in
-  let pci_attributes = ast_of_attributes pci_attributes in
-  ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Versions.V4_07.Class_expr.t Versions.V4_07.Class_infos.concrete)
+and concrete_of_class_infos
+  : type a a_ .(a_ -> a Unversioned.Types.node) -> a_ Compiler_types.class_infos -> a Unversioned.Types.node Versions.V4_07.Class_infos.concrete
+  = fun ast_of_a { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } ->
+      let pci_virt = ast_of_virtual_flag pci_virt in
+      let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) pci_params in
+      let pci_expr = ast_of_a pci_expr in
+      let pci_attributes = ast_of_attributes pci_attributes in
+      { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
 
-and ast_to_class_infos_class_expr x =
-  let concrete = Versions.V4_07.Class_infos.to_concrete x in
-  concrete_to_class_infos_class_expr concrete
+and ast_to_class_infos
+  : type a a_ .(a Unversioned.Types.node -> a_) -> a Unversioned.Types.node Versions.V4_07.Class_infos.t -> a_ Compiler_types.class_infos
+  = fun ast_to_a x ->
+    let concrete = Versions.V4_07.Class_infos.to_concrete x in
+    concrete_to_class_infos ast_to_a concrete
 
-and concrete_to_class_infos_class_expr
-  ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Versions.V4_07.Class_expr.t Versions.V4_07.Class_infos.concrete)
-=
-  let pci_virt = ast_to_virtual_flag pci_virt in
-  let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) pci_params in
-  let pci_expr = ast_to_class_expr pci_expr in
-  let pci_attributes = ast_to_attributes pci_attributes in
-  ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Compiler_types.class_expr Compiler_types.class_infos)
+and concrete_to_class_infos
+  : type a a_ .(a Unversioned.Types.node -> a_) -> a Unversioned.Types.node Versions.V4_07.Class_infos.concrete -> a_ Compiler_types.class_infos
+  = fun ast_to_a { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } ->
+      let pci_virt = ast_to_virtual_flag pci_virt in
+      let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) pci_params in
+      let pci_expr = ast_to_a pci_expr in
+      let pci_attributes = ast_to_attributes pci_attributes in
+      { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
 
-and ast_of_class_infos_class_type x =
-  Versions.V4_07.Class_infos.of_concrete (concrete_of_class_infos_class_type x)
+and ast_of_class_description
+  : Compiler_types.class_description -> Versions.V4_07.Class_description.t
+  = fun x ->
+    Versions.V4_07.Class_description.of_concrete (concrete_of_class_description x)
 
-and concrete_of_class_infos_class_type
-  ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Compiler_types.class_type Compiler_types.class_infos)
-=
-  let pci_virt = ast_of_virtual_flag pci_virt in
-  let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_variance)) pci_params in
-  let pci_expr = ast_of_class_type pci_expr in
-  let pci_attributes = ast_of_attributes pci_attributes in
-  ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Versions.V4_07.Class_type.t Versions.V4_07.Class_infos.concrete)
+and concrete_of_class_description
+  : Compiler_types.class_description -> Versions.V4_07.Class_description.concrete
+  = fun x ->
+    (ast_of_class_infos ast_of_class_type) x
 
-and ast_to_class_infos_class_type x =
-  let concrete = Versions.V4_07.Class_infos.to_concrete x in
-  concrete_to_class_infos_class_type concrete
+and ast_to_class_description
+  : Versions.V4_07.Class_description.t -> Compiler_types.class_description
+  = fun x ->
+    let concrete = Versions.V4_07.Class_description.to_concrete x in
+    concrete_to_class_description concrete
 
-and concrete_to_class_infos_class_type
-  ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Versions.V4_07.Class_type.t Versions.V4_07.Class_infos.concrete)
-=
-  let pci_virt = ast_to_virtual_flag pci_virt in
-  let pci_params = (List.map ~f:(Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_variance)) pci_params in
-  let pci_expr = ast_to_class_type pci_expr in
-  let pci_attributes = ast_to_attributes pci_attributes in
-  ({ pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Compiler_types.class_type Compiler_types.class_infos)
+and concrete_to_class_description
+  : Versions.V4_07.Class_description.concrete -> Compiler_types.class_description
+  = fun x ->
+    (ast_to_class_infos ast_to_class_type) x
 
-and ast_of_class_description x =
-  Versions.V4_07.Class_description.of_concrete (concrete_of_class_description x)
+and ast_of_class_type_declaration
+  : Compiler_types.class_type_declaration -> Versions.V4_07.Class_type_declaration.t
+  = fun x ->
+    Versions.V4_07.Class_type_declaration.of_concrete (concrete_of_class_type_declaration x)
 
-and concrete_of_class_description x =
-  ast_of_class_infos_class_type x
+and concrete_of_class_type_declaration
+  : Compiler_types.class_type_declaration -> Versions.V4_07.Class_type_declaration.concrete
+  = fun x ->
+    (ast_of_class_infos ast_of_class_type) x
 
-and ast_to_class_description x =
-  let concrete = Versions.V4_07.Class_description.to_concrete x in
-  concrete_to_class_description concrete
+and ast_to_class_type_declaration
+  : Versions.V4_07.Class_type_declaration.t -> Compiler_types.class_type_declaration
+  = fun x ->
+    let concrete = Versions.V4_07.Class_type_declaration.to_concrete x in
+    concrete_to_class_type_declaration concrete
 
-and concrete_to_class_description x =
-  ast_to_class_infos_class_type x
+and concrete_to_class_type_declaration
+  : Versions.V4_07.Class_type_declaration.concrete -> Compiler_types.class_type_declaration
+  = fun x ->
+    (ast_to_class_infos ast_to_class_type) x
 
-and ast_of_class_type_declaration x =
-  Versions.V4_07.Class_type_declaration.of_concrete (concrete_of_class_type_declaration x)
-
-and concrete_of_class_type_declaration x =
-  ast_of_class_infos_class_type x
-
-and ast_to_class_type_declaration x =
-  let concrete = Versions.V4_07.Class_type_declaration.to_concrete x in
-  concrete_to_class_type_declaration concrete
-
-and concrete_to_class_type_declaration x =
-  ast_to_class_infos_class_type x
-
-and ast_of_class_expr x =
-  Versions.V4_07.Class_expr.of_concrete (concrete_of_class_expr x)
+and ast_of_class_expr
+  : Compiler_types.class_expr -> Versions.V4_07.Class_expr.t
+  = fun x ->
+    Versions.V4_07.Class_expr.of_concrete (concrete_of_class_expr x)
 
 and concrete_of_class_expr
-  ({ pcl_desc; pcl_loc; pcl_attributes } : Compiler_types.class_expr)
-=
-  let pcl_desc = ast_of_class_expr_desc pcl_desc in
-  let pcl_attributes = ast_of_attributes pcl_attributes in
-  ({ pcl_desc; pcl_loc; pcl_attributes } : Versions.V4_07.Class_expr.concrete)
+  : Compiler_types.class_expr -> Versions.V4_07.Class_expr.concrete
+  = fun { pcl_desc; pcl_loc; pcl_attributes } ->
+      let pcl_desc = ast_of_class_expr_desc pcl_desc in
+      let pcl_attributes = ast_of_attributes pcl_attributes in
+      { pcl_desc; pcl_loc; pcl_attributes }
 
-and ast_to_class_expr x =
-  let concrete = Versions.V4_07.Class_expr.to_concrete x in
-  concrete_to_class_expr concrete
+and ast_to_class_expr
+  : Versions.V4_07.Class_expr.t -> Compiler_types.class_expr
+  = fun x ->
+    let concrete = Versions.V4_07.Class_expr.to_concrete x in
+    concrete_to_class_expr concrete
 
 and concrete_to_class_expr
-  ({ pcl_desc; pcl_loc; pcl_attributes } : Versions.V4_07.Class_expr.concrete)
-=
-  let pcl_desc = ast_to_class_expr_desc pcl_desc in
-  let pcl_attributes = ast_to_attributes pcl_attributes in
-  ({ pcl_desc; pcl_loc; pcl_attributes } : Compiler_types.class_expr)
+  : Versions.V4_07.Class_expr.concrete -> Compiler_types.class_expr
+  = fun { pcl_desc; pcl_loc; pcl_attributes } ->
+      let pcl_desc = ast_to_class_expr_desc pcl_desc in
+      let pcl_attributes = ast_to_attributes pcl_attributes in
+      { pcl_desc; pcl_loc; pcl_attributes }
 
-and ast_of_class_expr_desc x =
-  Versions.V4_07.Class_expr_desc.of_concrete (concrete_of_class_expr_desc x)
+and ast_of_class_expr_desc
+  : Compiler_types.class_expr_desc -> Versions.V4_07.Class_expr_desc.t
+  = fun x ->
+    Versions.V4_07.Class_expr_desc.of_concrete (concrete_of_class_expr_desc x)
 
-and concrete_of_class_expr_desc x : Versions.V4_07.Class_expr_desc.concrete =
-  match (x : Compiler_types.class_expr_desc) with
-  | Pcl_constr (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = (List.map ~f:ast_of_core_type) x2 in
-    Pcl_constr (x1, x2)
-  | Pcl_structure (x1) ->
-    let x1 = ast_of_class_structure x1 in
-    Pcl_structure (x1)
-  | Pcl_fun (x1, x2, x3, x4) ->
-    let x1 = ast_of_arg_label x1 in
-    let x2 = (Option.map ~f:ast_of_expression) x2 in
-    let x3 = ast_of_pattern x3 in
-    let x4 = ast_of_class_expr x4 in
-    Pcl_fun (x1, x2, x3, x4)
-  | Pcl_apply (x1, x2) ->
-    let x1 = ast_of_class_expr x1 in
-    let x2 = (List.map ~f:(Tuple.map2 ~f1:ast_of_arg_label ~f2:ast_of_expression)) x2 in
-    Pcl_apply (x1, x2)
-  | Pcl_let (x1, x2, x3) ->
-    let x1 = ast_of_rec_flag x1 in
-    let x2 = (List.map ~f:ast_of_value_binding) x2 in
-    let x3 = ast_of_class_expr x3 in
-    Pcl_let (x1, x2, x3)
-  | Pcl_constraint (x1, x2) ->
-    let x1 = ast_of_class_expr x1 in
-    let x2 = ast_of_class_type x2 in
-    Pcl_constraint (x1, x2)
-  | Pcl_extension (x1) ->
-    let x1 = ast_of_extension x1 in
-    Pcl_extension (x1)
-  | Pcl_open (x1, x2, x3) ->
-    let x1 = ast_of_override_flag x1 in
-    let x2 = ast_of_longident_loc x2 in
-    let x3 = ast_of_class_expr x3 in
-    Pcl_open (x1, x2, x3)
+and concrete_of_class_expr_desc
+  : Compiler_types.class_expr_desc -> Versions.V4_07.Class_expr_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.class_expr_desc) with
+    | Pcl_constr (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = (List.map ~f:ast_of_core_type) x2 in
+      Pcl_constr (x1, x2)
+    | Pcl_structure (x1) ->
+      let x1 = ast_of_class_structure x1 in
+      Pcl_structure (x1)
+    | Pcl_fun (x1, x2, x3, x4) ->
+      let x1 = ast_of_arg_label x1 in
+      let x2 = (Option.map ~f:ast_of_expression) x2 in
+      let x3 = ast_of_pattern x3 in
+      let x4 = ast_of_class_expr x4 in
+      Pcl_fun (x1, x2, x3, x4)
+    | Pcl_apply (x1, x2) ->
+      let x1 = ast_of_class_expr x1 in
+      let x2 = (List.map ~f:(Tuple.map2 ~f1:ast_of_arg_label ~f2:ast_of_expression)) x2 in
+      Pcl_apply (x1, x2)
+    | Pcl_let (x1, x2, x3) ->
+      let x1 = ast_of_rec_flag x1 in
+      let x2 = (List.map ~f:ast_of_value_binding) x2 in
+      let x3 = ast_of_class_expr x3 in
+      Pcl_let (x1, x2, x3)
+    | Pcl_constraint (x1, x2) ->
+      let x1 = ast_of_class_expr x1 in
+      let x2 = ast_of_class_type x2 in
+      Pcl_constraint (x1, x2)
+    | Pcl_extension (x1) ->
+      let x1 = ast_of_extension x1 in
+      Pcl_extension (x1)
+    | Pcl_open (x1, x2, x3) ->
+      let x1 = ast_of_override_flag x1 in
+      let x2 = ast_of_longident_loc x2 in
+      let x3 = ast_of_class_expr x3 in
+      Pcl_open (x1, x2, x3)
 
-and ast_to_class_expr_desc x =
-  let concrete = Versions.V4_07.Class_expr_desc.to_concrete x in
-  concrete_to_class_expr_desc concrete
+and ast_to_class_expr_desc
+  : Versions.V4_07.Class_expr_desc.t -> Compiler_types.class_expr_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Class_expr_desc.to_concrete x in
+    concrete_to_class_expr_desc concrete
 
-and concrete_to_class_expr_desc x : Compiler_types.class_expr_desc =
-  match (x : Versions.V4_07.Class_expr_desc.concrete) with
-  | Pcl_constr (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = (List.map ~f:ast_to_core_type) x2 in
-    Pcl_constr (x1, x2)
-  | Pcl_structure (x1) ->
-    let x1 = ast_to_class_structure x1 in
-    Pcl_structure (x1)
-  | Pcl_fun (x1, x2, x3, x4) ->
-    let x1 = ast_to_arg_label x1 in
-    let x2 = (Option.map ~f:ast_to_expression) x2 in
-    let x3 = ast_to_pattern x3 in
-    let x4 = ast_to_class_expr x4 in
-    Pcl_fun (x1, x2, x3, x4)
-  | Pcl_apply (x1, x2) ->
-    let x1 = ast_to_class_expr x1 in
-    let x2 = (List.map ~f:(Tuple.map2 ~f1:ast_to_arg_label ~f2:ast_to_expression)) x2 in
-    Pcl_apply (x1, x2)
-  | Pcl_let (x1, x2, x3) ->
-    let x1 = ast_to_rec_flag x1 in
-    let x2 = (List.map ~f:ast_to_value_binding) x2 in
-    let x3 = ast_to_class_expr x3 in
-    Pcl_let (x1, x2, x3)
-  | Pcl_constraint (x1, x2) ->
-    let x1 = ast_to_class_expr x1 in
-    let x2 = ast_to_class_type x2 in
-    Pcl_constraint (x1, x2)
-  | Pcl_extension (x1) ->
-    let x1 = ast_to_extension x1 in
-    Pcl_extension (x1)
-  | Pcl_open (x1, x2, x3) ->
-    let x1 = ast_to_override_flag x1 in
-    let x2 = ast_to_longident_loc x2 in
-    let x3 = ast_to_class_expr x3 in
-    Pcl_open (x1, x2, x3)
+and concrete_to_class_expr_desc
+  : Versions.V4_07.Class_expr_desc.concrete -> Compiler_types.class_expr_desc
+  = fun x ->
+    match (x : Versions.V4_07.Class_expr_desc.concrete) with
+    | Pcl_constr (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = (List.map ~f:ast_to_core_type) x2 in
+      Pcl_constr (x1, x2)
+    | Pcl_structure (x1) ->
+      let x1 = ast_to_class_structure x1 in
+      Pcl_structure (x1)
+    | Pcl_fun (x1, x2, x3, x4) ->
+      let x1 = ast_to_arg_label x1 in
+      let x2 = (Option.map ~f:ast_to_expression) x2 in
+      let x3 = ast_to_pattern x3 in
+      let x4 = ast_to_class_expr x4 in
+      Pcl_fun (x1, x2, x3, x4)
+    | Pcl_apply (x1, x2) ->
+      let x1 = ast_to_class_expr x1 in
+      let x2 = (List.map ~f:(Tuple.map2 ~f1:ast_to_arg_label ~f2:ast_to_expression)) x2 in
+      Pcl_apply (x1, x2)
+    | Pcl_let (x1, x2, x3) ->
+      let x1 = ast_to_rec_flag x1 in
+      let x2 = (List.map ~f:ast_to_value_binding) x2 in
+      let x3 = ast_to_class_expr x3 in
+      Pcl_let (x1, x2, x3)
+    | Pcl_constraint (x1, x2) ->
+      let x1 = ast_to_class_expr x1 in
+      let x2 = ast_to_class_type x2 in
+      Pcl_constraint (x1, x2)
+    | Pcl_extension (x1) ->
+      let x1 = ast_to_extension x1 in
+      Pcl_extension (x1)
+    | Pcl_open (x1, x2, x3) ->
+      let x1 = ast_to_override_flag x1 in
+      let x2 = ast_to_longident_loc x2 in
+      let x3 = ast_to_class_expr x3 in
+      Pcl_open (x1, x2, x3)
 
-and ast_of_class_structure x =
-  Versions.V4_07.Class_structure.of_concrete (concrete_of_class_structure x)
+and ast_of_class_structure
+  : Compiler_types.class_structure -> Versions.V4_07.Class_structure.t
+  = fun x ->
+    Versions.V4_07.Class_structure.of_concrete (concrete_of_class_structure x)
 
 and concrete_of_class_structure
-  ({ pcstr_self; pcstr_fields } : Compiler_types.class_structure)
-=
-  let pcstr_self = ast_of_pattern pcstr_self in
-  let pcstr_fields = (List.map ~f:ast_of_class_field) pcstr_fields in
-  ({ pcstr_self; pcstr_fields } : Versions.V4_07.Class_structure.concrete)
+  : Compiler_types.class_structure -> Versions.V4_07.Class_structure.concrete
+  = fun { pcstr_self; pcstr_fields } ->
+      let pcstr_self = ast_of_pattern pcstr_self in
+      let pcstr_fields = (List.map ~f:ast_of_class_field) pcstr_fields in
+      { pcstr_self; pcstr_fields }
 
-and ast_to_class_structure x =
-  let concrete = Versions.V4_07.Class_structure.to_concrete x in
-  concrete_to_class_structure concrete
+and ast_to_class_structure
+  : Versions.V4_07.Class_structure.t -> Compiler_types.class_structure
+  = fun x ->
+    let concrete = Versions.V4_07.Class_structure.to_concrete x in
+    concrete_to_class_structure concrete
 
 and concrete_to_class_structure
-  ({ pcstr_self; pcstr_fields } : Versions.V4_07.Class_structure.concrete)
-=
-  let pcstr_self = ast_to_pattern pcstr_self in
-  let pcstr_fields = (List.map ~f:ast_to_class_field) pcstr_fields in
-  ({ pcstr_self; pcstr_fields } : Compiler_types.class_structure)
+  : Versions.V4_07.Class_structure.concrete -> Compiler_types.class_structure
+  = fun { pcstr_self; pcstr_fields } ->
+      let pcstr_self = ast_to_pattern pcstr_self in
+      let pcstr_fields = (List.map ~f:ast_to_class_field) pcstr_fields in
+      { pcstr_self; pcstr_fields }
 
-and ast_of_class_field x =
-  Versions.V4_07.Class_field.of_concrete (concrete_of_class_field x)
+and ast_of_class_field
+  : Compiler_types.class_field -> Versions.V4_07.Class_field.t
+  = fun x ->
+    Versions.V4_07.Class_field.of_concrete (concrete_of_class_field x)
 
 and concrete_of_class_field
-  ({ pcf_desc; pcf_loc; pcf_attributes } : Compiler_types.class_field)
-=
-  let pcf_desc = ast_of_class_field_desc pcf_desc in
-  let pcf_attributes = ast_of_attributes pcf_attributes in
-  ({ pcf_desc; pcf_loc; pcf_attributes } : Versions.V4_07.Class_field.concrete)
+  : Compiler_types.class_field -> Versions.V4_07.Class_field.concrete
+  = fun { pcf_desc; pcf_loc; pcf_attributes } ->
+      let pcf_desc = ast_of_class_field_desc pcf_desc in
+      let pcf_attributes = ast_of_attributes pcf_attributes in
+      { pcf_desc; pcf_loc; pcf_attributes }
 
-and ast_to_class_field x =
-  let concrete = Versions.V4_07.Class_field.to_concrete x in
-  concrete_to_class_field concrete
+and ast_to_class_field
+  : Versions.V4_07.Class_field.t -> Compiler_types.class_field
+  = fun x ->
+    let concrete = Versions.V4_07.Class_field.to_concrete x in
+    concrete_to_class_field concrete
 
 and concrete_to_class_field
-  ({ pcf_desc; pcf_loc; pcf_attributes } : Versions.V4_07.Class_field.concrete)
-=
-  let pcf_desc = ast_to_class_field_desc pcf_desc in
-  let pcf_attributes = ast_to_attributes pcf_attributes in
-  ({ pcf_desc; pcf_loc; pcf_attributes } : Compiler_types.class_field)
+  : Versions.V4_07.Class_field.concrete -> Compiler_types.class_field
+  = fun { pcf_desc; pcf_loc; pcf_attributes } ->
+      let pcf_desc = ast_to_class_field_desc pcf_desc in
+      let pcf_attributes = ast_to_attributes pcf_attributes in
+      { pcf_desc; pcf_loc; pcf_attributes }
 
-and ast_of_class_field_desc x =
-  Versions.V4_07.Class_field_desc.of_concrete (concrete_of_class_field_desc x)
+and ast_of_class_field_desc
+  : Compiler_types.class_field_desc -> Versions.V4_07.Class_field_desc.t
+  = fun x ->
+    Versions.V4_07.Class_field_desc.of_concrete (concrete_of_class_field_desc x)
 
-and concrete_of_class_field_desc x : Versions.V4_07.Class_field_desc.concrete =
-  match (x : Compiler_types.class_field_desc) with
-  | Pcf_inherit (x1, x2, x3) ->
-    let x1 = ast_of_override_flag x1 in
-    let x2 = ast_of_class_expr x2 in
-    Pcf_inherit (x1, x2, x3)
-  | Pcf_val (x1) ->
-    let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_of_mutable_flag ~f3:ast_of_class_field_kind) x1 in
-    Pcf_val (x1)
-  | Pcf_method (x1) ->
-    let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_of_private_flag ~f3:ast_of_class_field_kind) x1 in
-    Pcf_method (x1)
-  | Pcf_constraint (x1) ->
-    let x1 = (Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_core_type) x1 in
-    Pcf_constraint (x1)
-  | Pcf_initializer (x1) ->
-    let x1 = ast_of_expression x1 in
-    Pcf_initializer (x1)
-  | Pcf_attribute (x1) ->
-    let x1 = ast_of_attribute x1 in
-    Pcf_attribute (x1)
-  | Pcf_extension (x1) ->
-    let x1 = ast_of_extension x1 in
-    Pcf_extension (x1)
+and concrete_of_class_field_desc
+  : Compiler_types.class_field_desc -> Versions.V4_07.Class_field_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.class_field_desc) with
+    | Pcf_inherit (x1, x2, x3) ->
+      let x1 = ast_of_override_flag x1 in
+      let x2 = ast_of_class_expr x2 in
+      Pcf_inherit (x1, x2, x3)
+    | Pcf_val (x1) ->
+      let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_of_mutable_flag ~f3:ast_of_class_field_kind) x1 in
+      Pcf_val (x1)
+    | Pcf_method (x1) ->
+      let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_of_private_flag ~f3:ast_of_class_field_kind) x1 in
+      Pcf_method (x1)
+    | Pcf_constraint (x1) ->
+      let x1 = (Tuple.map2 ~f1:ast_of_core_type ~f2:ast_of_core_type) x1 in
+      Pcf_constraint (x1)
+    | Pcf_initializer (x1) ->
+      let x1 = ast_of_expression x1 in
+      Pcf_initializer (x1)
+    | Pcf_attribute (x1) ->
+      let x1 = ast_of_attribute x1 in
+      Pcf_attribute (x1)
+    | Pcf_extension (x1) ->
+      let x1 = ast_of_extension x1 in
+      Pcf_extension (x1)
 
-and ast_to_class_field_desc x =
-  let concrete = Versions.V4_07.Class_field_desc.to_concrete x in
-  concrete_to_class_field_desc concrete
+and ast_to_class_field_desc
+  : Versions.V4_07.Class_field_desc.t -> Compiler_types.class_field_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Class_field_desc.to_concrete x in
+    concrete_to_class_field_desc concrete
 
-and concrete_to_class_field_desc x : Compiler_types.class_field_desc =
-  match (x : Versions.V4_07.Class_field_desc.concrete) with
-  | Pcf_inherit (x1, x2, x3) ->
-    let x1 = ast_to_override_flag x1 in
-    let x2 = ast_to_class_expr x2 in
-    Pcf_inherit (x1, x2, x3)
-  | Pcf_val (x1) ->
-    let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_to_mutable_flag ~f3:ast_to_class_field_kind) x1 in
-    Pcf_val (x1)
-  | Pcf_method (x1) ->
-    let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_to_private_flag ~f3:ast_to_class_field_kind) x1 in
-    Pcf_method (x1)
-  | Pcf_constraint (x1) ->
-    let x1 = (Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_core_type) x1 in
-    Pcf_constraint (x1)
-  | Pcf_initializer (x1) ->
-    let x1 = ast_to_expression x1 in
-    Pcf_initializer (x1)
-  | Pcf_attribute (x1) ->
-    let x1 = ast_to_attribute x1 in
-    Pcf_attribute (x1)
-  | Pcf_extension (x1) ->
-    let x1 = ast_to_extension x1 in
-    Pcf_extension (x1)
+and concrete_to_class_field_desc
+  : Versions.V4_07.Class_field_desc.concrete -> Compiler_types.class_field_desc
+  = fun x ->
+    match (x : Versions.V4_07.Class_field_desc.concrete) with
+    | Pcf_inherit (x1, x2, x3) ->
+      let x1 = ast_to_override_flag x1 in
+      let x2 = ast_to_class_expr x2 in
+      Pcf_inherit (x1, x2, x3)
+    | Pcf_val (x1) ->
+      let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_to_mutable_flag ~f3:ast_to_class_field_kind) x1 in
+      Pcf_val (x1)
+    | Pcf_method (x1) ->
+      let x1 = (Tuple.map3 ~f1:Fn.id ~f2:ast_to_private_flag ~f3:ast_to_class_field_kind) x1 in
+      Pcf_method (x1)
+    | Pcf_constraint (x1) ->
+      let x1 = (Tuple.map2 ~f1:ast_to_core_type ~f2:ast_to_core_type) x1 in
+      Pcf_constraint (x1)
+    | Pcf_initializer (x1) ->
+      let x1 = ast_to_expression x1 in
+      Pcf_initializer (x1)
+    | Pcf_attribute (x1) ->
+      let x1 = ast_to_attribute x1 in
+      Pcf_attribute (x1)
+    | Pcf_extension (x1) ->
+      let x1 = ast_to_extension x1 in
+      Pcf_extension (x1)
 
-and ast_of_class_field_kind x =
-  Versions.V4_07.Class_field_kind.of_concrete (concrete_of_class_field_kind x)
+and ast_of_class_field_kind
+  : Compiler_types.class_field_kind -> Versions.V4_07.Class_field_kind.t
+  = fun x ->
+    Versions.V4_07.Class_field_kind.of_concrete (concrete_of_class_field_kind x)
 
-and concrete_of_class_field_kind x : Versions.V4_07.Class_field_kind.concrete =
-  match (x : Compiler_types.class_field_kind) with
-  | Cfk_virtual (x1) ->
-    let x1 = ast_of_core_type x1 in
-    Cfk_virtual (x1)
-  | Cfk_concrete (x1, x2) ->
-    let x1 = ast_of_override_flag x1 in
-    let x2 = ast_of_expression x2 in
-    Cfk_concrete (x1, x2)
+and concrete_of_class_field_kind
+  : Compiler_types.class_field_kind -> Versions.V4_07.Class_field_kind.concrete
+  = fun x ->
+    match (x : Compiler_types.class_field_kind) with
+    | Cfk_virtual (x1) ->
+      let x1 = ast_of_core_type x1 in
+      Cfk_virtual (x1)
+    | Cfk_concrete (x1, x2) ->
+      let x1 = ast_of_override_flag x1 in
+      let x2 = ast_of_expression x2 in
+      Cfk_concrete (x1, x2)
 
-and ast_to_class_field_kind x =
-  let concrete = Versions.V4_07.Class_field_kind.to_concrete x in
-  concrete_to_class_field_kind concrete
+and ast_to_class_field_kind
+  : Versions.V4_07.Class_field_kind.t -> Compiler_types.class_field_kind
+  = fun x ->
+    let concrete = Versions.V4_07.Class_field_kind.to_concrete x in
+    concrete_to_class_field_kind concrete
 
-and concrete_to_class_field_kind x : Compiler_types.class_field_kind =
-  match (x : Versions.V4_07.Class_field_kind.concrete) with
-  | Cfk_virtual (x1) ->
-    let x1 = ast_to_core_type x1 in
-    Cfk_virtual (x1)
-  | Cfk_concrete (x1, x2) ->
-    let x1 = ast_to_override_flag x1 in
-    let x2 = ast_to_expression x2 in
-    Cfk_concrete (x1, x2)
+and concrete_to_class_field_kind
+  : Versions.V4_07.Class_field_kind.concrete -> Compiler_types.class_field_kind
+  = fun x ->
+    match (x : Versions.V4_07.Class_field_kind.concrete) with
+    | Cfk_virtual (x1) ->
+      let x1 = ast_to_core_type x1 in
+      Cfk_virtual (x1)
+    | Cfk_concrete (x1, x2) ->
+      let x1 = ast_to_override_flag x1 in
+      let x2 = ast_to_expression x2 in
+      Cfk_concrete (x1, x2)
 
-and ast_of_class_declaration x =
-  Versions.V4_07.Class_declaration.of_concrete (concrete_of_class_declaration x)
+and ast_of_class_declaration
+  : Compiler_types.class_declaration -> Versions.V4_07.Class_declaration.t
+  = fun x ->
+    Versions.V4_07.Class_declaration.of_concrete (concrete_of_class_declaration x)
 
-and concrete_of_class_declaration x =
-  ast_of_class_infos_class_expr x
+and concrete_of_class_declaration
+  : Compiler_types.class_declaration -> Versions.V4_07.Class_declaration.concrete
+  = fun x ->
+    (ast_of_class_infos ast_of_class_expr) x
 
-and ast_to_class_declaration x =
-  let concrete = Versions.V4_07.Class_declaration.to_concrete x in
-  concrete_to_class_declaration concrete
+and ast_to_class_declaration
+  : Versions.V4_07.Class_declaration.t -> Compiler_types.class_declaration
+  = fun x ->
+    let concrete = Versions.V4_07.Class_declaration.to_concrete x in
+    concrete_to_class_declaration concrete
 
-and concrete_to_class_declaration x =
-  ast_to_class_infos_class_expr x
+and concrete_to_class_declaration
+  : Versions.V4_07.Class_declaration.concrete -> Compiler_types.class_declaration
+  = fun x ->
+    (ast_to_class_infos ast_to_class_expr) x
 
-and ast_of_module_type x =
-  Versions.V4_07.Module_type.of_concrete (concrete_of_module_type x)
+and ast_of_module_type
+  : Compiler_types.module_type -> Versions.V4_07.Module_type.t
+  = fun x ->
+    Versions.V4_07.Module_type.of_concrete (concrete_of_module_type x)
 
 and concrete_of_module_type
-  ({ pmty_desc; pmty_loc; pmty_attributes } : Compiler_types.module_type)
-=
-  let pmty_desc = ast_of_module_type_desc pmty_desc in
-  let pmty_attributes = ast_of_attributes pmty_attributes in
-  ({ pmty_desc; pmty_loc; pmty_attributes } : Versions.V4_07.Module_type.concrete)
+  : Compiler_types.module_type -> Versions.V4_07.Module_type.concrete
+  = fun { pmty_desc; pmty_loc; pmty_attributes } ->
+      let pmty_desc = ast_of_module_type_desc pmty_desc in
+      let pmty_attributes = ast_of_attributes pmty_attributes in
+      { pmty_desc; pmty_loc; pmty_attributes }
 
-and ast_to_module_type x =
-  let concrete = Versions.V4_07.Module_type.to_concrete x in
-  concrete_to_module_type concrete
+and ast_to_module_type
+  : Versions.V4_07.Module_type.t -> Compiler_types.module_type
+  = fun x ->
+    let concrete = Versions.V4_07.Module_type.to_concrete x in
+    concrete_to_module_type concrete
 
 and concrete_to_module_type
-  ({ pmty_desc; pmty_loc; pmty_attributes } : Versions.V4_07.Module_type.concrete)
-=
-  let pmty_desc = ast_to_module_type_desc pmty_desc in
-  let pmty_attributes = ast_to_attributes pmty_attributes in
-  ({ pmty_desc; pmty_loc; pmty_attributes } : Compiler_types.module_type)
+  : Versions.V4_07.Module_type.concrete -> Compiler_types.module_type
+  = fun { pmty_desc; pmty_loc; pmty_attributes } ->
+      let pmty_desc = ast_to_module_type_desc pmty_desc in
+      let pmty_attributes = ast_to_attributes pmty_attributes in
+      { pmty_desc; pmty_loc; pmty_attributes }
 
-and ast_of_module_type_desc x =
-  Versions.V4_07.Module_type_desc.of_concrete (concrete_of_module_type_desc x)
+and ast_of_module_type_desc
+  : Compiler_types.module_type_desc -> Versions.V4_07.Module_type_desc.t
+  = fun x ->
+    Versions.V4_07.Module_type_desc.of_concrete (concrete_of_module_type_desc x)
 
-and concrete_of_module_type_desc x : Versions.V4_07.Module_type_desc.concrete =
-  match (x : Compiler_types.module_type_desc) with
-  | Pmty_ident (x1) ->
-    let x1 = ast_of_longident_loc x1 in
-    Pmty_ident (x1)
-  | Pmty_signature (x1) ->
-    let x1 = ast_of_signature x1 in
-    Pmty_signature (x1)
-  | Pmty_functor (x1, x2, x3) ->
-    let x2 = (Option.map ~f:ast_of_module_type) x2 in
-    let x3 = ast_of_module_type x3 in
-    Pmty_functor (x1, x2, x3)
-  | Pmty_with (x1, x2) ->
-    let x1 = ast_of_module_type x1 in
-    let x2 = (List.map ~f:ast_of_with_constraint) x2 in
-    Pmty_with (x1, x2)
-  | Pmty_typeof (x1) ->
-    let x1 = ast_of_module_expr x1 in
-    Pmty_typeof (x1)
-  | Pmty_extension (x1) ->
-    let x1 = ast_of_extension x1 in
-    Pmty_extension (x1)
-  | Pmty_alias (x1) ->
-    let x1 = ast_of_longident_loc x1 in
-    Pmty_alias (x1)
+and concrete_of_module_type_desc
+  : Compiler_types.module_type_desc -> Versions.V4_07.Module_type_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.module_type_desc) with
+    | Pmty_ident (x1) ->
+      let x1 = ast_of_longident_loc x1 in
+      Pmty_ident (x1)
+    | Pmty_signature (x1) ->
+      let x1 = ast_of_signature x1 in
+      Pmty_signature (x1)
+    | Pmty_functor (x1, x2, x3) ->
+      let x2 = (Option.map ~f:ast_of_module_type) x2 in
+      let x3 = ast_of_module_type x3 in
+      Pmty_functor (x1, x2, x3)
+    | Pmty_with (x1, x2) ->
+      let x1 = ast_of_module_type x1 in
+      let x2 = (List.map ~f:ast_of_with_constraint) x2 in
+      Pmty_with (x1, x2)
+    | Pmty_typeof (x1) ->
+      let x1 = ast_of_module_expr x1 in
+      Pmty_typeof (x1)
+    | Pmty_extension (x1) ->
+      let x1 = ast_of_extension x1 in
+      Pmty_extension (x1)
+    | Pmty_alias (x1) ->
+      let x1 = ast_of_longident_loc x1 in
+      Pmty_alias (x1)
 
-and ast_to_module_type_desc x =
-  let concrete = Versions.V4_07.Module_type_desc.to_concrete x in
-  concrete_to_module_type_desc concrete
+and ast_to_module_type_desc
+  : Versions.V4_07.Module_type_desc.t -> Compiler_types.module_type_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Module_type_desc.to_concrete x in
+    concrete_to_module_type_desc concrete
 
-and concrete_to_module_type_desc x : Compiler_types.module_type_desc =
-  match (x : Versions.V4_07.Module_type_desc.concrete) with
-  | Pmty_ident (x1) ->
-    let x1 = ast_to_longident_loc x1 in
-    Pmty_ident (x1)
-  | Pmty_signature (x1) ->
-    let x1 = ast_to_signature x1 in
-    Pmty_signature (x1)
-  | Pmty_functor (x1, x2, x3) ->
-    let x2 = (Option.map ~f:ast_to_module_type) x2 in
-    let x3 = ast_to_module_type x3 in
-    Pmty_functor (x1, x2, x3)
-  | Pmty_with (x1, x2) ->
-    let x1 = ast_to_module_type x1 in
-    let x2 = (List.map ~f:ast_to_with_constraint) x2 in
-    Pmty_with (x1, x2)
-  | Pmty_typeof (x1) ->
-    let x1 = ast_to_module_expr x1 in
-    Pmty_typeof (x1)
-  | Pmty_extension (x1) ->
-    let x1 = ast_to_extension x1 in
-    Pmty_extension (x1)
-  | Pmty_alias (x1) ->
-    let x1 = ast_to_longident_loc x1 in
-    Pmty_alias (x1)
+and concrete_to_module_type_desc
+  : Versions.V4_07.Module_type_desc.concrete -> Compiler_types.module_type_desc
+  = fun x ->
+    match (x : Versions.V4_07.Module_type_desc.concrete) with
+    | Pmty_ident (x1) ->
+      let x1 = ast_to_longident_loc x1 in
+      Pmty_ident (x1)
+    | Pmty_signature (x1) ->
+      let x1 = ast_to_signature x1 in
+      Pmty_signature (x1)
+    | Pmty_functor (x1, x2, x3) ->
+      let x2 = (Option.map ~f:ast_to_module_type) x2 in
+      let x3 = ast_to_module_type x3 in
+      Pmty_functor (x1, x2, x3)
+    | Pmty_with (x1, x2) ->
+      let x1 = ast_to_module_type x1 in
+      let x2 = (List.map ~f:ast_to_with_constraint) x2 in
+      Pmty_with (x1, x2)
+    | Pmty_typeof (x1) ->
+      let x1 = ast_to_module_expr x1 in
+      Pmty_typeof (x1)
+    | Pmty_extension (x1) ->
+      let x1 = ast_to_extension x1 in
+      Pmty_extension (x1)
+    | Pmty_alias (x1) ->
+      let x1 = ast_to_longident_loc x1 in
+      Pmty_alias (x1)
 
-and ast_of_signature x =
-  Versions.V4_07.Signature.of_concrete (concrete_of_signature x)
+and ast_of_signature
+  : Compiler_types.signature -> Versions.V4_07.Signature.t
+  = fun x ->
+    Versions.V4_07.Signature.of_concrete (concrete_of_signature x)
 
-and concrete_of_signature x =
-  (List.map ~f:ast_of_signature_item) x
+and concrete_of_signature
+  : Compiler_types.signature -> Versions.V4_07.Signature.concrete
+  = fun x ->
+    (List.map ~f:ast_of_signature_item) x
 
-and ast_to_signature x =
-  let concrete = Versions.V4_07.Signature.to_concrete x in
-  concrete_to_signature concrete
+and ast_to_signature
+  : Versions.V4_07.Signature.t -> Compiler_types.signature
+  = fun x ->
+    let concrete = Versions.V4_07.Signature.to_concrete x in
+    concrete_to_signature concrete
 
-and concrete_to_signature x =
-  (List.map ~f:ast_to_signature_item) x
+and concrete_to_signature
+  : Versions.V4_07.Signature.concrete -> Compiler_types.signature
+  = fun x ->
+    (List.map ~f:ast_to_signature_item) x
 
-and ast_of_signature_item x =
-  Versions.V4_07.Signature_item.of_concrete (concrete_of_signature_item x)
+and ast_of_signature_item
+  : Compiler_types.signature_item -> Versions.V4_07.Signature_item.t
+  = fun x ->
+    Versions.V4_07.Signature_item.of_concrete (concrete_of_signature_item x)
 
 and concrete_of_signature_item
-  ({ psig_desc; psig_loc } : Compiler_types.signature_item)
-=
-  let psig_desc = ast_of_signature_item_desc psig_desc in
-  ({ psig_desc; psig_loc } : Versions.V4_07.Signature_item.concrete)
+  : Compiler_types.signature_item -> Versions.V4_07.Signature_item.concrete
+  = fun { psig_desc; psig_loc } ->
+      let psig_desc = ast_of_signature_item_desc psig_desc in
+      { psig_desc; psig_loc }
 
-and ast_to_signature_item x =
-  let concrete = Versions.V4_07.Signature_item.to_concrete x in
-  concrete_to_signature_item concrete
+and ast_to_signature_item
+  : Versions.V4_07.Signature_item.t -> Compiler_types.signature_item
+  = fun x ->
+    let concrete = Versions.V4_07.Signature_item.to_concrete x in
+    concrete_to_signature_item concrete
 
 and concrete_to_signature_item
-  ({ psig_desc; psig_loc } : Versions.V4_07.Signature_item.concrete)
-=
-  let psig_desc = ast_to_signature_item_desc psig_desc in
-  ({ psig_desc; psig_loc } : Compiler_types.signature_item)
+  : Versions.V4_07.Signature_item.concrete -> Compiler_types.signature_item
+  = fun { psig_desc; psig_loc } ->
+      let psig_desc = ast_to_signature_item_desc psig_desc in
+      { psig_desc; psig_loc }
 
-and ast_of_signature_item_desc x =
-  Versions.V4_07.Signature_item_desc.of_concrete (concrete_of_signature_item_desc x)
+and ast_of_signature_item_desc
+  : Compiler_types.signature_item_desc -> Versions.V4_07.Signature_item_desc.t
+  = fun x ->
+    Versions.V4_07.Signature_item_desc.of_concrete (concrete_of_signature_item_desc x)
 
-and concrete_of_signature_item_desc x : Versions.V4_07.Signature_item_desc.concrete =
-  match (x : Compiler_types.signature_item_desc) with
-  | Psig_value (x1) ->
-    let x1 = ast_of_value_description x1 in
-    Psig_value (x1)
-  | Psig_type (x1, x2) ->
-    let x1 = ast_of_rec_flag x1 in
-    let x2 = (List.map ~f:ast_of_type_declaration) x2 in
-    Psig_type (x1, x2)
-  | Psig_typext (x1) ->
-    let x1 = ast_of_type_extension x1 in
-    Psig_typext (x1)
-  | Psig_exception (x1) ->
-    let x1 = ast_of_extension_constructor x1 in
-    Psig_exception (x1)
-  | Psig_module (x1) ->
-    let x1 = ast_of_module_declaration x1 in
-    Psig_module (x1)
-  | Psig_recmodule (x1) ->
-    let x1 = (List.map ~f:ast_of_module_declaration) x1 in
-    Psig_recmodule (x1)
-  | Psig_modtype (x1) ->
-    let x1 = ast_of_module_type_declaration x1 in
-    Psig_modtype (x1)
-  | Psig_open (x1) ->
-    let x1 = ast_of_open_description x1 in
-    Psig_open (x1)
-  | Psig_include (x1) ->
-    let x1 = ast_of_include_description x1 in
-    Psig_include (x1)
-  | Psig_class (x1) ->
-    let x1 = (List.map ~f:ast_of_class_description) x1 in
-    Psig_class (x1)
-  | Psig_class_type (x1) ->
-    let x1 = (List.map ~f:ast_of_class_type_declaration) x1 in
-    Psig_class_type (x1)
-  | Psig_attribute (x1) ->
-    let x1 = ast_of_attribute x1 in
-    Psig_attribute (x1)
-  | Psig_extension (x1, x2) ->
-    let x1 = ast_of_extension x1 in
-    let x2 = ast_of_attributes x2 in
-    Psig_extension (x1, x2)
+and concrete_of_signature_item_desc
+  : Compiler_types.signature_item_desc -> Versions.V4_07.Signature_item_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.signature_item_desc) with
+    | Psig_value (x1) ->
+      let x1 = ast_of_value_description x1 in
+      Psig_value (x1)
+    | Psig_type (x1, x2) ->
+      let x1 = ast_of_rec_flag x1 in
+      let x2 = (List.map ~f:ast_of_type_declaration) x2 in
+      Psig_type (x1, x2)
+    | Psig_typext (x1) ->
+      let x1 = ast_of_type_extension x1 in
+      Psig_typext (x1)
+    | Psig_exception (x1) ->
+      let x1 = ast_of_extension_constructor x1 in
+      Psig_exception (x1)
+    | Psig_module (x1) ->
+      let x1 = ast_of_module_declaration x1 in
+      Psig_module (x1)
+    | Psig_recmodule (x1) ->
+      let x1 = (List.map ~f:ast_of_module_declaration) x1 in
+      Psig_recmodule (x1)
+    | Psig_modtype (x1) ->
+      let x1 = ast_of_module_type_declaration x1 in
+      Psig_modtype (x1)
+    | Psig_open (x1) ->
+      let x1 = ast_of_open_description x1 in
+      Psig_open (x1)
+    | Psig_include (x1) ->
+      let x1 = ast_of_include_description x1 in
+      Psig_include (x1)
+    | Psig_class (x1) ->
+      let x1 = (List.map ~f:ast_of_class_description) x1 in
+      Psig_class (x1)
+    | Psig_class_type (x1) ->
+      let x1 = (List.map ~f:ast_of_class_type_declaration) x1 in
+      Psig_class_type (x1)
+    | Psig_attribute (x1) ->
+      let x1 = ast_of_attribute x1 in
+      Psig_attribute (x1)
+    | Psig_extension (x1, x2) ->
+      let x1 = ast_of_extension x1 in
+      let x2 = ast_of_attributes x2 in
+      Psig_extension (x1, x2)
 
-and ast_to_signature_item_desc x =
-  let concrete = Versions.V4_07.Signature_item_desc.to_concrete x in
-  concrete_to_signature_item_desc concrete
+and ast_to_signature_item_desc
+  : Versions.V4_07.Signature_item_desc.t -> Compiler_types.signature_item_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Signature_item_desc.to_concrete x in
+    concrete_to_signature_item_desc concrete
 
-and concrete_to_signature_item_desc x : Compiler_types.signature_item_desc =
-  match (x : Versions.V4_07.Signature_item_desc.concrete) with
-  | Psig_value (x1) ->
-    let x1 = ast_to_value_description x1 in
-    Psig_value (x1)
-  | Psig_type (x1, x2) ->
-    let x1 = ast_to_rec_flag x1 in
-    let x2 = (List.map ~f:ast_to_type_declaration) x2 in
-    Psig_type (x1, x2)
-  | Psig_typext (x1) ->
-    let x1 = ast_to_type_extension x1 in
-    Psig_typext (x1)
-  | Psig_exception (x1) ->
-    let x1 = ast_to_extension_constructor x1 in
-    Psig_exception (x1)
-  | Psig_module (x1) ->
-    let x1 = ast_to_module_declaration x1 in
-    Psig_module (x1)
-  | Psig_recmodule (x1) ->
-    let x1 = (List.map ~f:ast_to_module_declaration) x1 in
-    Psig_recmodule (x1)
-  | Psig_modtype (x1) ->
-    let x1 = ast_to_module_type_declaration x1 in
-    Psig_modtype (x1)
-  | Psig_open (x1) ->
-    let x1 = ast_to_open_description x1 in
-    Psig_open (x1)
-  | Psig_include (x1) ->
-    let x1 = ast_to_include_description x1 in
-    Psig_include (x1)
-  | Psig_class (x1) ->
-    let x1 = (List.map ~f:ast_to_class_description) x1 in
-    Psig_class (x1)
-  | Psig_class_type (x1) ->
-    let x1 = (List.map ~f:ast_to_class_type_declaration) x1 in
-    Psig_class_type (x1)
-  | Psig_attribute (x1) ->
-    let x1 = ast_to_attribute x1 in
-    Psig_attribute (x1)
-  | Psig_extension (x1, x2) ->
-    let x1 = ast_to_extension x1 in
-    let x2 = ast_to_attributes x2 in
-    Psig_extension (x1, x2)
+and concrete_to_signature_item_desc
+  : Versions.V4_07.Signature_item_desc.concrete -> Compiler_types.signature_item_desc
+  = fun x ->
+    match (x : Versions.V4_07.Signature_item_desc.concrete) with
+    | Psig_value (x1) ->
+      let x1 = ast_to_value_description x1 in
+      Psig_value (x1)
+    | Psig_type (x1, x2) ->
+      let x1 = ast_to_rec_flag x1 in
+      let x2 = (List.map ~f:ast_to_type_declaration) x2 in
+      Psig_type (x1, x2)
+    | Psig_typext (x1) ->
+      let x1 = ast_to_type_extension x1 in
+      Psig_typext (x1)
+    | Psig_exception (x1) ->
+      let x1 = ast_to_extension_constructor x1 in
+      Psig_exception (x1)
+    | Psig_module (x1) ->
+      let x1 = ast_to_module_declaration x1 in
+      Psig_module (x1)
+    | Psig_recmodule (x1) ->
+      let x1 = (List.map ~f:ast_to_module_declaration) x1 in
+      Psig_recmodule (x1)
+    | Psig_modtype (x1) ->
+      let x1 = ast_to_module_type_declaration x1 in
+      Psig_modtype (x1)
+    | Psig_open (x1) ->
+      let x1 = ast_to_open_description x1 in
+      Psig_open (x1)
+    | Psig_include (x1) ->
+      let x1 = ast_to_include_description x1 in
+      Psig_include (x1)
+    | Psig_class (x1) ->
+      let x1 = (List.map ~f:ast_to_class_description) x1 in
+      Psig_class (x1)
+    | Psig_class_type (x1) ->
+      let x1 = (List.map ~f:ast_to_class_type_declaration) x1 in
+      Psig_class_type (x1)
+    | Psig_attribute (x1) ->
+      let x1 = ast_to_attribute x1 in
+      Psig_attribute (x1)
+    | Psig_extension (x1, x2) ->
+      let x1 = ast_to_extension x1 in
+      let x2 = ast_to_attributes x2 in
+      Psig_extension (x1, x2)
 
-and ast_of_module_declaration x =
-  Versions.V4_07.Module_declaration.of_concrete (concrete_of_module_declaration x)
+and ast_of_module_declaration
+  : Compiler_types.module_declaration -> Versions.V4_07.Module_declaration.t
+  = fun x ->
+    Versions.V4_07.Module_declaration.of_concrete (concrete_of_module_declaration x)
 
 and concrete_of_module_declaration
-  ({ pmd_name; pmd_type; pmd_attributes; pmd_loc } : Compiler_types.module_declaration)
-=
-  let pmd_type = ast_of_module_type pmd_type in
-  let pmd_attributes = ast_of_attributes pmd_attributes in
-  ({ pmd_name; pmd_type; pmd_attributes; pmd_loc } : Versions.V4_07.Module_declaration.concrete)
+  : Compiler_types.module_declaration -> Versions.V4_07.Module_declaration.concrete
+  = fun { pmd_name; pmd_type; pmd_attributes; pmd_loc } ->
+      let pmd_type = ast_of_module_type pmd_type in
+      let pmd_attributes = ast_of_attributes pmd_attributes in
+      { pmd_name; pmd_type; pmd_attributes; pmd_loc }
 
-and ast_to_module_declaration x =
-  let concrete = Versions.V4_07.Module_declaration.to_concrete x in
-  concrete_to_module_declaration concrete
+and ast_to_module_declaration
+  : Versions.V4_07.Module_declaration.t -> Compiler_types.module_declaration
+  = fun x ->
+    let concrete = Versions.V4_07.Module_declaration.to_concrete x in
+    concrete_to_module_declaration concrete
 
 and concrete_to_module_declaration
-  ({ pmd_name; pmd_type; pmd_attributes; pmd_loc } : Versions.V4_07.Module_declaration.concrete)
-=
-  let pmd_type = ast_to_module_type pmd_type in
-  let pmd_attributes = ast_to_attributes pmd_attributes in
-  ({ pmd_name; pmd_type; pmd_attributes; pmd_loc } : Compiler_types.module_declaration)
+  : Versions.V4_07.Module_declaration.concrete -> Compiler_types.module_declaration
+  = fun { pmd_name; pmd_type; pmd_attributes; pmd_loc } ->
+      let pmd_type = ast_to_module_type pmd_type in
+      let pmd_attributes = ast_to_attributes pmd_attributes in
+      { pmd_name; pmd_type; pmd_attributes; pmd_loc }
 
-and ast_of_module_type_declaration x =
-  Versions.V4_07.Module_type_declaration.of_concrete (concrete_of_module_type_declaration x)
+and ast_of_module_type_declaration
+  : Compiler_types.module_type_declaration -> Versions.V4_07.Module_type_declaration.t
+  = fun x ->
+    Versions.V4_07.Module_type_declaration.of_concrete (concrete_of_module_type_declaration x)
 
 and concrete_of_module_type_declaration
-  ({ pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Compiler_types.module_type_declaration)
-=
-  let pmtd_type = (Option.map ~f:ast_of_module_type) pmtd_type in
-  let pmtd_attributes = ast_of_attributes pmtd_attributes in
-  ({ pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Versions.V4_07.Module_type_declaration.concrete)
+  : Compiler_types.module_type_declaration -> Versions.V4_07.Module_type_declaration.concrete
+  = fun { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } ->
+      let pmtd_type = (Option.map ~f:ast_of_module_type) pmtd_type in
+      let pmtd_attributes = ast_of_attributes pmtd_attributes in
+      { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc }
 
-and ast_to_module_type_declaration x =
-  let concrete = Versions.V4_07.Module_type_declaration.to_concrete x in
-  concrete_to_module_type_declaration concrete
+and ast_to_module_type_declaration
+  : Versions.V4_07.Module_type_declaration.t -> Compiler_types.module_type_declaration
+  = fun x ->
+    let concrete = Versions.V4_07.Module_type_declaration.to_concrete x in
+    concrete_to_module_type_declaration concrete
 
 and concrete_to_module_type_declaration
-  ({ pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Versions.V4_07.Module_type_declaration.concrete)
-=
-  let pmtd_type = (Option.map ~f:ast_to_module_type) pmtd_type in
-  let pmtd_attributes = ast_to_attributes pmtd_attributes in
-  ({ pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } : Compiler_types.module_type_declaration)
+  : Versions.V4_07.Module_type_declaration.concrete -> Compiler_types.module_type_declaration
+  = fun { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc } ->
+      let pmtd_type = (Option.map ~f:ast_to_module_type) pmtd_type in
+      let pmtd_attributes = ast_to_attributes pmtd_attributes in
+      { pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc }
 
-and ast_of_open_description x =
-  Versions.V4_07.Open_description.of_concrete (concrete_of_open_description x)
+and ast_of_open_description
+  : Compiler_types.open_description -> Versions.V4_07.Open_description.t
+  = fun x ->
+    Versions.V4_07.Open_description.of_concrete (concrete_of_open_description x)
 
 and concrete_of_open_description
-  ({ popen_lid; popen_override; popen_loc; popen_attributes } : Compiler_types.open_description)
-=
-  let popen_lid = ast_of_longident_loc popen_lid in
-  let popen_override = ast_of_override_flag popen_override in
-  let popen_attributes = ast_of_attributes popen_attributes in
-  ({ popen_lid; popen_override; popen_loc; popen_attributes } : Versions.V4_07.Open_description.concrete)
+  : Compiler_types.open_description -> Versions.V4_07.Open_description.concrete
+  = fun { popen_lid; popen_override; popen_loc; popen_attributes } ->
+      let popen_lid = ast_of_longident_loc popen_lid in
+      let popen_override = ast_of_override_flag popen_override in
+      let popen_attributes = ast_of_attributes popen_attributes in
+      { popen_lid; popen_override; popen_loc; popen_attributes }
 
-and ast_to_open_description x =
-  let concrete = Versions.V4_07.Open_description.to_concrete x in
-  concrete_to_open_description concrete
+and ast_to_open_description
+  : Versions.V4_07.Open_description.t -> Compiler_types.open_description
+  = fun x ->
+    let concrete = Versions.V4_07.Open_description.to_concrete x in
+    concrete_to_open_description concrete
 
 and concrete_to_open_description
-  ({ popen_lid; popen_override; popen_loc; popen_attributes } : Versions.V4_07.Open_description.concrete)
-=
-  let popen_lid = ast_to_longident_loc popen_lid in
-  let popen_override = ast_to_override_flag popen_override in
-  let popen_attributes = ast_to_attributes popen_attributes in
-  ({ popen_lid; popen_override; popen_loc; popen_attributes } : Compiler_types.open_description)
+  : Versions.V4_07.Open_description.concrete -> Compiler_types.open_description
+  = fun { popen_lid; popen_override; popen_loc; popen_attributes } ->
+      let popen_lid = ast_to_longident_loc popen_lid in
+      let popen_override = ast_to_override_flag popen_override in
+      let popen_attributes = ast_to_attributes popen_attributes in
+      { popen_lid; popen_override; popen_loc; popen_attributes }
 
-and ast_of_include_infos_module_expr x =
-  Versions.V4_07.Include_infos.of_concrete (concrete_of_include_infos_module_expr x)
+and ast_of_include_infos
+  : type a a_ .(a_ -> a Unversioned.Types.node) -> a_ Compiler_types.include_infos -> a Unversioned.Types.node Versions.V4_07.Include_infos.t
+  = fun ast_of_a x ->
+    Versions.V4_07.Include_infos.of_concrete (concrete_of_include_infos ast_of_a x)
 
-and concrete_of_include_infos_module_expr
-  ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_expr Compiler_types.include_infos)
-=
-  let pincl_mod = ast_of_module_expr pincl_mod in
-  let pincl_attributes = ast_of_attributes pincl_attributes in
-  ({ pincl_mod; pincl_loc; pincl_attributes } : Versions.V4_07.Module_expr.t Versions.V4_07.Include_infos.concrete)
+and concrete_of_include_infos
+  : type a a_ .(a_ -> a Unversioned.Types.node) -> a_ Compiler_types.include_infos -> a Unversioned.Types.node Versions.V4_07.Include_infos.concrete
+  = fun ast_of_a { pincl_mod; pincl_loc; pincl_attributes } ->
+      let pincl_mod = ast_of_a pincl_mod in
+      let pincl_attributes = ast_of_attributes pincl_attributes in
+      { pincl_mod; pincl_loc; pincl_attributes }
 
-and ast_to_include_infos_module_expr x =
-  let concrete = Versions.V4_07.Include_infos.to_concrete x in
-  concrete_to_include_infos_module_expr concrete
+and ast_to_include_infos
+  : type a a_ .(a Unversioned.Types.node -> a_) -> a Unversioned.Types.node Versions.V4_07.Include_infos.t -> a_ Compiler_types.include_infos
+  = fun ast_to_a x ->
+    let concrete = Versions.V4_07.Include_infos.to_concrete x in
+    concrete_to_include_infos ast_to_a concrete
 
-and concrete_to_include_infos_module_expr
-  ({ pincl_mod; pincl_loc; pincl_attributes } : Versions.V4_07.Module_expr.t Versions.V4_07.Include_infos.concrete)
-=
-  let pincl_mod = ast_to_module_expr pincl_mod in
-  let pincl_attributes = ast_to_attributes pincl_attributes in
-  ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_expr Compiler_types.include_infos)
+and concrete_to_include_infos
+  : type a a_ .(a Unversioned.Types.node -> a_) -> a Unversioned.Types.node Versions.V4_07.Include_infos.concrete -> a_ Compiler_types.include_infos
+  = fun ast_to_a { pincl_mod; pincl_loc; pincl_attributes } ->
+      let pincl_mod = ast_to_a pincl_mod in
+      let pincl_attributes = ast_to_attributes pincl_attributes in
+      { pincl_mod; pincl_loc; pincl_attributes }
 
-and ast_of_include_infos_module_type x =
-  Versions.V4_07.Include_infos.of_concrete (concrete_of_include_infos_module_type x)
+and ast_of_include_description
+  : Compiler_types.include_description -> Versions.V4_07.Include_description.t
+  = fun x ->
+    Versions.V4_07.Include_description.of_concrete (concrete_of_include_description x)
 
-and concrete_of_include_infos_module_type
-  ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_type Compiler_types.include_infos)
-=
-  let pincl_mod = ast_of_module_type pincl_mod in
-  let pincl_attributes = ast_of_attributes pincl_attributes in
-  ({ pincl_mod; pincl_loc; pincl_attributes } : Versions.V4_07.Module_type.t Versions.V4_07.Include_infos.concrete)
+and concrete_of_include_description
+  : Compiler_types.include_description -> Versions.V4_07.Include_description.concrete
+  = fun x ->
+    (ast_of_include_infos ast_of_module_type) x
 
-and ast_to_include_infos_module_type x =
-  let concrete = Versions.V4_07.Include_infos.to_concrete x in
-  concrete_to_include_infos_module_type concrete
+and ast_to_include_description
+  : Versions.V4_07.Include_description.t -> Compiler_types.include_description
+  = fun x ->
+    let concrete = Versions.V4_07.Include_description.to_concrete x in
+    concrete_to_include_description concrete
 
-and concrete_to_include_infos_module_type
-  ({ pincl_mod; pincl_loc; pincl_attributes } : Versions.V4_07.Module_type.t Versions.V4_07.Include_infos.concrete)
-=
-  let pincl_mod = ast_to_module_type pincl_mod in
-  let pincl_attributes = ast_to_attributes pincl_attributes in
-  ({ pincl_mod; pincl_loc; pincl_attributes } : Compiler_types.module_type Compiler_types.include_infos)
+and concrete_to_include_description
+  : Versions.V4_07.Include_description.concrete -> Compiler_types.include_description
+  = fun x ->
+    (ast_to_include_infos ast_to_module_type) x
 
-and ast_of_include_description x =
-  Versions.V4_07.Include_description.of_concrete (concrete_of_include_description x)
+and ast_of_include_declaration
+  : Compiler_types.include_declaration -> Versions.V4_07.Include_declaration.t
+  = fun x ->
+    Versions.V4_07.Include_declaration.of_concrete (concrete_of_include_declaration x)
 
-and concrete_of_include_description x =
-  ast_of_include_infos_module_type x
+and concrete_of_include_declaration
+  : Compiler_types.include_declaration -> Versions.V4_07.Include_declaration.concrete
+  = fun x ->
+    (ast_of_include_infos ast_of_module_expr) x
 
-and ast_to_include_description x =
-  let concrete = Versions.V4_07.Include_description.to_concrete x in
-  concrete_to_include_description concrete
+and ast_to_include_declaration
+  : Versions.V4_07.Include_declaration.t -> Compiler_types.include_declaration
+  = fun x ->
+    let concrete = Versions.V4_07.Include_declaration.to_concrete x in
+    concrete_to_include_declaration concrete
 
-and concrete_to_include_description x =
-  ast_to_include_infos_module_type x
+and concrete_to_include_declaration
+  : Versions.V4_07.Include_declaration.concrete -> Compiler_types.include_declaration
+  = fun x ->
+    (ast_to_include_infos ast_to_module_expr) x
 
-and ast_of_include_declaration x =
-  Versions.V4_07.Include_declaration.of_concrete (concrete_of_include_declaration x)
+and ast_of_with_constraint
+  : Compiler_types.with_constraint -> Versions.V4_07.With_constraint.t
+  = fun x ->
+    Versions.V4_07.With_constraint.of_concrete (concrete_of_with_constraint x)
 
-and concrete_of_include_declaration x =
-  ast_of_include_infos_module_expr x
+and concrete_of_with_constraint
+  : Compiler_types.with_constraint -> Versions.V4_07.With_constraint.concrete
+  = fun x ->
+    match (x : Compiler_types.with_constraint) with
+    | Pwith_type (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = ast_of_type_declaration x2 in
+      Pwith_type (x1, x2)
+    | Pwith_module (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = ast_of_longident_loc x2 in
+      Pwith_module (x1, x2)
+    | Pwith_typesubst (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = ast_of_type_declaration x2 in
+      Pwith_typesubst (x1, x2)
+    | Pwith_modsubst (x1, x2) ->
+      let x1 = ast_of_longident_loc x1 in
+      let x2 = ast_of_longident_loc x2 in
+      Pwith_modsubst (x1, x2)
 
-and ast_to_include_declaration x =
-  let concrete = Versions.V4_07.Include_declaration.to_concrete x in
-  concrete_to_include_declaration concrete
+and ast_to_with_constraint
+  : Versions.V4_07.With_constraint.t -> Compiler_types.with_constraint
+  = fun x ->
+    let concrete = Versions.V4_07.With_constraint.to_concrete x in
+    concrete_to_with_constraint concrete
 
-and concrete_to_include_declaration x =
-  ast_to_include_infos_module_expr x
+and concrete_to_with_constraint
+  : Versions.V4_07.With_constraint.concrete -> Compiler_types.with_constraint
+  = fun x ->
+    match (x : Versions.V4_07.With_constraint.concrete) with
+    | Pwith_type (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = ast_to_type_declaration x2 in
+      Pwith_type (x1, x2)
+    | Pwith_module (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = ast_to_longident_loc x2 in
+      Pwith_module (x1, x2)
+    | Pwith_typesubst (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = ast_to_type_declaration x2 in
+      Pwith_typesubst (x1, x2)
+    | Pwith_modsubst (x1, x2) ->
+      let x1 = ast_to_longident_loc x1 in
+      let x2 = ast_to_longident_loc x2 in
+      Pwith_modsubst (x1, x2)
 
-and ast_of_with_constraint x =
-  Versions.V4_07.With_constraint.of_concrete (concrete_of_with_constraint x)
-
-and concrete_of_with_constraint x : Versions.V4_07.With_constraint.concrete =
-  match (x : Compiler_types.with_constraint) with
-  | Pwith_type (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = ast_of_type_declaration x2 in
-    Pwith_type (x1, x2)
-  | Pwith_module (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = ast_of_longident_loc x2 in
-    Pwith_module (x1, x2)
-  | Pwith_typesubst (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = ast_of_type_declaration x2 in
-    Pwith_typesubst (x1, x2)
-  | Pwith_modsubst (x1, x2) ->
-    let x1 = ast_of_longident_loc x1 in
-    let x2 = ast_of_longident_loc x2 in
-    Pwith_modsubst (x1, x2)
-
-and ast_to_with_constraint x =
-  let concrete = Versions.V4_07.With_constraint.to_concrete x in
-  concrete_to_with_constraint concrete
-
-and concrete_to_with_constraint x : Compiler_types.with_constraint =
-  match (x : Versions.V4_07.With_constraint.concrete) with
-  | Pwith_type (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = ast_to_type_declaration x2 in
-    Pwith_type (x1, x2)
-  | Pwith_module (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = ast_to_longident_loc x2 in
-    Pwith_module (x1, x2)
-  | Pwith_typesubst (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = ast_to_type_declaration x2 in
-    Pwith_typesubst (x1, x2)
-  | Pwith_modsubst (x1, x2) ->
-    let x1 = ast_to_longident_loc x1 in
-    let x2 = ast_to_longident_loc x2 in
-    Pwith_modsubst (x1, x2)
-
-and ast_of_module_expr x =
-  Versions.V4_07.Module_expr.of_concrete (concrete_of_module_expr x)
+and ast_of_module_expr
+  : Compiler_types.module_expr -> Versions.V4_07.Module_expr.t
+  = fun x ->
+    Versions.V4_07.Module_expr.of_concrete (concrete_of_module_expr x)
 
 and concrete_of_module_expr
-  ({ pmod_desc; pmod_loc; pmod_attributes } : Compiler_types.module_expr)
-=
-  let pmod_desc = ast_of_module_expr_desc pmod_desc in
-  let pmod_attributes = ast_of_attributes pmod_attributes in
-  ({ pmod_desc; pmod_loc; pmod_attributes } : Versions.V4_07.Module_expr.concrete)
+  : Compiler_types.module_expr -> Versions.V4_07.Module_expr.concrete
+  = fun { pmod_desc; pmod_loc; pmod_attributes } ->
+      let pmod_desc = ast_of_module_expr_desc pmod_desc in
+      let pmod_attributes = ast_of_attributes pmod_attributes in
+      { pmod_desc; pmod_loc; pmod_attributes }
 
-and ast_to_module_expr x =
-  let concrete = Versions.V4_07.Module_expr.to_concrete x in
-  concrete_to_module_expr concrete
+and ast_to_module_expr
+  : Versions.V4_07.Module_expr.t -> Compiler_types.module_expr
+  = fun x ->
+    let concrete = Versions.V4_07.Module_expr.to_concrete x in
+    concrete_to_module_expr concrete
 
 and concrete_to_module_expr
-  ({ pmod_desc; pmod_loc; pmod_attributes } : Versions.V4_07.Module_expr.concrete)
-=
-  let pmod_desc = ast_to_module_expr_desc pmod_desc in
-  let pmod_attributes = ast_to_attributes pmod_attributes in
-  ({ pmod_desc; pmod_loc; pmod_attributes } : Compiler_types.module_expr)
+  : Versions.V4_07.Module_expr.concrete -> Compiler_types.module_expr
+  = fun { pmod_desc; pmod_loc; pmod_attributes } ->
+      let pmod_desc = ast_to_module_expr_desc pmod_desc in
+      let pmod_attributes = ast_to_attributes pmod_attributes in
+      { pmod_desc; pmod_loc; pmod_attributes }
 
-and ast_of_module_expr_desc x =
-  Versions.V4_07.Module_expr_desc.of_concrete (concrete_of_module_expr_desc x)
+and ast_of_module_expr_desc
+  : Compiler_types.module_expr_desc -> Versions.V4_07.Module_expr_desc.t
+  = fun x ->
+    Versions.V4_07.Module_expr_desc.of_concrete (concrete_of_module_expr_desc x)
 
-and concrete_of_module_expr_desc x : Versions.V4_07.Module_expr_desc.concrete =
-  match (x : Compiler_types.module_expr_desc) with
-  | Pmod_ident (x1) ->
-    let x1 = ast_of_longident_loc x1 in
-    Pmod_ident (x1)
-  | Pmod_structure (x1) ->
-    let x1 = ast_of_structure x1 in
-    Pmod_structure (x1)
-  | Pmod_functor (x1, x2, x3) ->
-    let x2 = (Option.map ~f:ast_of_module_type) x2 in
-    let x3 = ast_of_module_expr x3 in
-    Pmod_functor (x1, x2, x3)
-  | Pmod_apply (x1, x2) ->
-    let x1 = ast_of_module_expr x1 in
-    let x2 = ast_of_module_expr x2 in
-    Pmod_apply (x1, x2)
-  | Pmod_constraint (x1, x2) ->
-    let x1 = ast_of_module_expr x1 in
-    let x2 = ast_of_module_type x2 in
-    Pmod_constraint (x1, x2)
-  | Pmod_unpack (x1) ->
-    let x1 = ast_of_expression x1 in
-    Pmod_unpack (x1)
-  | Pmod_extension (x1) ->
-    let x1 = ast_of_extension x1 in
-    Pmod_extension (x1)
+and concrete_of_module_expr_desc
+  : Compiler_types.module_expr_desc -> Versions.V4_07.Module_expr_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.module_expr_desc) with
+    | Pmod_ident (x1) ->
+      let x1 = ast_of_longident_loc x1 in
+      Pmod_ident (x1)
+    | Pmod_structure (x1) ->
+      let x1 = ast_of_structure x1 in
+      Pmod_structure (x1)
+    | Pmod_functor (x1, x2, x3) ->
+      let x2 = (Option.map ~f:ast_of_module_type) x2 in
+      let x3 = ast_of_module_expr x3 in
+      Pmod_functor (x1, x2, x3)
+    | Pmod_apply (x1, x2) ->
+      let x1 = ast_of_module_expr x1 in
+      let x2 = ast_of_module_expr x2 in
+      Pmod_apply (x1, x2)
+    | Pmod_constraint (x1, x2) ->
+      let x1 = ast_of_module_expr x1 in
+      let x2 = ast_of_module_type x2 in
+      Pmod_constraint (x1, x2)
+    | Pmod_unpack (x1) ->
+      let x1 = ast_of_expression x1 in
+      Pmod_unpack (x1)
+    | Pmod_extension (x1) ->
+      let x1 = ast_of_extension x1 in
+      Pmod_extension (x1)
 
-and ast_to_module_expr_desc x =
-  let concrete = Versions.V4_07.Module_expr_desc.to_concrete x in
-  concrete_to_module_expr_desc concrete
+and ast_to_module_expr_desc
+  : Versions.V4_07.Module_expr_desc.t -> Compiler_types.module_expr_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Module_expr_desc.to_concrete x in
+    concrete_to_module_expr_desc concrete
 
-and concrete_to_module_expr_desc x : Compiler_types.module_expr_desc =
-  match (x : Versions.V4_07.Module_expr_desc.concrete) with
-  | Pmod_ident (x1) ->
-    let x1 = ast_to_longident_loc x1 in
-    Pmod_ident (x1)
-  | Pmod_structure (x1) ->
-    let x1 = ast_to_structure x1 in
-    Pmod_structure (x1)
-  | Pmod_functor (x1, x2, x3) ->
-    let x2 = (Option.map ~f:ast_to_module_type) x2 in
-    let x3 = ast_to_module_expr x3 in
-    Pmod_functor (x1, x2, x3)
-  | Pmod_apply (x1, x2) ->
-    let x1 = ast_to_module_expr x1 in
-    let x2 = ast_to_module_expr x2 in
-    Pmod_apply (x1, x2)
-  | Pmod_constraint (x1, x2) ->
-    let x1 = ast_to_module_expr x1 in
-    let x2 = ast_to_module_type x2 in
-    Pmod_constraint (x1, x2)
-  | Pmod_unpack (x1) ->
-    let x1 = ast_to_expression x1 in
-    Pmod_unpack (x1)
-  | Pmod_extension (x1) ->
-    let x1 = ast_to_extension x1 in
-    Pmod_extension (x1)
+and concrete_to_module_expr_desc
+  : Versions.V4_07.Module_expr_desc.concrete -> Compiler_types.module_expr_desc
+  = fun x ->
+    match (x : Versions.V4_07.Module_expr_desc.concrete) with
+    | Pmod_ident (x1) ->
+      let x1 = ast_to_longident_loc x1 in
+      Pmod_ident (x1)
+    | Pmod_structure (x1) ->
+      let x1 = ast_to_structure x1 in
+      Pmod_structure (x1)
+    | Pmod_functor (x1, x2, x3) ->
+      let x2 = (Option.map ~f:ast_to_module_type) x2 in
+      let x3 = ast_to_module_expr x3 in
+      Pmod_functor (x1, x2, x3)
+    | Pmod_apply (x1, x2) ->
+      let x1 = ast_to_module_expr x1 in
+      let x2 = ast_to_module_expr x2 in
+      Pmod_apply (x1, x2)
+    | Pmod_constraint (x1, x2) ->
+      let x1 = ast_to_module_expr x1 in
+      let x2 = ast_to_module_type x2 in
+      Pmod_constraint (x1, x2)
+    | Pmod_unpack (x1) ->
+      let x1 = ast_to_expression x1 in
+      Pmod_unpack (x1)
+    | Pmod_extension (x1) ->
+      let x1 = ast_to_extension x1 in
+      Pmod_extension (x1)
 
-and ast_of_structure x =
-  Versions.V4_07.Structure.of_concrete (concrete_of_structure x)
+and ast_of_structure
+  : Compiler_types.structure -> Versions.V4_07.Structure.t
+  = fun x ->
+    Versions.V4_07.Structure.of_concrete (concrete_of_structure x)
 
-and concrete_of_structure x =
-  (List.map ~f:ast_of_structure_item) x
+and concrete_of_structure
+  : Compiler_types.structure -> Versions.V4_07.Structure.concrete
+  = fun x ->
+    (List.map ~f:ast_of_structure_item) x
 
-and ast_to_structure x =
-  let concrete = Versions.V4_07.Structure.to_concrete x in
-  concrete_to_structure concrete
+and ast_to_structure
+  : Versions.V4_07.Structure.t -> Compiler_types.structure
+  = fun x ->
+    let concrete = Versions.V4_07.Structure.to_concrete x in
+    concrete_to_structure concrete
 
-and concrete_to_structure x =
-  (List.map ~f:ast_to_structure_item) x
+and concrete_to_structure
+  : Versions.V4_07.Structure.concrete -> Compiler_types.structure
+  = fun x ->
+    (List.map ~f:ast_to_structure_item) x
 
-and ast_of_structure_item x =
-  Versions.V4_07.Structure_item.of_concrete (concrete_of_structure_item x)
+and ast_of_structure_item
+  : Compiler_types.structure_item -> Versions.V4_07.Structure_item.t
+  = fun x ->
+    Versions.V4_07.Structure_item.of_concrete (concrete_of_structure_item x)
 
 and concrete_of_structure_item
-  ({ pstr_desc; pstr_loc } : Compiler_types.structure_item)
-=
-  let pstr_desc = ast_of_structure_item_desc pstr_desc in
-  ({ pstr_desc; pstr_loc } : Versions.V4_07.Structure_item.concrete)
+  : Compiler_types.structure_item -> Versions.V4_07.Structure_item.concrete
+  = fun { pstr_desc; pstr_loc } ->
+      let pstr_desc = ast_of_structure_item_desc pstr_desc in
+      { pstr_desc; pstr_loc }
 
-and ast_to_structure_item x =
-  let concrete = Versions.V4_07.Structure_item.to_concrete x in
-  concrete_to_structure_item concrete
+and ast_to_structure_item
+  : Versions.V4_07.Structure_item.t -> Compiler_types.structure_item
+  = fun x ->
+    let concrete = Versions.V4_07.Structure_item.to_concrete x in
+    concrete_to_structure_item concrete
 
 and concrete_to_structure_item
-  ({ pstr_desc; pstr_loc } : Versions.V4_07.Structure_item.concrete)
-=
-  let pstr_desc = ast_to_structure_item_desc pstr_desc in
-  ({ pstr_desc; pstr_loc } : Compiler_types.structure_item)
+  : Versions.V4_07.Structure_item.concrete -> Compiler_types.structure_item
+  = fun { pstr_desc; pstr_loc } ->
+      let pstr_desc = ast_to_structure_item_desc pstr_desc in
+      { pstr_desc; pstr_loc }
 
-and ast_of_structure_item_desc x =
-  Versions.V4_07.Structure_item_desc.of_concrete (concrete_of_structure_item_desc x)
+and ast_of_structure_item_desc
+  : Compiler_types.structure_item_desc -> Versions.V4_07.Structure_item_desc.t
+  = fun x ->
+    Versions.V4_07.Structure_item_desc.of_concrete (concrete_of_structure_item_desc x)
 
-and concrete_of_structure_item_desc x : Versions.V4_07.Structure_item_desc.concrete =
-  match (x : Compiler_types.structure_item_desc) with
-  | Pstr_eval (x1, x2) ->
-    let x1 = ast_of_expression x1 in
-    let x2 = ast_of_attributes x2 in
-    Pstr_eval (x1, x2)
-  | Pstr_value (x1, x2) ->
-    let x1 = ast_of_rec_flag x1 in
-    let x2 = (List.map ~f:ast_of_value_binding) x2 in
-    Pstr_value (x1, x2)
-  | Pstr_primitive (x1) ->
-    let x1 = ast_of_value_description x1 in
-    Pstr_primitive (x1)
-  | Pstr_type (x1, x2) ->
-    let x1 = ast_of_rec_flag x1 in
-    let x2 = (List.map ~f:ast_of_type_declaration) x2 in
-    Pstr_type (x1, x2)
-  | Pstr_typext (x1) ->
-    let x1 = ast_of_type_extension x1 in
-    Pstr_typext (x1)
-  | Pstr_exception (x1) ->
-    let x1 = ast_of_extension_constructor x1 in
-    Pstr_exception (x1)
-  | Pstr_module (x1) ->
-    let x1 = ast_of_module_binding x1 in
-    Pstr_module (x1)
-  | Pstr_recmodule (x1) ->
-    let x1 = (List.map ~f:ast_of_module_binding) x1 in
-    Pstr_recmodule (x1)
-  | Pstr_modtype (x1) ->
-    let x1 = ast_of_module_type_declaration x1 in
-    Pstr_modtype (x1)
-  | Pstr_open (x1) ->
-    let x1 = ast_of_open_description x1 in
-    Pstr_open (x1)
-  | Pstr_class (x1) ->
-    let x1 = (List.map ~f:ast_of_class_declaration) x1 in
-    Pstr_class (x1)
-  | Pstr_class_type (x1) ->
-    let x1 = (List.map ~f:ast_of_class_type_declaration) x1 in
-    Pstr_class_type (x1)
-  | Pstr_include (x1) ->
-    let x1 = ast_of_include_declaration x1 in
-    Pstr_include (x1)
-  | Pstr_attribute (x1) ->
-    let x1 = ast_of_attribute x1 in
-    Pstr_attribute (x1)
-  | Pstr_extension (x1, x2) ->
-    let x1 = ast_of_extension x1 in
-    let x2 = ast_of_attributes x2 in
-    Pstr_extension (x1, x2)
+and concrete_of_structure_item_desc
+  : Compiler_types.structure_item_desc -> Versions.V4_07.Structure_item_desc.concrete
+  = fun x ->
+    match (x : Compiler_types.structure_item_desc) with
+    | Pstr_eval (x1, x2) ->
+      let x1 = ast_of_expression x1 in
+      let x2 = ast_of_attributes x2 in
+      Pstr_eval (x1, x2)
+    | Pstr_value (x1, x2) ->
+      let x1 = ast_of_rec_flag x1 in
+      let x2 = (List.map ~f:ast_of_value_binding) x2 in
+      Pstr_value (x1, x2)
+    | Pstr_primitive (x1) ->
+      let x1 = ast_of_value_description x1 in
+      Pstr_primitive (x1)
+    | Pstr_type (x1, x2) ->
+      let x1 = ast_of_rec_flag x1 in
+      let x2 = (List.map ~f:ast_of_type_declaration) x2 in
+      Pstr_type (x1, x2)
+    | Pstr_typext (x1) ->
+      let x1 = ast_of_type_extension x1 in
+      Pstr_typext (x1)
+    | Pstr_exception (x1) ->
+      let x1 = ast_of_extension_constructor x1 in
+      Pstr_exception (x1)
+    | Pstr_module (x1) ->
+      let x1 = ast_of_module_binding x1 in
+      Pstr_module (x1)
+    | Pstr_recmodule (x1) ->
+      let x1 = (List.map ~f:ast_of_module_binding) x1 in
+      Pstr_recmodule (x1)
+    | Pstr_modtype (x1) ->
+      let x1 = ast_of_module_type_declaration x1 in
+      Pstr_modtype (x1)
+    | Pstr_open (x1) ->
+      let x1 = ast_of_open_description x1 in
+      Pstr_open (x1)
+    | Pstr_class (x1) ->
+      let x1 = (List.map ~f:ast_of_class_declaration) x1 in
+      Pstr_class (x1)
+    | Pstr_class_type (x1) ->
+      let x1 = (List.map ~f:ast_of_class_type_declaration) x1 in
+      Pstr_class_type (x1)
+    | Pstr_include (x1) ->
+      let x1 = ast_of_include_declaration x1 in
+      Pstr_include (x1)
+    | Pstr_attribute (x1) ->
+      let x1 = ast_of_attribute x1 in
+      Pstr_attribute (x1)
+    | Pstr_extension (x1, x2) ->
+      let x1 = ast_of_extension x1 in
+      let x2 = ast_of_attributes x2 in
+      Pstr_extension (x1, x2)
 
-and ast_to_structure_item_desc x =
-  let concrete = Versions.V4_07.Structure_item_desc.to_concrete x in
-  concrete_to_structure_item_desc concrete
+and ast_to_structure_item_desc
+  : Versions.V4_07.Structure_item_desc.t -> Compiler_types.structure_item_desc
+  = fun x ->
+    let concrete = Versions.V4_07.Structure_item_desc.to_concrete x in
+    concrete_to_structure_item_desc concrete
 
-and concrete_to_structure_item_desc x : Compiler_types.structure_item_desc =
-  match (x : Versions.V4_07.Structure_item_desc.concrete) with
-  | Pstr_eval (x1, x2) ->
-    let x1 = ast_to_expression x1 in
-    let x2 = ast_to_attributes x2 in
-    Pstr_eval (x1, x2)
-  | Pstr_value (x1, x2) ->
-    let x1 = ast_to_rec_flag x1 in
-    let x2 = (List.map ~f:ast_to_value_binding) x2 in
-    Pstr_value (x1, x2)
-  | Pstr_primitive (x1) ->
-    let x1 = ast_to_value_description x1 in
-    Pstr_primitive (x1)
-  | Pstr_type (x1, x2) ->
-    let x1 = ast_to_rec_flag x1 in
-    let x2 = (List.map ~f:ast_to_type_declaration) x2 in
-    Pstr_type (x1, x2)
-  | Pstr_typext (x1) ->
-    let x1 = ast_to_type_extension x1 in
-    Pstr_typext (x1)
-  | Pstr_exception (x1) ->
-    let x1 = ast_to_extension_constructor x1 in
-    Pstr_exception (x1)
-  | Pstr_module (x1) ->
-    let x1 = ast_to_module_binding x1 in
-    Pstr_module (x1)
-  | Pstr_recmodule (x1) ->
-    let x1 = (List.map ~f:ast_to_module_binding) x1 in
-    Pstr_recmodule (x1)
-  | Pstr_modtype (x1) ->
-    let x1 = ast_to_module_type_declaration x1 in
-    Pstr_modtype (x1)
-  | Pstr_open (x1) ->
-    let x1 = ast_to_open_description x1 in
-    Pstr_open (x1)
-  | Pstr_class (x1) ->
-    let x1 = (List.map ~f:ast_to_class_declaration) x1 in
-    Pstr_class (x1)
-  | Pstr_class_type (x1) ->
-    let x1 = (List.map ~f:ast_to_class_type_declaration) x1 in
-    Pstr_class_type (x1)
-  | Pstr_include (x1) ->
-    let x1 = ast_to_include_declaration x1 in
-    Pstr_include (x1)
-  | Pstr_attribute (x1) ->
-    let x1 = ast_to_attribute x1 in
-    Pstr_attribute (x1)
-  | Pstr_extension (x1, x2) ->
-    let x1 = ast_to_extension x1 in
-    let x2 = ast_to_attributes x2 in
-    Pstr_extension (x1, x2)
+and concrete_to_structure_item_desc
+  : Versions.V4_07.Structure_item_desc.concrete -> Compiler_types.structure_item_desc
+  = fun x ->
+    match (x : Versions.V4_07.Structure_item_desc.concrete) with
+    | Pstr_eval (x1, x2) ->
+      let x1 = ast_to_expression x1 in
+      let x2 = ast_to_attributes x2 in
+      Pstr_eval (x1, x2)
+    | Pstr_value (x1, x2) ->
+      let x1 = ast_to_rec_flag x1 in
+      let x2 = (List.map ~f:ast_to_value_binding) x2 in
+      Pstr_value (x1, x2)
+    | Pstr_primitive (x1) ->
+      let x1 = ast_to_value_description x1 in
+      Pstr_primitive (x1)
+    | Pstr_type (x1, x2) ->
+      let x1 = ast_to_rec_flag x1 in
+      let x2 = (List.map ~f:ast_to_type_declaration) x2 in
+      Pstr_type (x1, x2)
+    | Pstr_typext (x1) ->
+      let x1 = ast_to_type_extension x1 in
+      Pstr_typext (x1)
+    | Pstr_exception (x1) ->
+      let x1 = ast_to_extension_constructor x1 in
+      Pstr_exception (x1)
+    | Pstr_module (x1) ->
+      let x1 = ast_to_module_binding x1 in
+      Pstr_module (x1)
+    | Pstr_recmodule (x1) ->
+      let x1 = (List.map ~f:ast_to_module_binding) x1 in
+      Pstr_recmodule (x1)
+    | Pstr_modtype (x1) ->
+      let x1 = ast_to_module_type_declaration x1 in
+      Pstr_modtype (x1)
+    | Pstr_open (x1) ->
+      let x1 = ast_to_open_description x1 in
+      Pstr_open (x1)
+    | Pstr_class (x1) ->
+      let x1 = (List.map ~f:ast_to_class_declaration) x1 in
+      Pstr_class (x1)
+    | Pstr_class_type (x1) ->
+      let x1 = (List.map ~f:ast_to_class_type_declaration) x1 in
+      Pstr_class_type (x1)
+    | Pstr_include (x1) ->
+      let x1 = ast_to_include_declaration x1 in
+      Pstr_include (x1)
+    | Pstr_attribute (x1) ->
+      let x1 = ast_to_attribute x1 in
+      Pstr_attribute (x1)
+    | Pstr_extension (x1, x2) ->
+      let x1 = ast_to_extension x1 in
+      let x2 = ast_to_attributes x2 in
+      Pstr_extension (x1, x2)
 
-and ast_of_value_binding x =
-  Versions.V4_07.Value_binding.of_concrete (concrete_of_value_binding x)
+and ast_of_value_binding
+  : Compiler_types.value_binding -> Versions.V4_07.Value_binding.t
+  = fun x ->
+    Versions.V4_07.Value_binding.of_concrete (concrete_of_value_binding x)
 
 and concrete_of_value_binding
-  ({ pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Compiler_types.value_binding)
-=
-  let pvb_pat = ast_of_pattern pvb_pat in
-  let pvb_expr = ast_of_expression pvb_expr in
-  let pvb_attributes = ast_of_attributes pvb_attributes in
-  ({ pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Versions.V4_07.Value_binding.concrete)
+  : Compiler_types.value_binding -> Versions.V4_07.Value_binding.concrete
+  = fun { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } ->
+      let pvb_pat = ast_of_pattern pvb_pat in
+      let pvb_expr = ast_of_expression pvb_expr in
+      let pvb_attributes = ast_of_attributes pvb_attributes in
+      { pvb_pat; pvb_expr; pvb_attributes; pvb_loc }
 
-and ast_to_value_binding x =
-  let concrete = Versions.V4_07.Value_binding.to_concrete x in
-  concrete_to_value_binding concrete
+and ast_to_value_binding
+  : Versions.V4_07.Value_binding.t -> Compiler_types.value_binding
+  = fun x ->
+    let concrete = Versions.V4_07.Value_binding.to_concrete x in
+    concrete_to_value_binding concrete
 
 and concrete_to_value_binding
-  ({ pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Versions.V4_07.Value_binding.concrete)
-=
-  let pvb_pat = ast_to_pattern pvb_pat in
-  let pvb_expr = ast_to_expression pvb_expr in
-  let pvb_attributes = ast_to_attributes pvb_attributes in
-  ({ pvb_pat; pvb_expr; pvb_attributes; pvb_loc } : Compiler_types.value_binding)
+  : Versions.V4_07.Value_binding.concrete -> Compiler_types.value_binding
+  = fun { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } ->
+      let pvb_pat = ast_to_pattern pvb_pat in
+      let pvb_expr = ast_to_expression pvb_expr in
+      let pvb_attributes = ast_to_attributes pvb_attributes in
+      { pvb_pat; pvb_expr; pvb_attributes; pvb_loc }
 
-and ast_of_module_binding x =
-  Versions.V4_07.Module_binding.of_concrete (concrete_of_module_binding x)
+and ast_of_module_binding
+  : Compiler_types.module_binding -> Versions.V4_07.Module_binding.t
+  = fun x ->
+    Versions.V4_07.Module_binding.of_concrete (concrete_of_module_binding x)
 
 and concrete_of_module_binding
-  ({ pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Compiler_types.module_binding)
-=
-  let pmb_expr = ast_of_module_expr pmb_expr in
-  let pmb_attributes = ast_of_attributes pmb_attributes in
-  ({ pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Versions.V4_07.Module_binding.concrete)
+  : Compiler_types.module_binding -> Versions.V4_07.Module_binding.concrete
+  = fun { pmb_name; pmb_expr; pmb_attributes; pmb_loc } ->
+      let pmb_expr = ast_of_module_expr pmb_expr in
+      let pmb_attributes = ast_of_attributes pmb_attributes in
+      { pmb_name; pmb_expr; pmb_attributes; pmb_loc }
 
-and ast_to_module_binding x =
-  let concrete = Versions.V4_07.Module_binding.to_concrete x in
-  concrete_to_module_binding concrete
+and ast_to_module_binding
+  : Versions.V4_07.Module_binding.t -> Compiler_types.module_binding
+  = fun x ->
+    let concrete = Versions.V4_07.Module_binding.to_concrete x in
+    concrete_to_module_binding concrete
 
 and concrete_to_module_binding
-  ({ pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Versions.V4_07.Module_binding.concrete)
-=
-  let pmb_expr = ast_to_module_expr pmb_expr in
-  let pmb_attributes = ast_to_attributes pmb_attributes in
-  ({ pmb_name; pmb_expr; pmb_attributes; pmb_loc } : Compiler_types.module_binding)
+  : Versions.V4_07.Module_binding.concrete -> Compiler_types.module_binding
+  = fun { pmb_name; pmb_expr; pmb_attributes; pmb_loc } ->
+      let pmb_expr = ast_to_module_expr pmb_expr in
+      let pmb_attributes = ast_to_attributes pmb_attributes in
+      { pmb_name; pmb_expr; pmb_attributes; pmb_loc }
 
-and ast_of_toplevel_phrase x =
-  Versions.V4_07.Toplevel_phrase.of_concrete (concrete_of_toplevel_phrase x)
+and ast_of_toplevel_phrase
+  : Compiler_types.toplevel_phrase -> Versions.V4_07.Toplevel_phrase.t
+  = fun x ->
+    Versions.V4_07.Toplevel_phrase.of_concrete (concrete_of_toplevel_phrase x)
 
-and concrete_of_toplevel_phrase x : Versions.V4_07.Toplevel_phrase.concrete =
-  match (x : Compiler_types.toplevel_phrase) with
-  | Ptop_def (x1) ->
-    let x1 = ast_of_structure x1 in
-    Ptop_def (x1)
-  | Ptop_dir (x1, x2) ->
-    let x2 = ast_of_directive_argument x2 in
-    Ptop_dir (x1, x2)
+and concrete_of_toplevel_phrase
+  : Compiler_types.toplevel_phrase -> Versions.V4_07.Toplevel_phrase.concrete
+  = fun x ->
+    match (x : Compiler_types.toplevel_phrase) with
+    | Ptop_def (x1) ->
+      let x1 = ast_of_structure x1 in
+      Ptop_def (x1)
+    | Ptop_dir (x1, x2) ->
+      let x2 = ast_of_directive_argument x2 in
+      Ptop_dir (x1, x2)
 
-and ast_to_toplevel_phrase x =
-  let concrete = Versions.V4_07.Toplevel_phrase.to_concrete x in
-  concrete_to_toplevel_phrase concrete
+and ast_to_toplevel_phrase
+  : Versions.V4_07.Toplevel_phrase.t -> Compiler_types.toplevel_phrase
+  = fun x ->
+    let concrete = Versions.V4_07.Toplevel_phrase.to_concrete x in
+    concrete_to_toplevel_phrase concrete
 
-and concrete_to_toplevel_phrase x : Compiler_types.toplevel_phrase =
-  match (x : Versions.V4_07.Toplevel_phrase.concrete) with
-  | Ptop_def (x1) ->
-    let x1 = ast_to_structure x1 in
-    Ptop_def (x1)
-  | Ptop_dir (x1, x2) ->
-    let x2 = ast_to_directive_argument x2 in
-    Ptop_dir (x1, x2)
+and concrete_to_toplevel_phrase
+  : Versions.V4_07.Toplevel_phrase.concrete -> Compiler_types.toplevel_phrase
+  = fun x ->
+    match (x : Versions.V4_07.Toplevel_phrase.concrete) with
+    | Ptop_def (x1) ->
+      let x1 = ast_to_structure x1 in
+      Ptop_def (x1)
+    | Ptop_dir (x1, x2) ->
+      let x2 = ast_to_directive_argument x2 in
+      Ptop_dir (x1, x2)
 
-and ast_of_directive_argument x =
-  Versions.V4_07.Directive_argument.of_concrete (concrete_of_directive_argument x)
+and ast_of_directive_argument
+  : Compiler_types.directive_argument -> Versions.V4_07.Directive_argument.t
+  = fun x ->
+    Versions.V4_07.Directive_argument.of_concrete (concrete_of_directive_argument x)
 
-and concrete_of_directive_argument x : Versions.V4_07.Directive_argument.concrete =
-  match (x : Compiler_types.directive_argument) with
-  | Pdir_none -> Pdir_none
-  | Pdir_string (x1) ->
-    Pdir_string (x1)
-  | Pdir_int (x1, x2) ->
-    Pdir_int (x1, x2)
-  | Pdir_ident (x1) ->
-    let x1 = ast_of_longident x1 in
-    Pdir_ident (x1)
-  | Pdir_bool (x1) ->
-    Pdir_bool (x1)
+and concrete_of_directive_argument
+  : Compiler_types.directive_argument -> Versions.V4_07.Directive_argument.concrete
+  = fun x ->
+    match (x : Compiler_types.directive_argument) with
+    | Pdir_none -> Pdir_none
+    | Pdir_string (x1) ->
+      Pdir_string (x1)
+    | Pdir_int (x1, x2) ->
+      Pdir_int (x1, x2)
+    | Pdir_ident (x1) ->
+      let x1 = ast_of_longident x1 in
+      Pdir_ident (x1)
+    | Pdir_bool (x1) ->
+      Pdir_bool (x1)
 
-and ast_to_directive_argument x =
-  let concrete = Versions.V4_07.Directive_argument.to_concrete x in
-  concrete_to_directive_argument concrete
+and ast_to_directive_argument
+  : Versions.V4_07.Directive_argument.t -> Compiler_types.directive_argument
+  = fun x ->
+    let concrete = Versions.V4_07.Directive_argument.to_concrete x in
+    concrete_to_directive_argument concrete
 
-and concrete_to_directive_argument x : Compiler_types.directive_argument =
-  match (x : Versions.V4_07.Directive_argument.concrete) with
-  | Pdir_none -> Pdir_none
-  | Pdir_string (x1) ->
-    Pdir_string (x1)
-  | Pdir_int (x1, x2) ->
-    Pdir_int (x1, x2)
-  | Pdir_ident (x1) ->
-    let x1 = ast_to_longident x1 in
-    Pdir_ident (x1)
-  | Pdir_bool (x1) ->
-    Pdir_bool (x1)
+and concrete_to_directive_argument
+  : Versions.V4_07.Directive_argument.concrete -> Compiler_types.directive_argument
+  = fun x ->
+    match (x : Versions.V4_07.Directive_argument.concrete) with
+    | Pdir_none -> Pdir_none
+    | Pdir_string (x1) ->
+      Pdir_string (x1)
+    | Pdir_int (x1, x2) ->
+      Pdir_int (x1, x2)
+    | Pdir_ident (x1) ->
+      let x1 = ast_to_longident x1 in
+      Pdir_ident (x1)
+    | Pdir_bool (x1) ->
+      Pdir_bool (x1)
 (*$*)

--- a/ast/conversion.mli
+++ b/ast/conversion.mli
@@ -319,21 +319,15 @@ val ast_to_class_type_field_desc :
   Versions.V4_07.Class_type_field_desc.t
   -> Compiler_types.class_type_field_desc
 
-val ast_of_class_infos_class_expr :
-  Compiler_types.class_expr Compiler_types.class_infos
-  -> Versions.V4_07.Class_expr.t Versions.V4_07.Class_infos.t
+val ast_of_class_infos :
+  ('a_ -> 'a Unversioned.Types.node)
+  -> 'a_ Compiler_types.class_infos
+  -> 'a Unversioned.Types.node Versions.V4_07.Class_infos.t
 
-val ast_to_class_infos_class_expr :
-  Versions.V4_07.Class_expr.t Versions.V4_07.Class_infos.t
-  -> Compiler_types.class_expr Compiler_types.class_infos
-
-val ast_of_class_infos_class_type :
-  Compiler_types.class_type Compiler_types.class_infos
-  -> Versions.V4_07.Class_type.t Versions.V4_07.Class_infos.t
-
-val ast_to_class_infos_class_type :
-  Versions.V4_07.Class_type.t Versions.V4_07.Class_infos.t
-  -> Compiler_types.class_type Compiler_types.class_infos
+val ast_to_class_infos :
+  ('a Unversioned.Types.node -> 'a_)
+  -> 'a Unversioned.Types.node Versions.V4_07.Class_infos.t
+  -> 'a_ Compiler_types.class_infos
 
 val ast_of_class_description :
   Compiler_types.class_description
@@ -471,21 +465,15 @@ val ast_to_open_description :
   Versions.V4_07.Open_description.t
   -> Compiler_types.open_description
 
-val ast_of_include_infos_module_expr :
-  Compiler_types.module_expr Compiler_types.include_infos
-  -> Versions.V4_07.Module_expr.t Versions.V4_07.Include_infos.t
+val ast_of_include_infos :
+  ('a_ -> 'a Unversioned.Types.node)
+  -> 'a_ Compiler_types.include_infos
+  -> 'a Unversioned.Types.node Versions.V4_07.Include_infos.t
 
-val ast_to_include_infos_module_expr :
-  Versions.V4_07.Module_expr.t Versions.V4_07.Include_infos.t
-  -> Compiler_types.module_expr Compiler_types.include_infos
-
-val ast_of_include_infos_module_type :
-  Compiler_types.module_type Compiler_types.include_infos
-  -> Versions.V4_07.Module_type.t Versions.V4_07.Include_infos.t
-
-val ast_to_include_infos_module_type :
-  Versions.V4_07.Module_type.t Versions.V4_07.Include_infos.t
-  -> Compiler_types.module_type Compiler_types.include_infos
+val ast_to_include_infos :
+  ('a Unversioned.Types.node -> 'a_)
+  -> 'a Unversioned.Types.node Versions.V4_07.Include_infos.t
+  -> 'a_ Compiler_types.include_infos
 
 val ast_of_include_description :
   Compiler_types.include_description

--- a/ast/virtual_traverse_unstable_for_testing.ml
+++ b/ast/virtual_traverse_unstable_for_testing.ml
@@ -1,3 +1,4 @@
+open Unversioned.Types
 (*$ Ppx_ast_cinaps.print_virtual_traverse_ml (Astlib.Version.of_string "unstable_for_testing") *)
 open Versions.Unstable_for_testing
 
@@ -184,28 +185,20 @@ class virtual map =
     method include_declaration : Include_declaration.t -> Include_declaration.t  =
       fun include_declaration ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let concrete = self#include_infos_module_expr concrete in
+        let concrete = self#include_infos self#module_expr concrete in
         Include_declaration.of_concrete concrete
     method include_description : Include_description.t -> Include_description.t  =
       fun include_description ->
         let concrete = Include_description.to_concrete include_description in
-        let concrete = self#include_infos_module_type concrete in
+        let concrete = self#include_infos self#module_type concrete in
         Include_description.of_concrete concrete
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t  =
-      fun include_infos ->
+    method include_infos : 'a . ('a node -> 'a node) -> 'a node Include_infos.t -> 'a node Include_infos.t  =
+      fun fa include_infos ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_expr.t Include_infos.concrete = concrete in
+        let { pincl_attributes; pincl_loc; pincl_mod } : _ Include_infos.concrete = concrete in
         let pincl_attributes = self#attributes pincl_attributes in
         let pincl_loc = self#location pincl_loc in
-        let pincl_mod = self#module_expr pincl_mod in
-        Include_infos.of_concrete { pincl_attributes; pincl_loc; pincl_mod }
-    method include_infos_module_type : Module_type.t Include_infos.t -> Module_type.t Include_infos.t  =
-      fun include_infos ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_type.t Include_infos.concrete = concrete in
-        let pincl_attributes = self#attributes pincl_attributes in
-        let pincl_loc = self#location pincl_loc in
-        let pincl_mod = self#module_type pincl_mod in
+        let pincl_mod = fa pincl_mod in
         Include_infos.of_concrete { pincl_attributes; pincl_loc; pincl_mod }
     method open_description : Open_description.t -> Open_description.t  =
       fun open_description ->
@@ -330,7 +323,7 @@ class virtual map =
     method class_declaration : Class_declaration.t -> Class_declaration.t  =
       fun class_declaration ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let concrete = self#class_infos_class_expr concrete in
+        let concrete = self#class_infos self#class_expr concrete in
         Class_declaration.of_concrete concrete
     method class_field_kind : Class_field_kind.t -> Class_field_kind.t  =
       fun class_field_kind ->
@@ -434,31 +427,20 @@ class virtual map =
     method class_type_declaration : Class_type_declaration.t -> Class_type_declaration.t  =
       fun class_type_declaration ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let concrete = self#class_infos_class_type concrete in
+        let concrete = self#class_infos self#class_type concrete in
         Class_type_declaration.of_concrete concrete
     method class_description : Class_description.t -> Class_description.t  =
       fun class_description ->
         let concrete = Class_description.to_concrete class_description in
-        let concrete = self#class_infos_class_type concrete in
+        let concrete = self#class_infos self#class_type concrete in
         Class_description.of_concrete concrete
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t  =
-      fun class_infos ->
+    method class_infos : 'a . ('a node -> 'a node) -> 'a node Class_infos.t -> 'a node Class_infos.t  =
+      fun fa class_infos ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : _ Class_infos.concrete = concrete in
         let pci_attributes = self#attributes pci_attributes in
         let pci_loc = self#location pci_loc in
-        let pci_expr = self#class_expr pci_expr in
-        let pci_name = self#loc self#string pci_name in
-        let pci_params = self#list (fun (x0, x1) -> let x0 = self#variance x0 in let x1 = self#core_type x1 in (x0, x1)) pci_params in
-        let pci_virt = self#virtual_flag pci_virt in
-        Class_infos.of_concrete { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt }
-    method class_infos_class_type : Class_type.t Class_infos.t -> Class_type.t Class_infos.t  =
-      fun class_infos ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_type.t Class_infos.concrete = concrete in
-        let pci_attributes = self#attributes pci_attributes in
-        let pci_loc = self#location pci_loc in
-        let pci_expr = self#class_type pci_expr in
+        let pci_expr = fa pci_expr in
         let pci_name = self#loc self#string pci_name in
         let pci_params = self#list (fun (x0, x1) -> let x0 = self#variance x0 in let x1 = self#core_type x1 in (x0, x1)) pci_params in
         let pci_virt = self#virtual_flag pci_virt in
@@ -1252,25 +1234,18 @@ class virtual iter =
     method include_declaration : Include_declaration.t -> unit  =
       fun include_declaration ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        self#include_infos_module_expr concrete
+        self#include_infos self#module_expr concrete
     method include_description : Include_description.t -> unit  =
       fun include_description ->
         let concrete = Include_description.to_concrete include_description in
-        self#include_infos_module_type concrete
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> unit  =
-      fun include_infos ->
+        self#include_infos self#module_type concrete
+    method include_infos : 'a . ('a node -> unit) -> 'a node Include_infos.t -> unit  =
+      fun fa include_infos ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_expr.t Include_infos.concrete = concrete in
+        let { pincl_attributes; pincl_loc; pincl_mod } : _ Include_infos.concrete = concrete in
         self#attributes pincl_attributes;
         self#location pincl_loc;
-        self#module_expr pincl_mod
-    method include_infos_module_type : Module_type.t Include_infos.t -> unit  =
-      fun include_infos ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_type.t Include_infos.concrete = concrete in
-        self#attributes pincl_attributes;
-        self#location pincl_loc;
-        self#module_type pincl_mod
+        fa pincl_mod
     method open_description : Open_description.t -> unit  =
       fun open_description ->
         let concrete = Open_description.to_concrete open_description in
@@ -1368,7 +1343,7 @@ class virtual iter =
     method class_declaration : Class_declaration.t -> unit  =
       fun class_declaration ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        self#class_infos_class_expr concrete
+        self#class_infos self#class_expr concrete
     method class_field_kind : Class_field_kind.t -> unit  =
       fun class_field_kind ->
         let concrete = Class_field_kind.to_concrete class_field_kind in
@@ -1451,28 +1426,18 @@ class virtual iter =
     method class_type_declaration : Class_type_declaration.t -> unit  =
       fun class_type_declaration ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        self#class_infos_class_type concrete
+        self#class_infos self#class_type concrete
     method class_description : Class_description.t -> unit  =
       fun class_description ->
         let concrete = Class_description.to_concrete class_description in
-        self#class_infos_class_type concrete
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> unit  =
-      fun class_infos ->
+        self#class_infos self#class_type concrete
+    method class_infos : 'a . ('a node -> unit) -> 'a node Class_infos.t -> unit  =
+      fun fa class_infos ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : _ Class_infos.concrete = concrete in
         self#attributes pci_attributes;
         self#location pci_loc;
-        self#class_expr pci_expr;
-        self#loc self#string pci_name;
-        self#list (fun (x0, x1) -> self#variance x0; self#core_type x1) pci_params;
-        self#virtual_flag pci_virt
-    method class_infos_class_type : Class_type.t Class_infos.t -> unit  =
-      fun class_infos ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_type.t Class_infos.concrete = concrete in
-        self#attributes pci_attributes;
-        self#location pci_loc;
-        self#class_type pci_expr;
+        fa pci_expr;
         self#loc self#string pci_name;
         self#list (fun (x0, x1) -> self#variance x0; self#core_type x1) pci_params;
         self#virtual_flag pci_virt
@@ -2187,28 +2152,20 @@ class virtual ['acc] fold =
     method include_declaration : Include_declaration.t -> 'acc -> 'acc  =
       fun include_declaration acc ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let acc = self#include_infos_module_expr concrete acc in
+        let acc = self#include_infos self#module_expr concrete acc in
         acc
     method include_description : Include_description.t -> 'acc -> 'acc  =
       fun include_description acc ->
         let concrete = Include_description.to_concrete include_description in
-        let acc = self#include_infos_module_type concrete acc in
+        let acc = self#include_infos self#module_type concrete acc in
         acc
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> 'acc  =
-      fun include_infos acc ->
+    method include_infos : 'a . ('a node -> 'acc -> 'acc) -> 'a node Include_infos.t -> 'acc -> 'acc  =
+      fun fa include_infos acc ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_expr.t Include_infos.concrete = concrete in
+        let { pincl_attributes; pincl_loc; pincl_mod } : _ Include_infos.concrete = concrete in
         let acc = self#attributes pincl_attributes acc in
         let acc = self#location pincl_loc acc in
-        let acc = self#module_expr pincl_mod acc in
-        acc
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'acc -> 'acc  =
-      fun include_infos acc ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_type.t Include_infos.concrete = concrete in
-        let acc = self#attributes pincl_attributes acc in
-        let acc = self#location pincl_loc acc in
-        let acc = self#module_type pincl_mod acc in
+        let acc = fa pincl_mod acc in
         acc
     method open_description : Open_description.t -> 'acc -> 'acc  =
       fun open_description acc ->
@@ -2333,7 +2290,7 @@ class virtual ['acc] fold =
     method class_declaration : Class_declaration.t -> 'acc -> 'acc  =
       fun class_declaration acc ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let acc = self#class_infos_class_expr concrete acc in
+        let acc = self#class_infos self#class_expr concrete acc in
         acc
     method class_field_kind : Class_field_kind.t -> 'acc -> 'acc  =
       fun class_field_kind acc ->
@@ -2437,31 +2394,20 @@ class virtual ['acc] fold =
     method class_type_declaration : Class_type_declaration.t -> 'acc -> 'acc  =
       fun class_type_declaration acc ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let acc = self#class_infos_class_type concrete acc in
+        let acc = self#class_infos self#class_type concrete acc in
         acc
     method class_description : Class_description.t -> 'acc -> 'acc  =
       fun class_description acc ->
         let concrete = Class_description.to_concrete class_description in
-        let acc = self#class_infos_class_type concrete acc in
+        let acc = self#class_infos self#class_type concrete acc in
         acc
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> 'acc  =
-      fun class_infos acc ->
+    method class_infos : 'a . ('a node -> 'acc -> 'acc) -> 'a node Class_infos.t -> 'acc -> 'acc  =
+      fun fa class_infos acc ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : _ Class_infos.concrete = concrete in
         let acc = self#attributes pci_attributes acc in
         let acc = self#location pci_loc acc in
-        let acc = self#class_expr pci_expr acc in
-        let acc = self#loc self#string pci_name acc in
-        let acc = self#list (fun (x0, x1) acc -> let acc = self#variance x0 acc in let acc = self#core_type x1 acc in acc) pci_params acc in
-        let acc = self#virtual_flag pci_virt acc in
-        acc
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'acc -> 'acc  =
-      fun class_infos acc ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_type.t Class_infos.concrete = concrete in
-        let acc = self#attributes pci_attributes acc in
-        let acc = self#location pci_loc acc in
-        let acc = self#class_type pci_expr acc in
+        let acc = fa pci_expr acc in
         let acc = self#loc self#string pci_name acc in
         let acc = self#list (fun (x0, x1) acc -> let acc = self#variance x0 acc in let acc = self#core_type x1 acc in acc) pci_params acc in
         let acc = self#virtual_flag pci_virt acc in
@@ -3292,28 +3238,20 @@ class virtual ['acc] fold_map =
     method include_declaration : Include_declaration.t -> 'acc -> (Include_declaration.t * 'acc)  =
       fun include_declaration acc ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let (concrete, acc) = self#include_infos_module_expr concrete acc in
+        let (concrete, acc) = self#include_infos self#module_expr concrete acc in
         (Include_declaration.of_concrete concrete, acc)
     method include_description : Include_description.t -> 'acc -> (Include_description.t * 'acc)  =
       fun include_description acc ->
         let concrete = Include_description.to_concrete include_description in
-        let (concrete, acc) = self#include_infos_module_type concrete acc in
+        let (concrete, acc) = self#include_infos self#module_type concrete acc in
         (Include_description.of_concrete concrete, acc)
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> (Module_expr.t Include_infos.t * 'acc)  =
-      fun include_infos acc ->
+    method include_infos : 'a . ('a node -> 'acc -> ('a node * 'acc)) -> 'a node Include_infos.t -> 'acc -> ('a node Include_infos.t * 'acc)  =
+      fun fa include_infos acc ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_expr.t Include_infos.concrete = concrete in
+        let { pincl_attributes; pincl_loc; pincl_mod } : _ Include_infos.concrete = concrete in
         let (pincl_attributes, acc) = self#attributes pincl_attributes acc in
         let (pincl_loc, acc) = self#location pincl_loc acc in
-        let (pincl_mod, acc) = self#module_expr pincl_mod acc in
-        (Include_infos.of_concrete { pincl_attributes; pincl_loc; pincl_mod }, acc)
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'acc -> (Module_type.t Include_infos.t * 'acc)  =
-      fun include_infos acc ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_type.t Include_infos.concrete = concrete in
-        let (pincl_attributes, acc) = self#attributes pincl_attributes acc in
-        let (pincl_loc, acc) = self#location pincl_loc acc in
-        let (pincl_mod, acc) = self#module_type pincl_mod acc in
+        let (pincl_mod, acc) = fa pincl_mod acc in
         (Include_infos.of_concrete { pincl_attributes; pincl_loc; pincl_mod }, acc)
     method open_description : Open_description.t -> 'acc -> (Open_description.t * 'acc)  =
       fun open_description acc ->
@@ -3438,7 +3376,7 @@ class virtual ['acc] fold_map =
     method class_declaration : Class_declaration.t -> 'acc -> (Class_declaration.t * 'acc)  =
       fun class_declaration acc ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let (concrete, acc) = self#class_infos_class_expr concrete acc in
+        let (concrete, acc) = self#class_infos self#class_expr concrete acc in
         (Class_declaration.of_concrete concrete, acc)
     method class_field_kind : Class_field_kind.t -> 'acc -> (Class_field_kind.t * 'acc)  =
       fun class_field_kind acc ->
@@ -3542,31 +3480,20 @@ class virtual ['acc] fold_map =
     method class_type_declaration : Class_type_declaration.t -> 'acc -> (Class_type_declaration.t * 'acc)  =
       fun class_type_declaration acc ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let (concrete, acc) = self#class_infos_class_type concrete acc in
+        let (concrete, acc) = self#class_infos self#class_type concrete acc in
         (Class_type_declaration.of_concrete concrete, acc)
     method class_description : Class_description.t -> 'acc -> (Class_description.t * 'acc)  =
       fun class_description acc ->
         let concrete = Class_description.to_concrete class_description in
-        let (concrete, acc) = self#class_infos_class_type concrete acc in
+        let (concrete, acc) = self#class_infos self#class_type concrete acc in
         (Class_description.of_concrete concrete, acc)
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> (Class_expr.t Class_infos.t * 'acc)  =
-      fun class_infos acc ->
+    method class_infos : 'a . ('a node -> 'acc -> ('a node * 'acc)) -> 'a node Class_infos.t -> 'acc -> ('a node Class_infos.t * 'acc)  =
+      fun fa class_infos acc ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : _ Class_infos.concrete = concrete in
         let (pci_attributes, acc) = self#attributes pci_attributes acc in
         let (pci_loc, acc) = self#location pci_loc acc in
-        let (pci_expr, acc) = self#class_expr pci_expr acc in
-        let (pci_name, acc) = self#loc self#string pci_name acc in
-        let (pci_params, acc) = self#list (fun (x0, x1) acc -> let (x0, acc) = self#variance x0 acc in let (x1, acc) = self#core_type x1 acc in ((x0, x1), acc)) pci_params acc in
-        let (pci_virt, acc) = self#virtual_flag pci_virt acc in
-        (Class_infos.of_concrete { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt }, acc)
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'acc -> (Class_type.t Class_infos.t * 'acc)  =
-      fun class_infos acc ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_type.t Class_infos.concrete = concrete in
-        let (pci_attributes, acc) = self#attributes pci_attributes acc in
-        let (pci_loc, acc) = self#location pci_loc acc in
-        let (pci_expr, acc) = self#class_type pci_expr acc in
+        let (pci_expr, acc) = fa pci_expr acc in
         let (pci_name, acc) = self#loc self#string pci_name acc in
         let (pci_params, acc) = self#list (fun (x0, x1) acc -> let (x0, acc) = self#variance x0 acc in let (x1, acc) = self#core_type x1 acc in ((x0, x1), acc)) pci_params acc in
         let (pci_virt, acc) = self#virtual_flag pci_virt acc in
@@ -4397,28 +4324,20 @@ class virtual ['ctx] map_with_context =
     method include_declaration : 'ctx -> Include_declaration.t -> Include_declaration.t  =
       fun _ctx include_declaration ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let concrete = self#include_infos_module_expr _ctx concrete in
+        let concrete = self#include_infos self#module_expr _ctx concrete in
         Include_declaration.of_concrete concrete
     method include_description : 'ctx -> Include_description.t -> Include_description.t  =
       fun _ctx include_description ->
         let concrete = Include_description.to_concrete include_description in
-        let concrete = self#include_infos_module_type _ctx concrete in
+        let concrete = self#include_infos self#module_type _ctx concrete in
         Include_description.of_concrete concrete
-    method include_infos_module_expr : 'ctx -> Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t  =
-      fun _ctx include_infos ->
+    method include_infos : 'a . ('ctx -> 'a node -> 'a node) -> 'ctx -> 'a node Include_infos.t -> 'a node Include_infos.t  =
+      fun fa _ctx include_infos ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_expr.t Include_infos.concrete = concrete in
+        let { pincl_attributes; pincl_loc; pincl_mod } : _ Include_infos.concrete = concrete in
         let pincl_attributes = self#attributes _ctx pincl_attributes in
         let pincl_loc = self#location _ctx pincl_loc in
-        let pincl_mod = self#module_expr _ctx pincl_mod in
-        Include_infos.of_concrete { pincl_attributes; pincl_loc; pincl_mod }
-    method include_infos_module_type : 'ctx -> Module_type.t Include_infos.t -> Module_type.t Include_infos.t  =
-      fun _ctx include_infos ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_type.t Include_infos.concrete = concrete in
-        let pincl_attributes = self#attributes _ctx pincl_attributes in
-        let pincl_loc = self#location _ctx pincl_loc in
-        let pincl_mod = self#module_type _ctx pincl_mod in
+        let pincl_mod = fa _ctx pincl_mod in
         Include_infos.of_concrete { pincl_attributes; pincl_loc; pincl_mod }
     method open_description : 'ctx -> Open_description.t -> Open_description.t  =
       fun _ctx open_description ->
@@ -4543,7 +4462,7 @@ class virtual ['ctx] map_with_context =
     method class_declaration : 'ctx -> Class_declaration.t -> Class_declaration.t  =
       fun _ctx class_declaration ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let concrete = self#class_infos_class_expr _ctx concrete in
+        let concrete = self#class_infos self#class_expr _ctx concrete in
         Class_declaration.of_concrete concrete
     method class_field_kind : 'ctx -> Class_field_kind.t -> Class_field_kind.t  =
       fun _ctx class_field_kind ->
@@ -4647,31 +4566,20 @@ class virtual ['ctx] map_with_context =
     method class_type_declaration : 'ctx -> Class_type_declaration.t -> Class_type_declaration.t  =
       fun _ctx class_type_declaration ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let concrete = self#class_infos_class_type _ctx concrete in
+        let concrete = self#class_infos self#class_type _ctx concrete in
         Class_type_declaration.of_concrete concrete
     method class_description : 'ctx -> Class_description.t -> Class_description.t  =
       fun _ctx class_description ->
         let concrete = Class_description.to_concrete class_description in
-        let concrete = self#class_infos_class_type _ctx concrete in
+        let concrete = self#class_infos self#class_type _ctx concrete in
         Class_description.of_concrete concrete
-    method class_infos_class_expr : 'ctx -> Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t  =
-      fun _ctx class_infos ->
+    method class_infos : 'a . ('ctx -> 'a node -> 'a node) -> 'ctx -> 'a node Class_infos.t -> 'a node Class_infos.t  =
+      fun fa _ctx class_infos ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : _ Class_infos.concrete = concrete in
         let pci_attributes = self#attributes _ctx pci_attributes in
         let pci_loc = self#location _ctx pci_loc in
-        let pci_expr = self#class_expr _ctx pci_expr in
-        let pci_name = self#loc self#string _ctx pci_name in
-        let pci_params = self#list (fun _ctx (x0, x1) -> let x0 = self#variance _ctx x0 in let x1 = self#core_type _ctx x1 in (x0, x1)) _ctx pci_params in
-        let pci_virt = self#virtual_flag _ctx pci_virt in
-        Class_infos.of_concrete { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt }
-    method class_infos_class_type : 'ctx -> Class_type.t Class_infos.t -> Class_type.t Class_infos.t  =
-      fun _ctx class_infos ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_type.t Class_infos.concrete = concrete in
-        let pci_attributes = self#attributes _ctx pci_attributes in
-        let pci_loc = self#location _ctx pci_loc in
-        let pci_expr = self#class_type _ctx pci_expr in
+        let pci_expr = fa _ctx pci_expr in
         let pci_name = self#loc self#string _ctx pci_name in
         let pci_params = self#list (fun _ctx (x0, x1) -> let x0 = self#variance _ctx x0 in let x1 = self#core_type _ctx x1 in (x0, x1)) _ctx pci_params in
         let pci_virt = self#virtual_flag _ctx pci_virt in
@@ -5506,28 +5414,20 @@ class virtual ['res] lift =
     method include_declaration : Include_declaration.t -> 'res  =
       fun include_declaration ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let concrete = self#include_infos_module_expr concrete in
+        let concrete = self#include_infos self#module_expr concrete in
         self#node (Some ("include_declaration", 0)) concrete
     method include_description : Include_description.t -> 'res  =
       fun include_description ->
         let concrete = Include_description.to_concrete include_description in
-        let concrete = self#include_infos_module_type concrete in
+        let concrete = self#include_infos self#module_type concrete in
         self#node (Some ("include_description", 0)) concrete
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'res  =
-      fun include_infos ->
+    method include_infos : 'a . ('a node -> 'res) -> 'a node Include_infos.t -> 'res  =
+      fun fa include_infos ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_expr.t Include_infos.concrete = concrete in
+        let { pincl_attributes; pincl_loc; pincl_mod } : _ Include_infos.concrete = concrete in
         let pincl_attributes = self#attributes pincl_attributes in
         let pincl_loc = self#location pincl_loc in
-        let pincl_mod = self#module_expr pincl_mod in
-        self#record (Some ("include_infos", 1)) [("pincl_attributes", pincl_attributes); ("pincl_loc", pincl_loc); ("pincl_mod", pincl_mod)]
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'res  =
-      fun include_infos ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_attributes; pincl_loc; pincl_mod } : Module_type.t Include_infos.concrete = concrete in
-        let pincl_attributes = self#attributes pincl_attributes in
-        let pincl_loc = self#location pincl_loc in
-        let pincl_mod = self#module_type pincl_mod in
+        let pincl_mod = fa pincl_mod in
         self#record (Some ("include_infos", 1)) [("pincl_attributes", pincl_attributes); ("pincl_loc", pincl_loc); ("pincl_mod", pincl_mod)]
     method open_description : Open_description.t -> 'res  =
       fun open_description ->
@@ -5652,7 +5552,7 @@ class virtual ['res] lift =
     method class_declaration : Class_declaration.t -> 'res  =
       fun class_declaration ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let concrete = self#class_infos_class_expr concrete in
+        let concrete = self#class_infos self#class_expr concrete in
         self#node (Some ("class_declaration", 0)) concrete
     method class_field_kind : Class_field_kind.t -> 'res  =
       fun class_field_kind ->
@@ -5756,31 +5656,20 @@ class virtual ['res] lift =
     method class_type_declaration : Class_type_declaration.t -> 'res  =
       fun class_type_declaration ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let concrete = self#class_infos_class_type concrete in
+        let concrete = self#class_infos self#class_type concrete in
         self#node (Some ("class_type_declaration", 0)) concrete
     method class_description : Class_description.t -> 'res  =
       fun class_description ->
         let concrete = Class_description.to_concrete class_description in
-        let concrete = self#class_infos_class_type concrete in
+        let concrete = self#class_infos self#class_type concrete in
         self#node (Some ("class_description", 0)) concrete
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'res  =
-      fun class_infos ->
+    method class_infos : 'a . ('a node -> 'res) -> 'a node Class_infos.t -> 'res  =
+      fun fa class_infos ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : _ Class_infos.concrete = concrete in
         let pci_attributes = self#attributes pci_attributes in
         let pci_loc = self#location pci_loc in
-        let pci_expr = self#class_expr pci_expr in
-        let pci_name = self#loc self#string pci_name in
-        let pci_params = self#list (fun (x0, x1) -> let x0 = self#variance x0 in let x1 = self#core_type x1 in self#node None (self#tuple [x0; x1])) pci_params in
-        let pci_virt = self#virtual_flag pci_virt in
-        self#record (Some ("class_infos", 1)) [("pci_attributes", pci_attributes); ("pci_loc", pci_loc); ("pci_expr", pci_expr); ("pci_name", pci_name); ("pci_params", pci_params); ("pci_virt", pci_virt)]
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'res  =
-      fun class_infos ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_attributes; pci_loc; pci_expr; pci_name; pci_params; pci_virt } : Class_type.t Class_infos.concrete = concrete in
-        let pci_attributes = self#attributes pci_attributes in
-        let pci_loc = self#location pci_loc in
-        let pci_expr = self#class_type pci_expr in
+        let pci_expr = fa pci_expr in
         let pci_name = self#loc self#string pci_name in
         let pci_params = self#list (fun (x0, x1) -> let x0 = self#variance x0 in let x1 = self#core_type x1 in self#node None (self#tuple [x0; x1])) pci_params in
         let pci_virt = self#virtual_flag pci_virt in

--- a/ast/virtual_traverse_unstable_for_testing.mli
+++ b/ast/virtual_traverse_unstable_for_testing.mli
@@ -1,3 +1,4 @@
+open Unversioned.Types
 (*$ Ppx_ast_cinaps.print_virtual_traverse_mli (Astlib.Version.of_string "unstable_for_testing") *)
 open Versions.Unstable_for_testing
 
@@ -23,8 +24,7 @@ class virtual map :
     method with_constraint : With_constraint.t -> With_constraint.t
     method include_declaration : Include_declaration.t -> Include_declaration.t
     method include_description : Include_description.t -> Include_description.t
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t
-    method include_infos_module_type : Module_type.t Include_infos.t -> Module_type.t Include_infos.t
+    method include_infos : 'a . ('a node -> 'a node) -> 'a node Include_infos.t -> 'a node Include_infos.t
     method open_description : Open_description.t -> Open_description.t
     method module_type_declaration : Module_type_declaration.t -> Module_type_declaration.t
     method module_declaration : Module_declaration.t -> Module_declaration.t
@@ -42,8 +42,7 @@ class virtual map :
     method class_expr : Class_expr.t -> Class_expr.t
     method class_type_declaration : Class_type_declaration.t -> Class_type_declaration.t
     method class_description : Class_description.t -> Class_description.t
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t
-    method class_infos_class_type : Class_type.t Class_infos.t -> Class_type.t Class_infos.t
+    method class_infos : 'a . ('a node -> 'a node) -> 'a node Class_infos.t -> 'a node Class_infos.t
     method class_type_field_desc : Class_type_field_desc.t -> Class_type_field_desc.t
     method class_type_field : Class_type_field.t -> Class_type_field.t
     method class_signature : Class_signature.t -> Class_signature.t
@@ -108,8 +107,7 @@ class virtual iter :
     method with_constraint : With_constraint.t -> unit
     method include_declaration : Include_declaration.t -> unit
     method include_description : Include_description.t -> unit
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> unit
-    method include_infos_module_type : Module_type.t Include_infos.t -> unit
+    method include_infos : 'a . ('a node -> unit) -> 'a node Include_infos.t -> unit
     method open_description : Open_description.t -> unit
     method module_type_declaration : Module_type_declaration.t -> unit
     method module_declaration : Module_declaration.t -> unit
@@ -127,8 +125,7 @@ class virtual iter :
     method class_expr : Class_expr.t -> unit
     method class_type_declaration : Class_type_declaration.t -> unit
     method class_description : Class_description.t -> unit
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> unit
-    method class_infos_class_type : Class_type.t Class_infos.t -> unit
+    method class_infos : 'a . ('a node -> unit) -> 'a node Class_infos.t -> unit
     method class_type_field_desc : Class_type_field_desc.t -> unit
     method class_type_field : Class_type_field.t -> unit
     method class_signature : Class_signature.t -> unit
@@ -193,8 +190,7 @@ class virtual ['acc] fold :
     method with_constraint : With_constraint.t -> 'acc -> 'acc
     method include_declaration : Include_declaration.t -> 'acc -> 'acc
     method include_description : Include_description.t -> 'acc -> 'acc
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> 'acc
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'acc -> 'acc
+    method include_infos : 'a . ('a node -> 'acc -> 'acc) -> 'a node Include_infos.t -> 'acc -> 'acc
     method open_description : Open_description.t -> 'acc -> 'acc
     method module_type_declaration : Module_type_declaration.t -> 'acc -> 'acc
     method module_declaration : Module_declaration.t -> 'acc -> 'acc
@@ -212,8 +208,7 @@ class virtual ['acc] fold :
     method class_expr : Class_expr.t -> 'acc -> 'acc
     method class_type_declaration : Class_type_declaration.t -> 'acc -> 'acc
     method class_description : Class_description.t -> 'acc -> 'acc
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> 'acc
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'acc -> 'acc
+    method class_infos : 'a . ('a node -> 'acc -> 'acc) -> 'a node Class_infos.t -> 'acc -> 'acc
     method class_type_field_desc : Class_type_field_desc.t -> 'acc -> 'acc
     method class_type_field : Class_type_field.t -> 'acc -> 'acc
     method class_signature : Class_signature.t -> 'acc -> 'acc
@@ -278,8 +273,7 @@ class virtual ['acc] fold_map :
     method with_constraint : With_constraint.t -> 'acc -> (With_constraint.t * 'acc)
     method include_declaration : Include_declaration.t -> 'acc -> (Include_declaration.t * 'acc)
     method include_description : Include_description.t -> 'acc -> (Include_description.t * 'acc)
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> (Module_expr.t Include_infos.t * 'acc)
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'acc -> (Module_type.t Include_infos.t * 'acc)
+    method include_infos : 'a . ('a node -> 'acc -> ('a node * 'acc)) -> 'a node Include_infos.t -> 'acc -> ('a node Include_infos.t * 'acc)
     method open_description : Open_description.t -> 'acc -> (Open_description.t * 'acc)
     method module_type_declaration : Module_type_declaration.t -> 'acc -> (Module_type_declaration.t * 'acc)
     method module_declaration : Module_declaration.t -> 'acc -> (Module_declaration.t * 'acc)
@@ -297,8 +291,7 @@ class virtual ['acc] fold_map :
     method class_expr : Class_expr.t -> 'acc -> (Class_expr.t * 'acc)
     method class_type_declaration : Class_type_declaration.t -> 'acc -> (Class_type_declaration.t * 'acc)
     method class_description : Class_description.t -> 'acc -> (Class_description.t * 'acc)
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> (Class_expr.t Class_infos.t * 'acc)
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'acc -> (Class_type.t Class_infos.t * 'acc)
+    method class_infos : 'a . ('a node -> 'acc -> ('a node * 'acc)) -> 'a node Class_infos.t -> 'acc -> ('a node Class_infos.t * 'acc)
     method class_type_field_desc : Class_type_field_desc.t -> 'acc -> (Class_type_field_desc.t * 'acc)
     method class_type_field : Class_type_field.t -> 'acc -> (Class_type_field.t * 'acc)
     method class_signature : Class_signature.t -> 'acc -> (Class_signature.t * 'acc)
@@ -363,8 +356,7 @@ class virtual ['ctx] map_with_context :
     method with_constraint : 'ctx -> With_constraint.t -> With_constraint.t
     method include_declaration : 'ctx -> Include_declaration.t -> Include_declaration.t
     method include_description : 'ctx -> Include_description.t -> Include_description.t
-    method include_infos_module_expr : 'ctx -> Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t
-    method include_infos_module_type : 'ctx -> Module_type.t Include_infos.t -> Module_type.t Include_infos.t
+    method include_infos : 'a . ('ctx -> 'a node -> 'a node) -> 'ctx -> 'a node Include_infos.t -> 'a node Include_infos.t
     method open_description : 'ctx -> Open_description.t -> Open_description.t
     method module_type_declaration : 'ctx -> Module_type_declaration.t -> Module_type_declaration.t
     method module_declaration : 'ctx -> Module_declaration.t -> Module_declaration.t
@@ -382,8 +374,7 @@ class virtual ['ctx] map_with_context :
     method class_expr : 'ctx -> Class_expr.t -> Class_expr.t
     method class_type_declaration : 'ctx -> Class_type_declaration.t -> Class_type_declaration.t
     method class_description : 'ctx -> Class_description.t -> Class_description.t
-    method class_infos_class_expr : 'ctx -> Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t
-    method class_infos_class_type : 'ctx -> Class_type.t Class_infos.t -> Class_type.t Class_infos.t
+    method class_infos : 'a . ('ctx -> 'a node -> 'a node) -> 'ctx -> 'a node Class_infos.t -> 'a node Class_infos.t
     method class_type_field_desc : 'ctx -> Class_type_field_desc.t -> Class_type_field_desc.t
     method class_type_field : 'ctx -> Class_type_field.t -> Class_type_field.t
     method class_signature : 'ctx -> Class_signature.t -> Class_signature.t
@@ -452,8 +443,7 @@ class virtual ['res] lift :
     method with_constraint : With_constraint.t -> 'res
     method include_declaration : Include_declaration.t -> 'res
     method include_description : Include_description.t -> 'res
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'res
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'res
+    method include_infos : 'a . ('a node -> 'res) -> 'a node Include_infos.t -> 'res
     method open_description : Open_description.t -> 'res
     method module_type_declaration : Module_type_declaration.t -> 'res
     method module_declaration : Module_declaration.t -> 'res
@@ -471,8 +461,7 @@ class virtual ['res] lift :
     method class_expr : Class_expr.t -> 'res
     method class_type_declaration : Class_type_declaration.t -> 'res
     method class_description : Class_description.t -> 'res
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'res
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'res
+    method class_infos : 'a . ('a node -> 'res) -> 'a node Class_infos.t -> 'res
     method class_type_field_desc : Class_type_field_desc.t -> 'res
     method class_type_field : Class_type_field.t -> 'res
     method class_signature : Class_signature.t -> 'res

--- a/ast/virtual_traverse_v4_07.ml
+++ b/ast/virtual_traverse_v4_07.ml
@@ -1,3 +1,4 @@
+open Unversioned.Types
 (*$ Ppx_ast_cinaps.print_virtual_traverse_ml (Astlib.Version.of_string "v4_07") *)
 open Versions.V4_07
 
@@ -652,37 +653,26 @@ class virtual map =
         | Pctf_extension x0 ->
           let x0 = self#extension x0 in
           Class_type_field_desc.of_concrete (Pctf_extension x0)
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t  =
-      fun class_infos ->
+    method class_infos : 'a . ('a node -> 'a node) -> 'a node Class_infos.t -> 'a node Class_infos.t  =
+      fun fa class_infos ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : _ Class_infos.concrete = concrete in
         let pci_virt = self#virtual_flag pci_virt in
         let pci_params = self#list (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#variance x1 in (x0, x1)) pci_params in
         let pci_name = self#loc self#string pci_name in
-        let pci_expr = self#class_expr pci_expr in
-        let pci_loc = self#location pci_loc in
-        let pci_attributes = self#attributes pci_attributes in
-        Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
-    method class_infos_class_type : Class_type.t Class_infos.t -> Class_type.t Class_infos.t  =
-      fun class_infos ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
-        let pci_virt = self#virtual_flag pci_virt in
-        let pci_params = self#list (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#variance x1 in (x0, x1)) pci_params in
-        let pci_name = self#loc self#string pci_name in
-        let pci_expr = self#class_type pci_expr in
+        let pci_expr = fa pci_expr in
         let pci_loc = self#location pci_loc in
         let pci_attributes = self#attributes pci_attributes in
         Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
     method class_description : Class_description.t -> Class_description.t  =
       fun class_description ->
         let concrete = Class_description.to_concrete class_description in
-        let concrete = self#class_infos_class_type concrete in
+        let concrete = self#class_infos self#class_type concrete in
         Class_description.of_concrete concrete
     method class_type_declaration : Class_type_declaration.t -> Class_type_declaration.t  =
       fun class_type_declaration ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let concrete = self#class_infos_class_type concrete in
+        let concrete = self#class_infos self#class_type concrete in
         Class_type_declaration.of_concrete concrete
     method class_expr : Class_expr.t -> Class_expr.t  =
       fun class_expr ->
@@ -786,7 +776,7 @@ class virtual map =
     method class_declaration : Class_declaration.t -> Class_declaration.t  =
       fun class_declaration ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let concrete = self#class_infos_class_expr concrete in
+        let concrete = self#class_infos self#class_expr concrete in
         Class_declaration.of_concrete concrete
     method module_type : Module_type.t -> Module_type.t  =
       fun module_type ->
@@ -908,31 +898,23 @@ class virtual map =
         let popen_loc = self#location popen_loc in
         let popen_attributes = self#attributes popen_attributes in
         Open_description.of_concrete { popen_lid; popen_override; popen_loc; popen_attributes }
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t  =
-      fun include_infos ->
+    method include_infos : 'a . ('a node -> 'a node) -> 'a node Include_infos.t -> 'a node Include_infos.t  =
+      fun fa include_infos ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
-        let pincl_mod = self#module_expr pincl_mod in
-        let pincl_loc = self#location pincl_loc in
-        let pincl_attributes = self#attributes pincl_attributes in
-        Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }
-    method include_infos_module_type : Module_type.t Include_infos.t -> Module_type.t Include_infos.t  =
-      fun include_infos ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
-        let pincl_mod = self#module_type pincl_mod in
+        let { pincl_mod; pincl_loc; pincl_attributes } : _ Include_infos.concrete = concrete in
+        let pincl_mod = fa pincl_mod in
         let pincl_loc = self#location pincl_loc in
         let pincl_attributes = self#attributes pincl_attributes in
         Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }
     method include_description : Include_description.t -> Include_description.t  =
       fun include_description ->
         let concrete = Include_description.to_concrete include_description in
-        let concrete = self#include_infos_module_type concrete in
+        let concrete = self#include_infos self#module_type concrete in
         Include_description.of_concrete concrete
     method include_declaration : Include_declaration.t -> Include_declaration.t  =
       fun include_declaration ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let concrete = self#include_infos_module_expr concrete in
+        let concrete = self#include_infos self#module_expr concrete in
         Include_declaration.of_concrete concrete
     method with_constraint : With_constraint.t -> With_constraint.t  =
       fun with_constraint ->
@@ -1642,34 +1624,24 @@ class virtual iter =
           self#attribute x0
         | Pctf_extension x0 ->
           self#extension x0
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> unit  =
-      fun class_infos ->
+    method class_infos : 'a . ('a node -> unit) -> 'a node Class_infos.t -> unit  =
+      fun fa class_infos ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : _ Class_infos.concrete = concrete in
         self#virtual_flag pci_virt;
         self#list (fun (x0, x1) -> self#core_type x0; self#variance x1) pci_params;
         self#loc self#string pci_name;
-        self#class_expr pci_expr;
-        self#location pci_loc;
-        self#attributes pci_attributes
-    method class_infos_class_type : Class_type.t Class_infos.t -> unit  =
-      fun class_infos ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
-        self#virtual_flag pci_virt;
-        self#list (fun (x0, x1) -> self#core_type x0; self#variance x1) pci_params;
-        self#loc self#string pci_name;
-        self#class_type pci_expr;
+        fa pci_expr;
         self#location pci_loc;
         self#attributes pci_attributes
     method class_description : Class_description.t -> unit  =
       fun class_description ->
         let concrete = Class_description.to_concrete class_description in
-        self#class_infos_class_type concrete
+        self#class_infos self#class_type concrete
     method class_type_declaration : Class_type_declaration.t -> unit  =
       fun class_type_declaration ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        self#class_infos_class_type concrete
+        self#class_infos self#class_type concrete
     method class_expr : Class_expr.t -> unit  =
       fun class_expr ->
         let concrete = Class_expr.to_concrete class_expr in
@@ -1752,7 +1724,7 @@ class virtual iter =
     method class_declaration : Class_declaration.t -> unit  =
       fun class_declaration ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        self#class_infos_class_expr concrete
+        self#class_infos self#class_expr concrete
     method module_type : Module_type.t -> unit  =
       fun module_type ->
         let concrete = Module_type.to_concrete module_type in
@@ -1847,28 +1819,21 @@ class virtual iter =
         self#override_flag popen_override;
         self#location popen_loc;
         self#attributes popen_attributes
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> unit  =
-      fun include_infos ->
+    method include_infos : 'a . ('a node -> unit) -> 'a node Include_infos.t -> unit  =
+      fun fa include_infos ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
-        self#module_expr pincl_mod;
-        self#location pincl_loc;
-        self#attributes pincl_attributes
-    method include_infos_module_type : Module_type.t Include_infos.t -> unit  =
-      fun include_infos ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
-        self#module_type pincl_mod;
+        let { pincl_mod; pincl_loc; pincl_attributes } : _ Include_infos.concrete = concrete in
+        fa pincl_mod;
         self#location pincl_loc;
         self#attributes pincl_attributes
     method include_description : Include_description.t -> unit  =
       fun include_description ->
         let concrete = Include_description.to_concrete include_description in
-        self#include_infos_module_type concrete
+        self#include_infos self#module_type concrete
     method include_declaration : Include_declaration.t -> unit  =
       fun include_declaration ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        self#include_infos_module_expr concrete
+        self#include_infos self#module_expr concrete
     method with_constraint : With_constraint.t -> unit  =
       fun with_constraint ->
         let concrete = With_constraint.to_concrete with_constraint in
@@ -2655,37 +2620,26 @@ class virtual ['acc] fold =
         | Pctf_extension x0 ->
           let acc = self#extension x0 acc in
           acc
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> 'acc  =
-      fun class_infos acc ->
+    method class_infos : 'a . ('a node -> 'acc -> 'acc) -> 'a node Class_infos.t -> 'acc -> 'acc  =
+      fun fa class_infos acc ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : _ Class_infos.concrete = concrete in
         let acc = self#virtual_flag pci_virt acc in
         let acc = self#list (fun (x0, x1) acc -> let acc = self#core_type x0 acc in let acc = self#variance x1 acc in acc) pci_params acc in
         let acc = self#loc self#string pci_name acc in
-        let acc = self#class_expr pci_expr acc in
-        let acc = self#location pci_loc acc in
-        let acc = self#attributes pci_attributes acc in
-        acc
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'acc -> 'acc  =
-      fun class_infos acc ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
-        let acc = self#virtual_flag pci_virt acc in
-        let acc = self#list (fun (x0, x1) acc -> let acc = self#core_type x0 acc in let acc = self#variance x1 acc in acc) pci_params acc in
-        let acc = self#loc self#string pci_name acc in
-        let acc = self#class_type pci_expr acc in
+        let acc = fa pci_expr acc in
         let acc = self#location pci_loc acc in
         let acc = self#attributes pci_attributes acc in
         acc
     method class_description : Class_description.t -> 'acc -> 'acc  =
       fun class_description acc ->
         let concrete = Class_description.to_concrete class_description in
-        let acc = self#class_infos_class_type concrete acc in
+        let acc = self#class_infos self#class_type concrete acc in
         acc
     method class_type_declaration : Class_type_declaration.t -> 'acc -> 'acc  =
       fun class_type_declaration acc ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let acc = self#class_infos_class_type concrete acc in
+        let acc = self#class_infos self#class_type concrete acc in
         acc
     method class_expr : Class_expr.t -> 'acc -> 'acc  =
       fun class_expr acc ->
@@ -2789,7 +2743,7 @@ class virtual ['acc] fold =
     method class_declaration : Class_declaration.t -> 'acc -> 'acc  =
       fun class_declaration acc ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let acc = self#class_infos_class_expr concrete acc in
+        let acc = self#class_infos self#class_expr concrete acc in
         acc
     method module_type : Module_type.t -> 'acc -> 'acc  =
       fun module_type acc ->
@@ -2911,31 +2865,23 @@ class virtual ['acc] fold =
         let acc = self#location popen_loc acc in
         let acc = self#attributes popen_attributes acc in
         acc
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> 'acc  =
-      fun include_infos acc ->
+    method include_infos : 'a . ('a node -> 'acc -> 'acc) -> 'a node Include_infos.t -> 'acc -> 'acc  =
+      fun fa include_infos acc ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
-        let acc = self#module_expr pincl_mod acc in
-        let acc = self#location pincl_loc acc in
-        let acc = self#attributes pincl_attributes acc in
-        acc
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'acc -> 'acc  =
-      fun include_infos acc ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
-        let acc = self#module_type pincl_mod acc in
+        let { pincl_mod; pincl_loc; pincl_attributes } : _ Include_infos.concrete = concrete in
+        let acc = fa pincl_mod acc in
         let acc = self#location pincl_loc acc in
         let acc = self#attributes pincl_attributes acc in
         acc
     method include_description : Include_description.t -> 'acc -> 'acc  =
       fun include_description acc ->
         let concrete = Include_description.to_concrete include_description in
-        let acc = self#include_infos_module_type concrete acc in
+        let acc = self#include_infos self#module_type concrete acc in
         acc
     method include_declaration : Include_declaration.t -> 'acc -> 'acc  =
       fun include_declaration acc ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let acc = self#include_infos_module_expr concrete acc in
+        let acc = self#include_infos self#module_expr concrete acc in
         acc
     method with_constraint : With_constraint.t -> 'acc -> 'acc  =
       fun with_constraint acc ->
@@ -3760,37 +3706,26 @@ class virtual ['acc] fold_map =
         | Pctf_extension x0 ->
           let (x0, acc) = self#extension x0 acc in
           (Class_type_field_desc.of_concrete (Pctf_extension x0), acc)
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> (Class_expr.t Class_infos.t * 'acc)  =
-      fun class_infos acc ->
+    method class_infos : 'a . ('a node -> 'acc -> ('a node * 'acc)) -> 'a node Class_infos.t -> 'acc -> ('a node Class_infos.t * 'acc)  =
+      fun fa class_infos acc ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : _ Class_infos.concrete = concrete in
         let (pci_virt, acc) = self#virtual_flag pci_virt acc in
         let (pci_params, acc) = self#list (fun (x0, x1) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#variance x1 acc in ((x0, x1), acc)) pci_params acc in
         let (pci_name, acc) = self#loc self#string pci_name acc in
-        let (pci_expr, acc) = self#class_expr pci_expr acc in
-        let (pci_loc, acc) = self#location pci_loc acc in
-        let (pci_attributes, acc) = self#attributes pci_attributes acc in
-        (Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }, acc)
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'acc -> (Class_type.t Class_infos.t * 'acc)  =
-      fun class_infos acc ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
-        let (pci_virt, acc) = self#virtual_flag pci_virt acc in
-        let (pci_params, acc) = self#list (fun (x0, x1) acc -> let (x0, acc) = self#core_type x0 acc in let (x1, acc) = self#variance x1 acc in ((x0, x1), acc)) pci_params acc in
-        let (pci_name, acc) = self#loc self#string pci_name acc in
-        let (pci_expr, acc) = self#class_type pci_expr acc in
+        let (pci_expr, acc) = fa pci_expr acc in
         let (pci_loc, acc) = self#location pci_loc acc in
         let (pci_attributes, acc) = self#attributes pci_attributes acc in
         (Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }, acc)
     method class_description : Class_description.t -> 'acc -> (Class_description.t * 'acc)  =
       fun class_description acc ->
         let concrete = Class_description.to_concrete class_description in
-        let (concrete, acc) = self#class_infos_class_type concrete acc in
+        let (concrete, acc) = self#class_infos self#class_type concrete acc in
         (Class_description.of_concrete concrete, acc)
     method class_type_declaration : Class_type_declaration.t -> 'acc -> (Class_type_declaration.t * 'acc)  =
       fun class_type_declaration acc ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let (concrete, acc) = self#class_infos_class_type concrete acc in
+        let (concrete, acc) = self#class_infos self#class_type concrete acc in
         (Class_type_declaration.of_concrete concrete, acc)
     method class_expr : Class_expr.t -> 'acc -> (Class_expr.t * 'acc)  =
       fun class_expr acc ->
@@ -3894,7 +3829,7 @@ class virtual ['acc] fold_map =
     method class_declaration : Class_declaration.t -> 'acc -> (Class_declaration.t * 'acc)  =
       fun class_declaration acc ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let (concrete, acc) = self#class_infos_class_expr concrete acc in
+        let (concrete, acc) = self#class_infos self#class_expr concrete acc in
         (Class_declaration.of_concrete concrete, acc)
     method module_type : Module_type.t -> 'acc -> (Module_type.t * 'acc)  =
       fun module_type acc ->
@@ -4016,31 +3951,23 @@ class virtual ['acc] fold_map =
         let (popen_loc, acc) = self#location popen_loc acc in
         let (popen_attributes, acc) = self#attributes popen_attributes acc in
         (Open_description.of_concrete { popen_lid; popen_override; popen_loc; popen_attributes }, acc)
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> (Module_expr.t Include_infos.t * 'acc)  =
-      fun include_infos acc ->
+    method include_infos : 'a . ('a node -> 'acc -> ('a node * 'acc)) -> 'a node Include_infos.t -> 'acc -> ('a node Include_infos.t * 'acc)  =
+      fun fa include_infos acc ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
-        let (pincl_mod, acc) = self#module_expr pincl_mod acc in
-        let (pincl_loc, acc) = self#location pincl_loc acc in
-        let (pincl_attributes, acc) = self#attributes pincl_attributes acc in
-        (Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }, acc)
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'acc -> (Module_type.t Include_infos.t * 'acc)  =
-      fun include_infos acc ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
-        let (pincl_mod, acc) = self#module_type pincl_mod acc in
+        let { pincl_mod; pincl_loc; pincl_attributes } : _ Include_infos.concrete = concrete in
+        let (pincl_mod, acc) = fa pincl_mod acc in
         let (pincl_loc, acc) = self#location pincl_loc acc in
         let (pincl_attributes, acc) = self#attributes pincl_attributes acc in
         (Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }, acc)
     method include_description : Include_description.t -> 'acc -> (Include_description.t * 'acc)  =
       fun include_description acc ->
         let concrete = Include_description.to_concrete include_description in
-        let (concrete, acc) = self#include_infos_module_type concrete acc in
+        let (concrete, acc) = self#include_infos self#module_type concrete acc in
         (Include_description.of_concrete concrete, acc)
     method include_declaration : Include_declaration.t -> 'acc -> (Include_declaration.t * 'acc)  =
       fun include_declaration acc ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let (concrete, acc) = self#include_infos_module_expr concrete acc in
+        let (concrete, acc) = self#include_infos self#module_expr concrete acc in
         (Include_declaration.of_concrete concrete, acc)
     method with_constraint : With_constraint.t -> 'acc -> (With_constraint.t * 'acc)  =
       fun with_constraint acc ->
@@ -4865,37 +4792,26 @@ class virtual ['ctx] map_with_context =
         | Pctf_extension x0 ->
           let x0 = self#extension _ctx x0 in
           Class_type_field_desc.of_concrete (Pctf_extension x0)
-    method class_infos_class_expr : 'ctx -> Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t  =
-      fun _ctx class_infos ->
+    method class_infos : 'a . ('ctx -> 'a node -> 'a node) -> 'ctx -> 'a node Class_infos.t -> 'a node Class_infos.t  =
+      fun fa _ctx class_infos ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : _ Class_infos.concrete = concrete in
         let pci_virt = self#virtual_flag _ctx pci_virt in
         let pci_params = self#list (fun _ctx (x0, x1) -> let x0 = self#core_type _ctx x0 in let x1 = self#variance _ctx x1 in (x0, x1)) _ctx pci_params in
         let pci_name = self#loc self#string _ctx pci_name in
-        let pci_expr = self#class_expr _ctx pci_expr in
-        let pci_loc = self#location _ctx pci_loc in
-        let pci_attributes = self#attributes _ctx pci_attributes in
-        Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
-    method class_infos_class_type : 'ctx -> Class_type.t Class_infos.t -> Class_type.t Class_infos.t  =
-      fun _ctx class_infos ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
-        let pci_virt = self#virtual_flag _ctx pci_virt in
-        let pci_params = self#list (fun _ctx (x0, x1) -> let x0 = self#core_type _ctx x0 in let x1 = self#variance _ctx x1 in (x0, x1)) _ctx pci_params in
-        let pci_name = self#loc self#string _ctx pci_name in
-        let pci_expr = self#class_type _ctx pci_expr in
+        let pci_expr = fa _ctx pci_expr in
         let pci_loc = self#location _ctx pci_loc in
         let pci_attributes = self#attributes _ctx pci_attributes in
         Class_infos.of_concrete { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes }
     method class_description : 'ctx -> Class_description.t -> Class_description.t  =
       fun _ctx class_description ->
         let concrete = Class_description.to_concrete class_description in
-        let concrete = self#class_infos_class_type _ctx concrete in
+        let concrete = self#class_infos self#class_type _ctx concrete in
         Class_description.of_concrete concrete
     method class_type_declaration : 'ctx -> Class_type_declaration.t -> Class_type_declaration.t  =
       fun _ctx class_type_declaration ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let concrete = self#class_infos_class_type _ctx concrete in
+        let concrete = self#class_infos self#class_type _ctx concrete in
         Class_type_declaration.of_concrete concrete
     method class_expr : 'ctx -> Class_expr.t -> Class_expr.t  =
       fun _ctx class_expr ->
@@ -4999,7 +4915,7 @@ class virtual ['ctx] map_with_context =
     method class_declaration : 'ctx -> Class_declaration.t -> Class_declaration.t  =
       fun _ctx class_declaration ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let concrete = self#class_infos_class_expr _ctx concrete in
+        let concrete = self#class_infos self#class_expr _ctx concrete in
         Class_declaration.of_concrete concrete
     method module_type : 'ctx -> Module_type.t -> Module_type.t  =
       fun _ctx module_type ->
@@ -5121,31 +5037,23 @@ class virtual ['ctx] map_with_context =
         let popen_loc = self#location _ctx popen_loc in
         let popen_attributes = self#attributes _ctx popen_attributes in
         Open_description.of_concrete { popen_lid; popen_override; popen_loc; popen_attributes }
-    method include_infos_module_expr : 'ctx -> Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t  =
-      fun _ctx include_infos ->
+    method include_infos : 'a . ('ctx -> 'a node -> 'a node) -> 'ctx -> 'a node Include_infos.t -> 'a node Include_infos.t  =
+      fun fa _ctx include_infos ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
-        let pincl_mod = self#module_expr _ctx pincl_mod in
-        let pincl_loc = self#location _ctx pincl_loc in
-        let pincl_attributes = self#attributes _ctx pincl_attributes in
-        Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }
-    method include_infos_module_type : 'ctx -> Module_type.t Include_infos.t -> Module_type.t Include_infos.t  =
-      fun _ctx include_infos ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
-        let pincl_mod = self#module_type _ctx pincl_mod in
+        let { pincl_mod; pincl_loc; pincl_attributes } : _ Include_infos.concrete = concrete in
+        let pincl_mod = fa _ctx pincl_mod in
         let pincl_loc = self#location _ctx pincl_loc in
         let pincl_attributes = self#attributes _ctx pincl_attributes in
         Include_infos.of_concrete { pincl_mod; pincl_loc; pincl_attributes }
     method include_description : 'ctx -> Include_description.t -> Include_description.t  =
       fun _ctx include_description ->
         let concrete = Include_description.to_concrete include_description in
-        let concrete = self#include_infos_module_type _ctx concrete in
+        let concrete = self#include_infos self#module_type _ctx concrete in
         Include_description.of_concrete concrete
     method include_declaration : 'ctx -> Include_declaration.t -> Include_declaration.t  =
       fun _ctx include_declaration ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let concrete = self#include_infos_module_expr _ctx concrete in
+        let concrete = self#include_infos self#module_expr _ctx concrete in
         Include_declaration.of_concrete concrete
     method with_constraint : 'ctx -> With_constraint.t -> With_constraint.t  =
       fun _ctx with_constraint ->
@@ -5974,37 +5882,26 @@ class virtual ['res] lift =
         | Pctf_extension x0 ->
           let x0 = self#extension x0 in
           self#constr (Some ("class_type_field_desc", 0)) "Pctf_extension" [x0]
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'res  =
-      fun class_infos ->
+    method class_infos : 'a . ('a node -> 'res) -> 'a node Class_infos.t -> 'res  =
+      fun fa class_infos ->
         let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_expr.t Class_infos.concrete = concrete in
+        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : _ Class_infos.concrete = concrete in
         let pci_virt = self#virtual_flag pci_virt in
         let pci_params = self#list (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#variance x1 in self#node None (self#tuple [x0; x1])) pci_params in
         let pci_name = self#loc self#string pci_name in
-        let pci_expr = self#class_expr pci_expr in
-        let pci_loc = self#location pci_loc in
-        let pci_attributes = self#attributes pci_attributes in
-        self#record (Some ("class_infos", 1)) [("pci_virt", pci_virt); ("pci_params", pci_params); ("pci_name", pci_name); ("pci_expr", pci_expr); ("pci_loc", pci_loc); ("pci_attributes", pci_attributes)]
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'res  =
-      fun class_infos ->
-        let concrete = Class_infos.to_concrete class_infos in
-        let { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } : Class_type.t Class_infos.concrete = concrete in
-        let pci_virt = self#virtual_flag pci_virt in
-        let pci_params = self#list (fun (x0, x1) -> let x0 = self#core_type x0 in let x1 = self#variance x1 in self#node None (self#tuple [x0; x1])) pci_params in
-        let pci_name = self#loc self#string pci_name in
-        let pci_expr = self#class_type pci_expr in
+        let pci_expr = fa pci_expr in
         let pci_loc = self#location pci_loc in
         let pci_attributes = self#attributes pci_attributes in
         self#record (Some ("class_infos", 1)) [("pci_virt", pci_virt); ("pci_params", pci_params); ("pci_name", pci_name); ("pci_expr", pci_expr); ("pci_loc", pci_loc); ("pci_attributes", pci_attributes)]
     method class_description : Class_description.t -> 'res  =
       fun class_description ->
         let concrete = Class_description.to_concrete class_description in
-        let concrete = self#class_infos_class_type concrete in
+        let concrete = self#class_infos self#class_type concrete in
         self#node (Some ("class_description", 0)) concrete
     method class_type_declaration : Class_type_declaration.t -> 'res  =
       fun class_type_declaration ->
         let concrete = Class_type_declaration.to_concrete class_type_declaration in
-        let concrete = self#class_infos_class_type concrete in
+        let concrete = self#class_infos self#class_type concrete in
         self#node (Some ("class_type_declaration", 0)) concrete
     method class_expr : Class_expr.t -> 'res  =
       fun class_expr ->
@@ -6108,7 +6005,7 @@ class virtual ['res] lift =
     method class_declaration : Class_declaration.t -> 'res  =
       fun class_declaration ->
         let concrete = Class_declaration.to_concrete class_declaration in
-        let concrete = self#class_infos_class_expr concrete in
+        let concrete = self#class_infos self#class_expr concrete in
         self#node (Some ("class_declaration", 0)) concrete
     method module_type : Module_type.t -> 'res  =
       fun module_type ->
@@ -6230,31 +6127,23 @@ class virtual ['res] lift =
         let popen_loc = self#location popen_loc in
         let popen_attributes = self#attributes popen_attributes in
         self#record (Some ("open_description", 0)) [("popen_lid", popen_lid); ("popen_override", popen_override); ("popen_loc", popen_loc); ("popen_attributes", popen_attributes)]
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'res  =
-      fun include_infos ->
+    method include_infos : 'a . ('a node -> 'res) -> 'a node Include_infos.t -> 'res  =
+      fun fa include_infos ->
         let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_expr.t Include_infos.concrete = concrete in
-        let pincl_mod = self#module_expr pincl_mod in
-        let pincl_loc = self#location pincl_loc in
-        let pincl_attributes = self#attributes pincl_attributes in
-        self#record (Some ("include_infos", 1)) [("pincl_mod", pincl_mod); ("pincl_loc", pincl_loc); ("pincl_attributes", pincl_attributes)]
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'res  =
-      fun include_infos ->
-        let concrete = Include_infos.to_concrete include_infos in
-        let { pincl_mod; pincl_loc; pincl_attributes } : Module_type.t Include_infos.concrete = concrete in
-        let pincl_mod = self#module_type pincl_mod in
+        let { pincl_mod; pincl_loc; pincl_attributes } : _ Include_infos.concrete = concrete in
+        let pincl_mod = fa pincl_mod in
         let pincl_loc = self#location pincl_loc in
         let pincl_attributes = self#attributes pincl_attributes in
         self#record (Some ("include_infos", 1)) [("pincl_mod", pincl_mod); ("pincl_loc", pincl_loc); ("pincl_attributes", pincl_attributes)]
     method include_description : Include_description.t -> 'res  =
       fun include_description ->
         let concrete = Include_description.to_concrete include_description in
-        let concrete = self#include_infos_module_type concrete in
+        let concrete = self#include_infos self#module_type concrete in
         self#node (Some ("include_description", 0)) concrete
     method include_declaration : Include_declaration.t -> 'res  =
       fun include_declaration ->
         let concrete = Include_declaration.to_concrete include_declaration in
-        let concrete = self#include_infos_module_expr concrete in
+        let concrete = self#include_infos self#module_expr concrete in
         self#node (Some ("include_declaration", 0)) concrete
     method with_constraint : With_constraint.t -> 'res  =
       fun with_constraint ->

--- a/ast/virtual_traverse_v4_07.mli
+++ b/ast/virtual_traverse_v4_07.mli
@@ -1,3 +1,4 @@
+open Unversioned.Types
 (*$ Ppx_ast_cinaps.print_virtual_traverse_mli (Astlib.Version.of_string "v4_07") *)
 open Versions.V4_07
 
@@ -51,8 +52,7 @@ class virtual map :
     method class_signature : Class_signature.t -> Class_signature.t
     method class_type_field : Class_type_field.t -> Class_type_field.t
     method class_type_field_desc : Class_type_field_desc.t -> Class_type_field_desc.t
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t
-    method class_infos_class_type : Class_type.t Class_infos.t -> Class_type.t Class_infos.t
+    method class_infos : 'a . ('a node -> 'a node) -> 'a node Class_infos.t -> 'a node Class_infos.t
     method class_description : Class_description.t -> Class_description.t
     method class_type_declaration : Class_type_declaration.t -> Class_type_declaration.t
     method class_expr : Class_expr.t -> Class_expr.t
@@ -70,8 +70,7 @@ class virtual map :
     method module_declaration : Module_declaration.t -> Module_declaration.t
     method module_type_declaration : Module_type_declaration.t -> Module_type_declaration.t
     method open_description : Open_description.t -> Open_description.t
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t
-    method include_infos_module_type : Module_type.t Include_infos.t -> Module_type.t Include_infos.t
+    method include_infos : 'a . ('a node -> 'a node) -> 'a node Include_infos.t -> 'a node Include_infos.t
     method include_description : Include_description.t -> Include_description.t
     method include_declaration : Include_declaration.t -> Include_declaration.t
     method with_constraint : With_constraint.t -> With_constraint.t
@@ -136,8 +135,7 @@ class virtual iter :
     method class_signature : Class_signature.t -> unit
     method class_type_field : Class_type_field.t -> unit
     method class_type_field_desc : Class_type_field_desc.t -> unit
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> unit
-    method class_infos_class_type : Class_type.t Class_infos.t -> unit
+    method class_infos : 'a . ('a node -> unit) -> 'a node Class_infos.t -> unit
     method class_description : Class_description.t -> unit
     method class_type_declaration : Class_type_declaration.t -> unit
     method class_expr : Class_expr.t -> unit
@@ -155,8 +153,7 @@ class virtual iter :
     method module_declaration : Module_declaration.t -> unit
     method module_type_declaration : Module_type_declaration.t -> unit
     method open_description : Open_description.t -> unit
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> unit
-    method include_infos_module_type : Module_type.t Include_infos.t -> unit
+    method include_infos : 'a . ('a node -> unit) -> 'a node Include_infos.t -> unit
     method include_description : Include_description.t -> unit
     method include_declaration : Include_declaration.t -> unit
     method with_constraint : With_constraint.t -> unit
@@ -221,8 +218,7 @@ class virtual ['acc] fold :
     method class_signature : Class_signature.t -> 'acc -> 'acc
     method class_type_field : Class_type_field.t -> 'acc -> 'acc
     method class_type_field_desc : Class_type_field_desc.t -> 'acc -> 'acc
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> 'acc
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'acc -> 'acc
+    method class_infos : 'a . ('a node -> 'acc -> 'acc) -> 'a node Class_infos.t -> 'acc -> 'acc
     method class_description : Class_description.t -> 'acc -> 'acc
     method class_type_declaration : Class_type_declaration.t -> 'acc -> 'acc
     method class_expr : Class_expr.t -> 'acc -> 'acc
@@ -240,8 +236,7 @@ class virtual ['acc] fold :
     method module_declaration : Module_declaration.t -> 'acc -> 'acc
     method module_type_declaration : Module_type_declaration.t -> 'acc -> 'acc
     method open_description : Open_description.t -> 'acc -> 'acc
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> 'acc
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'acc -> 'acc
+    method include_infos : 'a . ('a node -> 'acc -> 'acc) -> 'a node Include_infos.t -> 'acc -> 'acc
     method include_description : Include_description.t -> 'acc -> 'acc
     method include_declaration : Include_declaration.t -> 'acc -> 'acc
     method with_constraint : With_constraint.t -> 'acc -> 'acc
@@ -306,8 +301,7 @@ class virtual ['acc] fold_map :
     method class_signature : Class_signature.t -> 'acc -> (Class_signature.t * 'acc)
     method class_type_field : Class_type_field.t -> 'acc -> (Class_type_field.t * 'acc)
     method class_type_field_desc : Class_type_field_desc.t -> 'acc -> (Class_type_field_desc.t * 'acc)
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'acc -> (Class_expr.t Class_infos.t * 'acc)
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'acc -> (Class_type.t Class_infos.t * 'acc)
+    method class_infos : 'a . ('a node -> 'acc -> ('a node * 'acc)) -> 'a node Class_infos.t -> 'acc -> ('a node Class_infos.t * 'acc)
     method class_description : Class_description.t -> 'acc -> (Class_description.t * 'acc)
     method class_type_declaration : Class_type_declaration.t -> 'acc -> (Class_type_declaration.t * 'acc)
     method class_expr : Class_expr.t -> 'acc -> (Class_expr.t * 'acc)
@@ -325,8 +319,7 @@ class virtual ['acc] fold_map :
     method module_declaration : Module_declaration.t -> 'acc -> (Module_declaration.t * 'acc)
     method module_type_declaration : Module_type_declaration.t -> 'acc -> (Module_type_declaration.t * 'acc)
     method open_description : Open_description.t -> 'acc -> (Open_description.t * 'acc)
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'acc -> (Module_expr.t Include_infos.t * 'acc)
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'acc -> (Module_type.t Include_infos.t * 'acc)
+    method include_infos : 'a . ('a node -> 'acc -> ('a node * 'acc)) -> 'a node Include_infos.t -> 'acc -> ('a node Include_infos.t * 'acc)
     method include_description : Include_description.t -> 'acc -> (Include_description.t * 'acc)
     method include_declaration : Include_declaration.t -> 'acc -> (Include_declaration.t * 'acc)
     method with_constraint : With_constraint.t -> 'acc -> (With_constraint.t * 'acc)
@@ -391,8 +384,7 @@ class virtual ['ctx] map_with_context :
     method class_signature : 'ctx -> Class_signature.t -> Class_signature.t
     method class_type_field : 'ctx -> Class_type_field.t -> Class_type_field.t
     method class_type_field_desc : 'ctx -> Class_type_field_desc.t -> Class_type_field_desc.t
-    method class_infos_class_expr : 'ctx -> Class_expr.t Class_infos.t -> Class_expr.t Class_infos.t
-    method class_infos_class_type : 'ctx -> Class_type.t Class_infos.t -> Class_type.t Class_infos.t
+    method class_infos : 'a . ('ctx -> 'a node -> 'a node) -> 'ctx -> 'a node Class_infos.t -> 'a node Class_infos.t
     method class_description : 'ctx -> Class_description.t -> Class_description.t
     method class_type_declaration : 'ctx -> Class_type_declaration.t -> Class_type_declaration.t
     method class_expr : 'ctx -> Class_expr.t -> Class_expr.t
@@ -410,8 +402,7 @@ class virtual ['ctx] map_with_context :
     method module_declaration : 'ctx -> Module_declaration.t -> Module_declaration.t
     method module_type_declaration : 'ctx -> Module_type_declaration.t -> Module_type_declaration.t
     method open_description : 'ctx -> Open_description.t -> Open_description.t
-    method include_infos_module_expr : 'ctx -> Module_expr.t Include_infos.t -> Module_expr.t Include_infos.t
-    method include_infos_module_type : 'ctx -> Module_type.t Include_infos.t -> Module_type.t Include_infos.t
+    method include_infos : 'a . ('ctx -> 'a node -> 'a node) -> 'ctx -> 'a node Include_infos.t -> 'a node Include_infos.t
     method include_description : 'ctx -> Include_description.t -> Include_description.t
     method include_declaration : 'ctx -> Include_declaration.t -> Include_declaration.t
     method with_constraint : 'ctx -> With_constraint.t -> With_constraint.t
@@ -480,8 +471,7 @@ class virtual ['res] lift :
     method class_signature : Class_signature.t -> 'res
     method class_type_field : Class_type_field.t -> 'res
     method class_type_field_desc : Class_type_field_desc.t -> 'res
-    method class_infos_class_expr : Class_expr.t Class_infos.t -> 'res
-    method class_infos_class_type : Class_type.t Class_infos.t -> 'res
+    method class_infos : 'a . ('a node -> 'res) -> 'a node Class_infos.t -> 'res
     method class_description : Class_description.t -> 'res
     method class_type_declaration : Class_type_declaration.t -> 'res
     method class_expr : Class_expr.t -> 'res
@@ -499,8 +489,7 @@ class virtual ['res] lift :
     method module_declaration : Module_declaration.t -> 'res
     method module_type_declaration : Module_type_declaration.t -> 'res
     method open_description : Open_description.t -> 'res
-    method include_infos_module_expr : Module_expr.t Include_infos.t -> 'res
-    method include_infos_module_type : Module_type.t Include_infos.t -> 'res
+    method include_infos : 'a . ('a node -> 'res) -> 'a node Include_infos.t -> 'res
     method include_description : Include_description.t -> 'res
     method include_declaration : Include_declaration.t -> 'res
     method with_constraint : With_constraint.t -> 'res


### PR DESCRIPTION
Stop instantiating polymorphic types at all instances in the AST, and just use polymorphic conversions and methods. With "nodified" types, we can now do this universally.