### PR TITLE
Use unversioned types

### DIFF
--- a/ast/builder.ml
+++ b/ast/builder.ml
@@ -1,9 +1,0 @@
-module V4_07 = struct
-  include Builder_common
-  include Builder_v4_07
-end
-
-module Unstable_for_testing = struct
-  include Builder_common
-  include Builder_unstable_for_testing
-end

--- a/ast/builder.mli
+++ b/ast/builder.mli
@@ -1,9 +1,0 @@
-module V4_07 : sig
-  include module type of Builder_common
-  include module type of Builder_v4_07
-end
-
-module Unstable_for_testing : sig
-  include module type of Builder_common
-  include module type of Builder_unstable_for_testing
-end

--- a/ast/builder_unstable_for_testing.mli
+++ b/ast/builder_unstable_for_testing.mli
@@ -1,693 +1,693 @@
 (*$ Ppx_ast_cinaps.print_builder_mli (Astlib.Version.of_string "unstable_for_testing") *)
-open Versions.Unstable_for_testing
+open Versions
 val module_binding :
   loc:Astlib.Location.t
-  -> expr:Module_expr.t
+  -> expr:module_expr
   -> name:string Astlib.Loc.t
-  -> Module_binding.t
+  -> module_binding
 val value_binding :
   loc:Astlib.Location.t
-  -> expr:Expression.t
-  -> pat:Pattern.t
-  -> Value_binding.t
+  -> expr:expression
+  -> pat:pattern
+  -> value_binding
 val pstr_extension :
   loc:Astlib.Location.t
-  -> Attributes.t
-  -> Extension.t
-  -> Structure_item.t
+  -> attributes
+  -> extension
+  -> structure_item
 val pstr_attribute :
   loc:Astlib.Location.t
-  -> Attribute.t
-  -> Structure_item.t
+  -> attribute
+  -> structure_item
 val pstr_include :
   loc:Astlib.Location.t
-  -> Include_declaration.t
-  -> Structure_item.t
+  -> include_declaration
+  -> structure_item
 val pstr_class_type :
   loc:Astlib.Location.t
-  -> Class_type_declaration.t list
-  -> Structure_item.t
+  -> class_type_declaration list
+  -> structure_item
 val pstr_class :
   loc:Astlib.Location.t
-  -> Class_declaration.t list
-  -> Structure_item.t
+  -> class_declaration list
+  -> structure_item
 val pstr_open :
   loc:Astlib.Location.t
-  -> Open_description.t
-  -> Structure_item.t
+  -> open_description
+  -> structure_item
 val pstr_modtype :
   loc:Astlib.Location.t
-  -> Module_type_declaration.t
-  -> Structure_item.t
+  -> module_type_declaration
+  -> structure_item
 val pstr_recmodule :
   loc:Astlib.Location.t
-  -> Module_binding.t list
-  -> Structure_item.t
+  -> module_binding list
+  -> structure_item
 val pstr_module :
   loc:Astlib.Location.t
-  -> Module_binding.t
-  -> Structure_item.t
+  -> module_binding
+  -> structure_item
 val pstr_exception :
   loc:Astlib.Location.t
-  -> Extension_constructor.t
-  -> Structure_item.t
+  -> extension_constructor
+  -> structure_item
 val pstr_typext :
   loc:Astlib.Location.t
-  -> Type_extension.t
-  -> Structure_item.t
+  -> type_extension
+  -> structure_item
 val pstr_type :
   loc:Astlib.Location.t
-  -> Type_declaration.t list
-  -> Rec_flag.t
-  -> Structure_item.t
+  -> type_declaration list
+  -> rec_flag
+  -> structure_item
 val pstr_primitive :
   loc:Astlib.Location.t
-  -> Value_description.t
-  -> Structure_item.t
+  -> value_description
+  -> structure_item
 val pstr_value :
   loc:Astlib.Location.t
-  -> Value_binding.t list
-  -> Rec_flag.t
-  -> Structure_item.t
+  -> value_binding list
+  -> rec_flag
+  -> structure_item
 val pstr_eval :
   loc:Astlib.Location.t
-  -> Attributes.t
-  -> Expression.t
-  -> Structure_item.t
+  -> attributes
+  -> expression
+  -> structure_item
 val pmod_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Module_expr.t
+  -> extension
+  -> module_expr
 val pmod_unpack :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Module_expr.t
+  -> expression
+  -> module_expr
 val pmod_constraint :
   loc:Astlib.Location.t
-  -> Module_type.t
-  -> Module_expr.t
-  -> Module_expr.t
+  -> module_type
+  -> module_expr
+  -> module_expr
 val pmod_apply :
   loc:Astlib.Location.t
-  -> Module_expr.t
-  -> Module_expr.t
-  -> Module_expr.t
+  -> module_expr
+  -> module_expr
+  -> module_expr
 val pmod_functor :
   loc:Astlib.Location.t
-  -> Module_expr.t
-  -> Module_type.t option
+  -> module_expr
+  -> module_type option
   -> string Astlib.Loc.t
-  -> Module_expr.t
+  -> module_expr
 val pmod_structure :
   loc:Astlib.Location.t
-  -> Structure.t
-  -> Module_expr.t
+  -> structure
+  -> module_expr
 val pmod_ident :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Module_expr.t
+  -> longident_loc
+  -> module_expr
 val open_description :
   loc:Astlib.Location.t
-  -> lid:Longident_loc.t
-  -> override:Override_flag.t
-  -> Open_description.t
+  -> lid:longident_loc
+  -> override:override_flag
+  -> open_description
 val module_type_declaration :
   loc:Astlib.Location.t
   -> name:string Astlib.Loc.t
-  -> type_:Module_type.t option
-  -> Module_type_declaration.t
+  -> type_:module_type option
+  -> module_type_declaration
 val module_declaration :
   loc:Astlib.Location.t
   -> name:string Astlib.Loc.t
-  -> type_:Module_type.t
-  -> Module_declaration.t
+  -> type_:module_type
+  -> module_declaration
 val psig_extension :
   loc:Astlib.Location.t
-  -> Attributes.t
-  -> Extension.t
-  -> Signature_item.t
+  -> attributes
+  -> extension
+  -> signature_item
 val psig_attribute :
   loc:Astlib.Location.t
-  -> Attribute.t
-  -> Signature_item.t
+  -> attribute
+  -> signature_item
 val psig_class_type :
   loc:Astlib.Location.t
-  -> Class_type_declaration.t list
-  -> Signature_item.t
+  -> class_type_declaration list
+  -> signature_item
 val psig_class :
   loc:Astlib.Location.t
-  -> Class_description.t list
-  -> Signature_item.t
+  -> class_description list
+  -> signature_item
 val psig_include :
   loc:Astlib.Location.t
-  -> Include_description.t
-  -> Signature_item.t
+  -> include_description
+  -> signature_item
 val psig_open :
   loc:Astlib.Location.t
-  -> Open_description.t
-  -> Signature_item.t
+  -> open_description
+  -> signature_item
 val psig_modtype :
   loc:Astlib.Location.t
-  -> Module_type_declaration.t
-  -> Signature_item.t
+  -> module_type_declaration
+  -> signature_item
 val psig_recmodule :
   loc:Astlib.Location.t
-  -> Module_declaration.t list
-  -> Signature_item.t
+  -> module_declaration list
+  -> signature_item
 val psig_module :
   loc:Astlib.Location.t
-  -> Module_declaration.t
-  -> Signature_item.t
+  -> module_declaration
+  -> signature_item
 val psig_exception :
   loc:Astlib.Location.t
-  -> Extension_constructor.t
-  -> Signature_item.t
+  -> extension_constructor
+  -> signature_item
 val psig_typext :
   loc:Astlib.Location.t
-  -> Type_extension.t
-  -> Signature_item.t
+  -> type_extension
+  -> signature_item
 val psig_type :
   loc:Astlib.Location.t
-  -> Type_declaration.t list
-  -> Rec_flag.t
-  -> Signature_item.t
+  -> type_declaration list
+  -> rec_flag
+  -> signature_item
 val psig_value :
   loc:Astlib.Location.t
-  -> Value_description.t
-  -> Signature_item.t
+  -> value_description
+  -> signature_item
 val pmty_alias :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Module_type.t
+  -> longident_loc
+  -> module_type
 val pmty_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Module_type.t
+  -> extension
+  -> module_type
 val pmty_typeof :
   loc:Astlib.Location.t
-  -> Module_expr.t
-  -> Module_type.t
+  -> module_expr
+  -> module_type
 val pmty_with :
   loc:Astlib.Location.t
-  -> With_constraint.t list
-  -> Module_type.t
-  -> Module_type.t
+  -> with_constraint list
+  -> module_type
+  -> module_type
 val pmty_functor :
   loc:Astlib.Location.t
-  -> Module_type.t
-  -> Module_type.t option
+  -> module_type
+  -> module_type option
   -> string Astlib.Loc.t
-  -> Module_type.t
+  -> module_type
 val pmty_signature :
   loc:Astlib.Location.t
-  -> Signature.t
-  -> Module_type.t
+  -> signature
+  -> module_type
 val pmty_ident :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Module_type.t
+  -> longident_loc
+  -> module_type
 val pcf_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Class_field.t
+  -> extension
+  -> class_field
 val pcf_attribute :
   loc:Astlib.Location.t
-  -> Attribute.t
-  -> Class_field.t
+  -> attribute
+  -> class_field
 val pcf_initializer :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Class_field.t
+  -> expression
+  -> class_field
 val pcf_constraint :
   loc:Astlib.Location.t
-  -> (Core_type.t * Core_type.t)
-  -> Class_field.t
+  -> (core_type * core_type)
+  -> class_field
 val pcf_method :
   loc:Astlib.Location.t
-  -> (Class_field_kind.t * Private_flag.t * string Astlib.Loc.t)
-  -> Class_field.t
+  -> (class_field_kind * private_flag * string Astlib.Loc.t)
+  -> class_field
 val pcf_val :
   loc:Astlib.Location.t
-  -> (Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t)
-  -> Class_field.t
+  -> (class_field_kind * mutable_flag * string Astlib.Loc.t)
+  -> class_field
 val pcf_inherit :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t option
-  -> Class_expr.t
-  -> Override_flag.t
-  -> Class_field.t
+  -> class_expr
+  -> override_flag
+  -> class_field
 val class_structure :
-  fields:Class_field.t list
-  -> self:Pattern.t
-  -> Class_structure.t
+  fields:class_field list
+  -> self:pattern
+  -> class_structure
 val pcl_open :
   loc:Astlib.Location.t
-  -> Class_expr.t
-  -> Longident_loc.t
-  -> Override_flag.t
-  -> Class_expr.t
+  -> class_expr
+  -> longident_loc
+  -> override_flag
+  -> class_expr
 val pcl_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Class_expr.t
+  -> extension
+  -> class_expr
 val pcl_constraint :
   loc:Astlib.Location.t
-  -> Class_type.t
-  -> Class_expr.t
-  -> Class_expr.t
+  -> class_type
+  -> class_expr
+  -> class_expr
 val pcl_let :
   loc:Astlib.Location.t
-  -> Class_expr.t
-  -> Value_binding.t list
-  -> Rec_flag.t
-  -> Class_expr.t
+  -> class_expr
+  -> value_binding list
+  -> rec_flag
+  -> class_expr
 val pcl_apply :
   loc:Astlib.Location.t
-  -> (Expression.t * Arg_label.t) list
-  -> Class_expr.t
-  -> Class_expr.t
+  -> (expression * arg_label) list
+  -> class_expr
+  -> class_expr
 val pcl_fun :
   loc:Astlib.Location.t
-  -> Class_expr.t
-  -> Pattern.t
-  -> Expression.t option
-  -> Arg_label.t
-  -> Class_expr.t
+  -> class_expr
+  -> pattern
+  -> expression option
+  -> arg_label
+  -> class_expr
 val pcl_structure :
   loc:Astlib.Location.t
-  -> Class_structure.t
-  -> Class_expr.t
+  -> class_structure
+  -> class_expr
 val pcl_constr :
   loc:Astlib.Location.t
-  -> Core_type.t list
-  -> Longident_loc.t
-  -> Class_expr.t
+  -> core_type list
+  -> longident_loc
+  -> class_expr
 val pctf_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Class_type_field.t
+  -> extension
+  -> class_type_field
 val pctf_attribute :
   loc:Astlib.Location.t
-  -> Attribute.t
-  -> Class_type_field.t
+  -> attribute
+  -> class_type_field
 val pctf_constraint :
   loc:Astlib.Location.t
-  -> (Core_type.t * Core_type.t)
-  -> Class_type_field.t
+  -> (core_type * core_type)
+  -> class_type_field
 val pctf_method :
   loc:Astlib.Location.t
-  -> (Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t)
-  -> Class_type_field.t
+  -> (core_type * virtual_flag * private_flag * string Astlib.Loc.t)
+  -> class_type_field
 val pctf_val :
   loc:Astlib.Location.t
-  -> (Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t)
-  -> Class_type_field.t
+  -> (core_type * virtual_flag * mutable_flag * string Astlib.Loc.t)
+  -> class_type_field
 val pctf_inherit :
   loc:Astlib.Location.t
-  -> Class_type.t
-  -> Class_type_field.t
+  -> class_type
+  -> class_type_field
 val class_signature :
-  fields:Class_type_field.t list
-  -> self:Core_type.t
-  -> Class_signature.t
+  fields:class_type_field list
+  -> self:core_type
+  -> class_signature
 val pcty_open :
   loc:Astlib.Location.t
-  -> Class_type.t
-  -> Longident_loc.t
-  -> Override_flag.t
-  -> Class_type.t
+  -> class_type
+  -> longident_loc
+  -> override_flag
+  -> class_type
 val pcty_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Class_type.t
+  -> extension
+  -> class_type
 val pcty_arrow :
   loc:Astlib.Location.t
-  -> Class_type.t
-  -> Core_type.t
-  -> Arg_label.t
-  -> Class_type.t
+  -> class_type
+  -> core_type
+  -> arg_label
+  -> class_type
 val pcty_signature :
   loc:Astlib.Location.t
-  -> Class_signature.t
-  -> Class_type.t
+  -> class_signature
+  -> class_type
 val pcty_constr :
   loc:Astlib.Location.t
-  -> Core_type.t list
-  -> Longident_loc.t
-  -> Class_type.t
+  -> core_type list
+  -> longident_loc
+  -> class_type
 val extension_constructor :
   loc:Astlib.Location.t
-  -> kind:Extension_constructor_kind.t
+  -> kind:extension_constructor_kind
   -> name:string Astlib.Loc.t
-  -> Extension_constructor.t
+  -> extension_constructor
 val type_extension :
-  constructors:Extension_constructor.t list
-  -> params:(Variance.t * Core_type.t) list
-  -> path:Longident_loc.t
-  -> private_:Private_flag.t
-  -> Type_extension.t
+  constructors:extension_constructor list
+  -> params:(variance * core_type) list
+  -> path:longident_loc
+  -> private_:private_flag
+  -> type_extension
 val constructor_declaration :
   loc:Astlib.Location.t
-  -> args:Constructor_arguments.t
+  -> args:constructor_arguments
   -> name:string Astlib.Loc.t
-  -> res:Core_type.t option
-  -> Constructor_declaration.t
+  -> res:core_type option
+  -> constructor_declaration
 val label_declaration :
   loc:Astlib.Location.t
-  -> mutable_:Mutable_flag.t
+  -> mutable_:mutable_flag
   -> name:string Astlib.Loc.t
-  -> type_:Core_type.t
-  -> Label_declaration.t
+  -> type_:core_type
+  -> label_declaration
 val type_declaration :
   loc:Astlib.Location.t
-  -> cstrs:(Astlib.Location.t * Core_type.t * Core_type.t) list
-  -> kind:Type_kind.t
-  -> manifest:Core_type.t option
+  -> cstrs:(Astlib.Location.t * core_type * core_type) list
+  -> kind:type_kind
+  -> manifest:core_type option
   -> name:string Astlib.Loc.t
-  -> params:(Variance.t * Core_type.t) list
-  -> private_:Private_flag.t
-  -> Type_declaration.t
+  -> params:(variance * core_type) list
+  -> private_:private_flag
+  -> type_declaration
 val value_description :
   loc:Astlib.Location.t
   -> name:string Astlib.Loc.t
   -> prim:string list
-  -> type_:Core_type.t
-  -> Value_description.t
+  -> type_:core_type
+  -> value_description
 val case :
-  guard:Expression.t option
-  -> lhs:Pattern.t
-  -> rhs:Expression.t
-  -> Case.t
+  guard:expression option
+  -> lhs:pattern
+  -> rhs:expression
+  -> case
 val pexp_unreachable :
   loc:Astlib.Location.t
-  -> Expression.t
+  -> expression
 val pexp_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Expression.t
+  -> extension
+  -> expression
 val pexp_open :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Longident_loc.t
-  -> Override_flag.t
-  -> Expression.t
+  -> expression
+  -> longident_loc
+  -> override_flag
+  -> expression
 val pexp_pack :
   loc:Astlib.Location.t
-  -> Module_expr.t
-  -> Expression.t
+  -> module_expr
+  -> expression
 val pexp_newtype :
   loc:Astlib.Location.t
-  -> Expression.t
+  -> expression
   -> string Astlib.Loc.t
-  -> Expression.t
+  -> expression
 val pexp_object :
   loc:Astlib.Location.t
-  -> Class_structure.t
-  -> Expression.t
+  -> class_structure
+  -> expression
 val pexp_poly :
   loc:Astlib.Location.t
-  -> Core_type.t option
-  -> Expression.t
-  -> Expression.t
+  -> core_type option
+  -> expression
+  -> expression
 val pexp_lazy :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
 val pexp_assert :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
 val pexp_letexception :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Extension_constructor.t
-  -> Expression.t
+  -> expression
+  -> extension_constructor
+  -> expression
 val pexp_letmodule :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Module_expr.t
+  -> expression
+  -> module_expr
   -> string Astlib.Loc.t
-  -> Expression.t
+  -> expression
 val pexp_override :
   loc:Astlib.Location.t
-  -> (Expression.t * string Astlib.Loc.t) list
-  -> Expression.t
+  -> (expression * string Astlib.Loc.t) list
+  -> expression
 val pexp_setinstvar :
   loc:Astlib.Location.t
-  -> Expression.t
+  -> expression
   -> string Astlib.Loc.t
-  -> Expression.t
+  -> expression
 val pexp_new :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Expression.t
+  -> longident_loc
+  -> expression
 val pexp_send :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
 val pexp_coerce :
   loc:Astlib.Location.t
-  -> Core_type.t
-  -> Core_type.t option
-  -> Expression.t
-  -> Expression.t
+  -> core_type
+  -> core_type option
+  -> expression
+  -> expression
 val pexp_constraint :
   loc:Astlib.Location.t
-  -> Core_type.t
-  -> Expression.t
-  -> Expression.t
+  -> core_type
+  -> expression
+  -> expression
 val pexp_for :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Direction_flag.t
-  -> Expression.t
-  -> Expression.t
-  -> Pattern.t
-  -> Expression.t
+  -> expression
+  -> direction_flag
+  -> expression
+  -> expression
+  -> pattern
+  -> expression
 val pexp_while :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
+  -> expression
 val pexp_sequence :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
+  -> expression
 val pexp_ifthenelse :
   loc:Astlib.Location.t
-  -> Expression.t option
-  -> Expression.t
-  -> Expression.t
-  -> Expression.t
+  -> expression option
+  -> expression
+  -> expression
+  -> expression
 val pexp_array :
   loc:Astlib.Location.t
-  -> Expression.t list
-  -> Expression.t
+  -> expression list
+  -> expression
 val pexp_setfield :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Longident_loc.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> longident_loc
+  -> expression
+  -> expression
 val pexp_field :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Expression.t
-  -> Expression.t
+  -> longident_loc
+  -> expression
+  -> expression
 val pexp_record :
   loc:Astlib.Location.t
-  -> Expression.t option
-  -> (Expression.t * Longident_loc.t) list
-  -> Expression.t
+  -> expression option
+  -> (expression * longident_loc) list
+  -> expression
 val pexp_variant :
   loc:Astlib.Location.t
-  -> Expression.t option
+  -> expression option
   -> string
-  -> Expression.t
+  -> expression
 val pexp_construct :
   loc:Astlib.Location.t
-  -> Expression.t option
-  -> Longident_loc.t
-  -> Expression.t
+  -> expression option
+  -> longident_loc
+  -> expression
 val pexp_tuple :
   loc:Astlib.Location.t
-  -> Expression.t list
-  -> Expression.t
+  -> expression list
+  -> expression
 val pexp_try :
   loc:Astlib.Location.t
-  -> Case.t list
-  -> Expression.t
-  -> Expression.t
+  -> case list
+  -> expression
+  -> expression
 val pexp_match :
   loc:Astlib.Location.t
-  -> Case.t list
-  -> Expression.t
-  -> Expression.t
+  -> case list
+  -> expression
+  -> expression
 val pexp_apply :
   loc:Astlib.Location.t
-  -> (Expression.t * Arg_label.t) list
-  -> Expression.t
-  -> Expression.t
+  -> (expression * arg_label) list
+  -> expression
+  -> expression
 val pexp_fun :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Pattern.t
-  -> Expression.t option
-  -> Arg_label.t
-  -> Expression.t
+  -> expression
+  -> pattern
+  -> expression option
+  -> arg_label
+  -> expression
 val pexp_function :
   loc:Astlib.Location.t
-  -> Case.t list
-  -> Expression.t
+  -> case list
+  -> expression
 val pexp_let :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Value_binding.t list
-  -> Rec_flag.t
-  -> Expression.t
+  -> expression
+  -> value_binding list
+  -> rec_flag
+  -> expression
 val pexp_constant :
   loc:Astlib.Location.t
-  -> Constant.t
-  -> Expression.t
+  -> constant
+  -> expression
 val pexp_ident :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Expression.t
+  -> longident_loc
+  -> expression
 val ppat_open :
   loc:Astlib.Location.t
-  -> Pattern.t
-  -> Longident_loc.t
-  -> Pattern.t
+  -> pattern
+  -> longident_loc
+  -> pattern
 val ppat_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Pattern.t
+  -> extension
+  -> pattern
 val ppat_exception :
   loc:Astlib.Location.t
-  -> Pattern.t
-  -> Pattern.t
+  -> pattern
+  -> pattern
 val ppat_unpack :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Pattern.t
+  -> pattern
 val ppat_lazy :
   loc:Astlib.Location.t
-  -> Pattern.t
-  -> Pattern.t
+  -> pattern
+  -> pattern
 val ppat_type :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Pattern.t
+  -> longident_loc
+  -> pattern
 val ppat_constraint :
   loc:Astlib.Location.t
-  -> Core_type.t
-  -> Pattern.t
-  -> Pattern.t
+  -> core_type
+  -> pattern
+  -> pattern
 val ppat_or :
   loc:Astlib.Location.t
-  -> Pattern.t
-  -> Pattern.t
-  -> Pattern.t
+  -> pattern
+  -> pattern
+  -> pattern
 val ppat_array :
   loc:Astlib.Location.t
-  -> Pattern.t list
-  -> Pattern.t
+  -> pattern list
+  -> pattern
 val ppat_record :
   loc:Astlib.Location.t
-  -> Closed_flag.t
-  -> (Pattern.t * Longident_loc.t) list
-  -> Pattern.t
+  -> closed_flag
+  -> (pattern * longident_loc) list
+  -> pattern
 val ppat_variant :
   loc:Astlib.Location.t
-  -> Pattern.t option
+  -> pattern option
   -> string
-  -> Pattern.t
+  -> pattern
 val ppat_construct :
   loc:Astlib.Location.t
-  -> Pattern.t option
-  -> Longident_loc.t
-  -> Pattern.t
+  -> pattern option
+  -> longident_loc
+  -> pattern
 val ppat_tuple :
   loc:Astlib.Location.t
-  -> Pattern.t list
-  -> Pattern.t
+  -> pattern list
+  -> pattern
 val ppat_interval :
   loc:Astlib.Location.t
-  -> Constant.t
-  -> Constant.t
-  -> Pattern.t
+  -> constant
+  -> constant
+  -> pattern
 val ppat_constant :
   loc:Astlib.Location.t
-  -> Constant.t
-  -> Pattern.t
+  -> constant
+  -> pattern
 val ppat_alias :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Pattern.t
-  -> Pattern.t
+  -> pattern
+  -> pattern
 val ppat_var :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Pattern.t
+  -> pattern
 val ppat_any :
   loc:Astlib.Location.t
-  -> Pattern.t
+  -> pattern
 val ptyp_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Core_type.t
+  -> extension
+  -> core_type
 val ptyp_package :
   loc:Astlib.Location.t
-  -> Package_type.t
-  -> Core_type.t
+  -> package_type
+  -> core_type
 val ptyp_poly :
   loc:Astlib.Location.t
-  -> Core_type.t
+  -> core_type
   -> string Astlib.Loc.t list
-  -> Core_type.t
+  -> core_type
 val ptyp_variant :
   loc:Astlib.Location.t
   -> string list option
-  -> Closed_flag.t
-  -> Row_field.t list
-  -> Core_type.t
+  -> closed_flag
+  -> row_field list
+  -> core_type
 val ptyp_alias :
   loc:Astlib.Location.t
   -> string
-  -> Core_type.t
-  -> Core_type.t
+  -> core_type
+  -> core_type
 val ptyp_class :
   loc:Astlib.Location.t
-  -> Core_type.t list
-  -> Longident_loc.t
-  -> Core_type.t
+  -> core_type list
+  -> longident_loc
+  -> core_type
 val ptyp_object :
   loc:Astlib.Location.t
-  -> Closed_flag.t
-  -> Object_field.t list
-  -> Core_type.t
+  -> closed_flag
+  -> object_field list
+  -> core_type
 val ptyp_constr :
   loc:Astlib.Location.t
-  -> Core_type.t list
-  -> Longident_loc.t
-  -> Core_type.t
+  -> core_type list
+  -> longident_loc
+  -> core_type
 val ptyp_tuple :
   loc:Astlib.Location.t
-  -> Core_type.t list
-  -> Core_type.t
+  -> core_type list
+  -> core_type
 val ptyp_arrow :
   loc:Astlib.Location.t
-  -> Core_type.t
-  -> Core_type.t
-  -> Arg_label.t
-  -> Core_type.t
+  -> core_type
+  -> core_type
+  -> arg_label
+  -> core_type
 val ptyp_var :
   loc:Astlib.Location.t
   -> string
-  -> Core_type.t
+  -> core_type
 val ptyp_any :
   loc:Astlib.Location.t
-  -> Core_type.t
+  -> core_type
 (*$*)

--- a/ast/builder_v4_07.mli
+++ b/ast/builder_v4_07.mli
@@ -1,693 +1,693 @@
 (*$ Ppx_ast_cinaps.print_builder_mli (Astlib.Version.of_string "v4_07") *)
-open Versions.V4_07
+open Versions
 val ptyp_any :
   loc:Astlib.Location.t
-  -> Core_type.t
+  -> core_type
 val ptyp_var :
   loc:Astlib.Location.t
   -> string
-  -> Core_type.t
+  -> core_type
 val ptyp_arrow :
   loc:Astlib.Location.t
-  -> Arg_label.t
-  -> Core_type.t
-  -> Core_type.t
-  -> Core_type.t
+  -> arg_label
+  -> core_type
+  -> core_type
+  -> core_type
 val ptyp_tuple :
   loc:Astlib.Location.t
-  -> Core_type.t list
-  -> Core_type.t
+  -> core_type list
+  -> core_type
 val ptyp_constr :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Core_type.t list
-  -> Core_type.t
+  -> longident_loc
+  -> core_type list
+  -> core_type
 val ptyp_object :
   loc:Astlib.Location.t
-  -> Object_field.t list
-  -> Closed_flag.t
-  -> Core_type.t
+  -> object_field list
+  -> closed_flag
+  -> core_type
 val ptyp_class :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Core_type.t list
-  -> Core_type.t
+  -> longident_loc
+  -> core_type list
+  -> core_type
 val ptyp_alias :
   loc:Astlib.Location.t
-  -> Core_type.t
+  -> core_type
   -> string
-  -> Core_type.t
+  -> core_type
 val ptyp_variant :
   loc:Astlib.Location.t
-  -> Row_field.t list
-  -> Closed_flag.t
+  -> row_field list
+  -> closed_flag
   -> string list option
-  -> Core_type.t
+  -> core_type
 val ptyp_poly :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t list
-  -> Core_type.t
-  -> Core_type.t
+  -> core_type
+  -> core_type
 val ptyp_package :
   loc:Astlib.Location.t
-  -> Package_type.t
-  -> Core_type.t
+  -> package_type
+  -> core_type
 val ptyp_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Core_type.t
+  -> extension
+  -> core_type
 val ppat_any :
   loc:Astlib.Location.t
-  -> Pattern.t
+  -> pattern
 val ppat_var :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Pattern.t
+  -> pattern
 val ppat_alias :
   loc:Astlib.Location.t
-  -> Pattern.t
+  -> pattern
   -> string Astlib.Loc.t
-  -> Pattern.t
+  -> pattern
 val ppat_constant :
   loc:Astlib.Location.t
-  -> Constant.t
-  -> Pattern.t
+  -> constant
+  -> pattern
 val ppat_interval :
   loc:Astlib.Location.t
-  -> Constant.t
-  -> Constant.t
-  -> Pattern.t
+  -> constant
+  -> constant
+  -> pattern
 val ppat_tuple :
   loc:Astlib.Location.t
-  -> Pattern.t list
-  -> Pattern.t
+  -> pattern list
+  -> pattern
 val ppat_construct :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Pattern.t option
-  -> Pattern.t
+  -> longident_loc
+  -> pattern option
+  -> pattern
 val ppat_variant :
   loc:Astlib.Location.t
   -> string
-  -> Pattern.t option
-  -> Pattern.t
+  -> pattern option
+  -> pattern
 val ppat_record :
   loc:Astlib.Location.t
-  -> (Longident_loc.t * Pattern.t) list
-  -> Closed_flag.t
-  -> Pattern.t
+  -> (longident_loc * pattern) list
+  -> closed_flag
+  -> pattern
 val ppat_array :
   loc:Astlib.Location.t
-  -> Pattern.t list
-  -> Pattern.t
+  -> pattern list
+  -> pattern
 val ppat_or :
   loc:Astlib.Location.t
-  -> Pattern.t
-  -> Pattern.t
-  -> Pattern.t
+  -> pattern
+  -> pattern
+  -> pattern
 val ppat_constraint :
   loc:Astlib.Location.t
-  -> Pattern.t
-  -> Core_type.t
-  -> Pattern.t
+  -> pattern
+  -> core_type
+  -> pattern
 val ppat_type :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Pattern.t
+  -> longident_loc
+  -> pattern
 val ppat_lazy :
   loc:Astlib.Location.t
-  -> Pattern.t
-  -> Pattern.t
+  -> pattern
+  -> pattern
 val ppat_unpack :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Pattern.t
+  -> pattern
 val ppat_exception :
   loc:Astlib.Location.t
-  -> Pattern.t
-  -> Pattern.t
+  -> pattern
+  -> pattern
 val ppat_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Pattern.t
+  -> extension
+  -> pattern
 val ppat_open :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Pattern.t
-  -> Pattern.t
+  -> longident_loc
+  -> pattern
+  -> pattern
 val pexp_ident :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Expression.t
+  -> longident_loc
+  -> expression
 val pexp_constant :
   loc:Astlib.Location.t
-  -> Constant.t
-  -> Expression.t
+  -> constant
+  -> expression
 val pexp_let :
   loc:Astlib.Location.t
-  -> Rec_flag.t
-  -> Value_binding.t list
-  -> Expression.t
-  -> Expression.t
+  -> rec_flag
+  -> value_binding list
+  -> expression
+  -> expression
 val pexp_function :
   loc:Astlib.Location.t
-  -> Case.t list
-  -> Expression.t
+  -> case list
+  -> expression
 val pexp_fun :
   loc:Astlib.Location.t
-  -> Arg_label.t
-  -> Expression.t option
-  -> Pattern.t
-  -> Expression.t
-  -> Expression.t
+  -> arg_label
+  -> expression option
+  -> pattern
+  -> expression
+  -> expression
 val pexp_apply :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> (Arg_label.t * Expression.t) list
-  -> Expression.t
+  -> expression
+  -> (arg_label * expression) list
+  -> expression
 val pexp_match :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Case.t list
-  -> Expression.t
+  -> expression
+  -> case list
+  -> expression
 val pexp_try :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Case.t list
-  -> Expression.t
+  -> expression
+  -> case list
+  -> expression
 val pexp_tuple :
   loc:Astlib.Location.t
-  -> Expression.t list
-  -> Expression.t
+  -> expression list
+  -> expression
 val pexp_construct :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Expression.t option
-  -> Expression.t
+  -> longident_loc
+  -> expression option
+  -> expression
 val pexp_variant :
   loc:Astlib.Location.t
   -> string
-  -> Expression.t option
-  -> Expression.t
+  -> expression option
+  -> expression
 val pexp_record :
   loc:Astlib.Location.t
-  -> (Longident_loc.t * Expression.t) list
-  -> Expression.t option
-  -> Expression.t
+  -> (longident_loc * expression) list
+  -> expression option
+  -> expression
 val pexp_field :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Longident_loc.t
-  -> Expression.t
+  -> expression
+  -> longident_loc
+  -> expression
 val pexp_setfield :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Longident_loc.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> longident_loc
+  -> expression
+  -> expression
 val pexp_array :
   loc:Astlib.Location.t
-  -> Expression.t list
-  -> Expression.t
+  -> expression list
+  -> expression
 val pexp_ifthenelse :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Expression.t
-  -> Expression.t option
-  -> Expression.t
+  -> expression
+  -> expression
+  -> expression option
+  -> expression
 val pexp_sequence :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
+  -> expression
 val pexp_while :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
+  -> expression
 val pexp_for :
   loc:Astlib.Location.t
-  -> Pattern.t
-  -> Expression.t
-  -> Expression.t
-  -> Direction_flag.t
-  -> Expression.t
-  -> Expression.t
+  -> pattern
+  -> expression
+  -> expression
+  -> direction_flag
+  -> expression
+  -> expression
 val pexp_constraint :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Core_type.t
-  -> Expression.t
+  -> expression
+  -> core_type
+  -> expression
 val pexp_coerce :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Core_type.t option
-  -> Core_type.t
-  -> Expression.t
+  -> expression
+  -> core_type option
+  -> core_type
+  -> expression
 val pexp_send :
   loc:Astlib.Location.t
-  -> Expression.t
+  -> expression
   -> string Astlib.Loc.t
-  -> Expression.t
+  -> expression
 val pexp_new :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Expression.t
+  -> longident_loc
+  -> expression
 val pexp_setinstvar :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
 val pexp_override :
   loc:Astlib.Location.t
-  -> (string Astlib.Loc.t * Expression.t) list
-  -> Expression.t
+  -> (string Astlib.Loc.t * expression) list
+  -> expression
 val pexp_letmodule :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Module_expr.t
-  -> Expression.t
-  -> Expression.t
+  -> module_expr
+  -> expression
+  -> expression
 val pexp_letexception :
   loc:Astlib.Location.t
-  -> Extension_constructor.t
-  -> Expression.t
-  -> Expression.t
+  -> extension_constructor
+  -> expression
+  -> expression
 val pexp_assert :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
 val pexp_lazy :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
 val pexp_poly :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Core_type.t option
-  -> Expression.t
+  -> expression
+  -> core_type option
+  -> expression
 val pexp_object :
   loc:Astlib.Location.t
-  -> Class_structure.t
-  -> Expression.t
+  -> class_structure
+  -> expression
 val pexp_newtype :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Expression.t
-  -> Expression.t
+  -> expression
+  -> expression
 val pexp_pack :
   loc:Astlib.Location.t
-  -> Module_expr.t
-  -> Expression.t
+  -> module_expr
+  -> expression
 val pexp_open :
   loc:Astlib.Location.t
-  -> Override_flag.t
-  -> Longident_loc.t
-  -> Expression.t
-  -> Expression.t
+  -> override_flag
+  -> longident_loc
+  -> expression
+  -> expression
 val pexp_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Expression.t
+  -> extension
+  -> expression
 val pexp_unreachable :
   loc:Astlib.Location.t
-  -> Expression.t
+  -> expression
 val case :
-  guard:Expression.t option
-  -> lhs:Pattern.t
-  -> rhs:Expression.t
-  -> Case.t
+  guard:expression option
+  -> lhs:pattern
+  -> rhs:expression
+  -> case
 val value_description :
   loc:Astlib.Location.t
   -> name:string Astlib.Loc.t
   -> prim:string list
-  -> type_:Core_type.t
-  -> Value_description.t
+  -> type_:core_type
+  -> value_description
 val type_declaration :
   loc:Astlib.Location.t
-  -> cstrs:(Core_type.t * Core_type.t * Astlib.Location.t) list
-  -> kind:Type_kind.t
-  -> manifest:Core_type.t option
+  -> cstrs:(core_type * core_type * Astlib.Location.t) list
+  -> kind:type_kind
+  -> manifest:core_type option
   -> name:string Astlib.Loc.t
-  -> params:(Core_type.t * Variance.t) list
-  -> private_:Private_flag.t
-  -> Type_declaration.t
+  -> params:(core_type * variance) list
+  -> private_:private_flag
+  -> type_declaration
 val label_declaration :
   loc:Astlib.Location.t
-  -> mutable_:Mutable_flag.t
+  -> mutable_:mutable_flag
   -> name:string Astlib.Loc.t
-  -> type_:Core_type.t
-  -> Label_declaration.t
+  -> type_:core_type
+  -> label_declaration
 val constructor_declaration :
   loc:Astlib.Location.t
-  -> args:Constructor_arguments.t
+  -> args:constructor_arguments
   -> name:string Astlib.Loc.t
-  -> res:Core_type.t option
-  -> Constructor_declaration.t
+  -> res:core_type option
+  -> constructor_declaration
 val type_extension :
-  constructors:Extension_constructor.t list
-  -> params:(Core_type.t * Variance.t) list
-  -> path:Longident_loc.t
-  -> private_:Private_flag.t
-  -> Type_extension.t
+  constructors:extension_constructor list
+  -> params:(core_type * variance) list
+  -> path:longident_loc
+  -> private_:private_flag
+  -> type_extension
 val extension_constructor :
   loc:Astlib.Location.t
-  -> kind:Extension_constructor_kind.t
+  -> kind:extension_constructor_kind
   -> name:string Astlib.Loc.t
-  -> Extension_constructor.t
+  -> extension_constructor
 val pcty_constr :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Core_type.t list
-  -> Class_type.t
+  -> longident_loc
+  -> core_type list
+  -> class_type
 val pcty_signature :
   loc:Astlib.Location.t
-  -> Class_signature.t
-  -> Class_type.t
+  -> class_signature
+  -> class_type
 val pcty_arrow :
   loc:Astlib.Location.t
-  -> Arg_label.t
-  -> Core_type.t
-  -> Class_type.t
-  -> Class_type.t
+  -> arg_label
+  -> core_type
+  -> class_type
+  -> class_type
 val pcty_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Class_type.t
+  -> extension
+  -> class_type
 val pcty_open :
   loc:Astlib.Location.t
-  -> Override_flag.t
-  -> Longident_loc.t
-  -> Class_type.t
-  -> Class_type.t
+  -> override_flag
+  -> longident_loc
+  -> class_type
+  -> class_type
 val class_signature :
-  fields:Class_type_field.t list
-  -> self:Core_type.t
-  -> Class_signature.t
+  fields:class_type_field list
+  -> self:core_type
+  -> class_signature
 val pctf_inherit :
   loc:Astlib.Location.t
-  -> Class_type.t
-  -> Class_type_field.t
+  -> class_type
+  -> class_type_field
 val pctf_val :
   loc:Astlib.Location.t
-  -> (string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
-  -> Class_type_field.t
+  -> (string Astlib.Loc.t * mutable_flag * virtual_flag * core_type)
+  -> class_type_field
 val pctf_method :
   loc:Astlib.Location.t
-  -> (string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
-  -> Class_type_field.t
+  -> (string Astlib.Loc.t * private_flag * virtual_flag * core_type)
+  -> class_type_field
 val pctf_constraint :
   loc:Astlib.Location.t
-  -> (Core_type.t * Core_type.t)
-  -> Class_type_field.t
+  -> (core_type * core_type)
+  -> class_type_field
 val pctf_attribute :
   loc:Astlib.Location.t
-  -> Attribute.t
-  -> Class_type_field.t
+  -> attribute
+  -> class_type_field
 val pctf_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Class_type_field.t
+  -> extension
+  -> class_type_field
 val pcl_constr :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Core_type.t list
-  -> Class_expr.t
+  -> longident_loc
+  -> core_type list
+  -> class_expr
 val pcl_structure :
   loc:Astlib.Location.t
-  -> Class_structure.t
-  -> Class_expr.t
+  -> class_structure
+  -> class_expr
 val pcl_fun :
   loc:Astlib.Location.t
-  -> Arg_label.t
-  -> Expression.t option
-  -> Pattern.t
-  -> Class_expr.t
-  -> Class_expr.t
+  -> arg_label
+  -> expression option
+  -> pattern
+  -> class_expr
+  -> class_expr
 val pcl_apply :
   loc:Astlib.Location.t
-  -> Class_expr.t
-  -> (Arg_label.t * Expression.t) list
-  -> Class_expr.t
+  -> class_expr
+  -> (arg_label * expression) list
+  -> class_expr
 val pcl_let :
   loc:Astlib.Location.t
-  -> Rec_flag.t
-  -> Value_binding.t list
-  -> Class_expr.t
-  -> Class_expr.t
+  -> rec_flag
+  -> value_binding list
+  -> class_expr
+  -> class_expr
 val pcl_constraint :
   loc:Astlib.Location.t
-  -> Class_expr.t
-  -> Class_type.t
-  -> Class_expr.t
+  -> class_expr
+  -> class_type
+  -> class_expr
 val pcl_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Class_expr.t
+  -> extension
+  -> class_expr
 val pcl_open :
   loc:Astlib.Location.t
-  -> Override_flag.t
-  -> Longident_loc.t
-  -> Class_expr.t
-  -> Class_expr.t
+  -> override_flag
+  -> longident_loc
+  -> class_expr
+  -> class_expr
 val class_structure :
-  fields:Class_field.t list
-  -> self:Pattern.t
-  -> Class_structure.t
+  fields:class_field list
+  -> self:pattern
+  -> class_structure
 val pcf_inherit :
   loc:Astlib.Location.t
-  -> Override_flag.t
-  -> Class_expr.t
+  -> override_flag
+  -> class_expr
   -> string Astlib.Loc.t option
-  -> Class_field.t
+  -> class_field
 val pcf_val :
   loc:Astlib.Location.t
-  -> (string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
-  -> Class_field.t
+  -> (string Astlib.Loc.t * mutable_flag * class_field_kind)
+  -> class_field
 val pcf_method :
   loc:Astlib.Location.t
-  -> (string Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
-  -> Class_field.t
+  -> (string Astlib.Loc.t * private_flag * class_field_kind)
+  -> class_field
 val pcf_constraint :
   loc:Astlib.Location.t
-  -> (Core_type.t * Core_type.t)
-  -> Class_field.t
+  -> (core_type * core_type)
+  -> class_field
 val pcf_initializer :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Class_field.t
+  -> expression
+  -> class_field
 val pcf_attribute :
   loc:Astlib.Location.t
-  -> Attribute.t
-  -> Class_field.t
+  -> attribute
+  -> class_field
 val pcf_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Class_field.t
+  -> extension
+  -> class_field
 val pmty_ident :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Module_type.t
+  -> longident_loc
+  -> module_type
 val pmty_signature :
   loc:Astlib.Location.t
-  -> Signature.t
-  -> Module_type.t
+  -> signature
+  -> module_type
 val pmty_functor :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Module_type.t option
-  -> Module_type.t
-  -> Module_type.t
+  -> module_type option
+  -> module_type
+  -> module_type
 val pmty_with :
   loc:Astlib.Location.t
-  -> Module_type.t
-  -> With_constraint.t list
-  -> Module_type.t
+  -> module_type
+  -> with_constraint list
+  -> module_type
 val pmty_typeof :
   loc:Astlib.Location.t
-  -> Module_expr.t
-  -> Module_type.t
+  -> module_expr
+  -> module_type
 val pmty_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Module_type.t
+  -> extension
+  -> module_type
 val pmty_alias :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Module_type.t
+  -> longident_loc
+  -> module_type
 val psig_value :
   loc:Astlib.Location.t
-  -> Value_description.t
-  -> Signature_item.t
+  -> value_description
+  -> signature_item
 val psig_type :
   loc:Astlib.Location.t
-  -> Rec_flag.t
-  -> Type_declaration.t list
-  -> Signature_item.t
+  -> rec_flag
+  -> type_declaration list
+  -> signature_item
 val psig_typext :
   loc:Astlib.Location.t
-  -> Type_extension.t
-  -> Signature_item.t
+  -> type_extension
+  -> signature_item
 val psig_exception :
   loc:Astlib.Location.t
-  -> Extension_constructor.t
-  -> Signature_item.t
+  -> extension_constructor
+  -> signature_item
 val psig_module :
   loc:Astlib.Location.t
-  -> Module_declaration.t
-  -> Signature_item.t
+  -> module_declaration
+  -> signature_item
 val psig_recmodule :
   loc:Astlib.Location.t
-  -> Module_declaration.t list
-  -> Signature_item.t
+  -> module_declaration list
+  -> signature_item
 val psig_modtype :
   loc:Astlib.Location.t
-  -> Module_type_declaration.t
-  -> Signature_item.t
+  -> module_type_declaration
+  -> signature_item
 val psig_open :
   loc:Astlib.Location.t
-  -> Open_description.t
-  -> Signature_item.t
+  -> open_description
+  -> signature_item
 val psig_include :
   loc:Astlib.Location.t
-  -> Include_description.t
-  -> Signature_item.t
+  -> include_description
+  -> signature_item
 val psig_class :
   loc:Astlib.Location.t
-  -> Class_description.t list
-  -> Signature_item.t
+  -> class_description list
+  -> signature_item
 val psig_class_type :
   loc:Astlib.Location.t
-  -> Class_type_declaration.t list
-  -> Signature_item.t
+  -> class_type_declaration list
+  -> signature_item
 val psig_attribute :
   loc:Astlib.Location.t
-  -> Attribute.t
-  -> Signature_item.t
+  -> attribute
+  -> signature_item
 val psig_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Attributes.t
-  -> Signature_item.t
+  -> extension
+  -> attributes
+  -> signature_item
 val module_declaration :
   loc:Astlib.Location.t
   -> name:string Astlib.Loc.t
-  -> type_:Module_type.t
-  -> Module_declaration.t
+  -> type_:module_type
+  -> module_declaration
 val module_type_declaration :
   loc:Astlib.Location.t
   -> name:string Astlib.Loc.t
-  -> type_:Module_type.t option
-  -> Module_type_declaration.t
+  -> type_:module_type option
+  -> module_type_declaration
 val open_description :
   loc:Astlib.Location.t
-  -> lid:Longident_loc.t
-  -> override:Override_flag.t
-  -> Open_description.t
+  -> lid:longident_loc
+  -> override:override_flag
+  -> open_description
 val pmod_ident :
   loc:Astlib.Location.t
-  -> Longident_loc.t
-  -> Module_expr.t
+  -> longident_loc
+  -> module_expr
 val pmod_structure :
   loc:Astlib.Location.t
-  -> Structure.t
-  -> Module_expr.t
+  -> structure
+  -> module_expr
 val pmod_functor :
   loc:Astlib.Location.t
   -> string Astlib.Loc.t
-  -> Module_type.t option
-  -> Module_expr.t
-  -> Module_expr.t
+  -> module_type option
+  -> module_expr
+  -> module_expr
 val pmod_apply :
   loc:Astlib.Location.t
-  -> Module_expr.t
-  -> Module_expr.t
-  -> Module_expr.t
+  -> module_expr
+  -> module_expr
+  -> module_expr
 val pmod_constraint :
   loc:Astlib.Location.t
-  -> Module_expr.t
-  -> Module_type.t
-  -> Module_expr.t
+  -> module_expr
+  -> module_type
+  -> module_expr
 val pmod_unpack :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Module_expr.t
+  -> expression
+  -> module_expr
 val pmod_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Module_expr.t
+  -> extension
+  -> module_expr
 val pstr_eval :
   loc:Astlib.Location.t
-  -> Expression.t
-  -> Attributes.t
-  -> Structure_item.t
+  -> expression
+  -> attributes
+  -> structure_item
 val pstr_value :
   loc:Astlib.Location.t
-  -> Rec_flag.t
-  -> Value_binding.t list
-  -> Structure_item.t
+  -> rec_flag
+  -> value_binding list
+  -> structure_item
 val pstr_primitive :
   loc:Astlib.Location.t
-  -> Value_description.t
-  -> Structure_item.t
+  -> value_description
+  -> structure_item
 val pstr_type :
   loc:Astlib.Location.t
-  -> Rec_flag.t
-  -> Type_declaration.t list
-  -> Structure_item.t
+  -> rec_flag
+  -> type_declaration list
+  -> structure_item
 val pstr_typext :
   loc:Astlib.Location.t
-  -> Type_extension.t
-  -> Structure_item.t
+  -> type_extension
+  -> structure_item
 val pstr_exception :
   loc:Astlib.Location.t
-  -> Extension_constructor.t
-  -> Structure_item.t
+  -> extension_constructor
+  -> structure_item
 val pstr_module :
   loc:Astlib.Location.t
-  -> Module_binding.t
-  -> Structure_item.t
+  -> module_binding
+  -> structure_item
 val pstr_recmodule :
   loc:Astlib.Location.t
-  -> Module_binding.t list
-  -> Structure_item.t
+  -> module_binding list
+  -> structure_item
 val pstr_modtype :
   loc:Astlib.Location.t
-  -> Module_type_declaration.t
-  -> Structure_item.t
+  -> module_type_declaration
+  -> structure_item
 val pstr_open :
   loc:Astlib.Location.t
-  -> Open_description.t
-  -> Structure_item.t
+  -> open_description
+  -> structure_item
 val pstr_class :
   loc:Astlib.Location.t
-  -> Class_declaration.t list
-  -> Structure_item.t
+  -> class_declaration list
+  -> structure_item
 val pstr_class_type :
   loc:Astlib.Location.t
-  -> Class_type_declaration.t list
-  -> Structure_item.t
+  -> class_type_declaration list
+  -> structure_item
 val pstr_include :
   loc:Astlib.Location.t
-  -> Include_declaration.t
-  -> Structure_item.t
+  -> include_declaration
+  -> structure_item
 val pstr_attribute :
   loc:Astlib.Location.t
-  -> Attribute.t
-  -> Structure_item.t
+  -> attribute
+  -> structure_item
 val pstr_extension :
   loc:Astlib.Location.t
-  -> Extension.t
-  -> Attributes.t
-  -> Structure_item.t
+  -> extension
+  -> attributes
+  -> structure_item
 val value_binding :
   loc:Astlib.Location.t
-  -> expr:Expression.t
-  -> pat:Pattern.t
-  -> Value_binding.t
+  -> expr:expression
+  -> pat:pattern
+  -> value_binding
 val module_binding :
   loc:Astlib.Location.t
-  -> expr:Module_expr.t
+  -> expr:module_expr
   -> name:string Astlib.Loc.t
-  -> Module_binding.t
+  -> module_binding
 (*$*)

--- a/ast/cinaps/gen_builder.ml
+++ b/ast/cinaps/gen_builder.ml
@@ -47,9 +47,9 @@ module Arrow = struct
     }
 
   let print_sig { ret; args } =
-    Grammar.string_of_ty ~internal:false ret
+    Grammar.string_of_ty ~nodify:false ret
     |> Ml.print_arrow args ~f:(fun a ->
-      let typ = Grammar.string_of_ty ~internal:false a.typ in
+      let typ = Grammar.string_of_ty ~nodify:false a.typ in
       match a.label with
       | None -> typ
       | Some label -> Ml.id label ^ ":" ^ typ)
@@ -287,12 +287,11 @@ let print_builder_ml version =
 let print_builder_mli version =
   Print.newline ();
   let grammar = Astlib.History.find_grammar Astlib.history ~version in
-  let version = Ml.module_name (Astlib.Version.to_string version) in
   let shortcut =
     let m = lazy (Shortcut.Map.from_grammar grammar) in
     fun name -> Shortcut.Map.find (Lazy.force m) name
   in
-  Print.println "open Versions.%s" version;
+  Print.println "open Versions";
   List.iter grammar ~f:(fun (node_name, (kind : Astlib.Grammar.kind)) ->
     let builders = builders node_name kind shortcut in
     List.iter ~f:Builder.print_sig builders)

--- a/ast/cinaps/gen_versions.ml
+++ b/ast/cinaps/gen_versions.ml
@@ -1,11 +1,10 @@
 open Stdppx
 
-module Render (Config : sig val internal : bool end) = struct
-  let string_of_ty ?nodify ty =
-    Grammar.string_of_ty ?nodify ~internal:Config.internal ty
+module Render = struct
+  let string_of_ty ?(nodify=false) ty = Grammar.string_of_ty ~nodify ty
 
-  let string_of_tuple_type ?(parens = true) tuple =
-    Grammar.string_of_tuple_type ~internal:Config.internal ~parens tuple
+  let string_of_tuple_type ?(nodify=false) ?(parens=true) tuple =
+    Grammar.string_of_tuple_type ~nodify ~parens tuple
 
   let print_record_type record =
     Ml.print_record_type record ~f:string_of_ty
@@ -27,8 +26,6 @@ module Render (Config : sig val internal : bool end) = struct
 end
 
 module Signature = struct
-  module Render = Render (struct let internal = false end)
-
   let inst_node ty ~tvars =
     Ml.poly_inst ty ~args:(List.map tvars ~f:(fun tvar ->
       Render.string_of_ty (Instance ("node", [Tvar tvar]))))
@@ -113,8 +110,6 @@ module Signature = struct
 end
 
 module Structure = struct
-  module Render = Render (struct let internal = true end)
-
   let rec ast_of_ty ~grammar ty =
     match (ty : Astlib.Grammar.ty) with
     | Var _

--- a/ast/cinaps/gen_viewer.ml
+++ b/ast/cinaps/gen_viewer.ml
@@ -1,6 +1,6 @@
 open Stdppx
 
-let string_of_ty ty = Grammar.string_of_ty ~internal:false ty
+let string_of_ty ty = Grammar.string_of_ty ~nodify:false ty
 
 let variant_viewer_name cname =
   Ml.id (cname ^ "'const")
@@ -343,6 +343,5 @@ let print_viewer_mli version =
   let wrapper_types = wrapper_types grammar in
   let shortcuts = Shortcut.Map.from_grammar grammar in
   Print.println "open Versions";
-  Print.println "open %s" (Ml.module_name (Astlib.Version.to_string version));
   Print.println "include module type of Viewer_common";
   List.iter grammar ~f:(print_viewer ~what:`Intf ~shortcuts ~wrapper_types)

--- a/ast/cinaps/grammar.ml
+++ b/ast/cinaps/grammar.ml
@@ -1,7 +1,6 @@
 open Stdppx
 
-let string_of_name ~internal name =
-  if internal then Ml.id name else Ml.module_name name ^ ".t"
+let string_of_name name = Ml.id name
 
 let string_of_var ~nodify var =
   if nodify then
@@ -9,30 +8,29 @@ let string_of_var ~nodify var =
   else
     Ml.tvar var
 
-let string_of_targ ?(nodify=false) ~internal targ =
+let string_of_targ ~nodify targ =
   match (targ : Astlib.Grammar.targ) with
-  | Tname name -> string_of_name ~internal name
+  | Tname name -> string_of_name name
   | Tvar var -> string_of_var ~nodify var
 
-let rec string_of_ty ?(nodify=false) ~internal ty =
+let rec string_of_ty ~nodify ty =
   match (ty : Astlib.Grammar.ty) with
   | Var var -> string_of_var ~nodify var
-  | Name name -> string_of_name ~internal name
+  | Name name -> string_of_name name
   | Bool -> "bool"
   | Char -> "char"
   | Int -> "int"
   | String -> "string"
   | Location -> "Astlib.Location.t"
-  | Loc ty -> string_of_ty ~nodify ~internal ty ^ " Astlib.Loc.t"
-  | List ty -> string_of_ty ~nodify ~internal ty ^ " list"
-  | Option ty -> string_of_ty ~nodify ~internal ty ^ " option"
-  | Tuple tuple -> string_of_tuple_type ~nodify ~internal tuple
+  | Loc ty -> string_of_ty ~nodify ty ^ " Astlib.Loc.t"
+  | List ty -> string_of_ty ~nodify ty ^ " list"
+  | Option ty -> string_of_ty ~nodify ty ^ " option"
+  | Tuple tuple -> string_of_tuple_type ~nodify ~parens:true tuple
   | Instance (poly, args) ->
-    let name = if poly = "node" || internal then poly else poly ^ ".t" in
-    Ml.poly_inst name ~args:(List.map args ~f:(string_of_targ ~nodify ~internal))
+    Ml.poly_inst (string_of_name poly) ~args:(List.map args ~f:(string_of_targ ~nodify))
 
-and string_of_tuple_type ?nodify ~internal ?(parens = true) tuple =
-  Printf.sprintf "%s%s%s"
-    (if parens then "(" else "")
-    (Ml.tuple_type (List.map tuple ~f:(string_of_ty ?nodify ~internal)))
-    (if parens then ")" else "")
+and string_of_tuple_type ~nodify ~parens tuple =
+  let inner = Ml.tuple_type (List.map tuple ~f:(string_of_ty ~nodify)) in
+  if parens
+  then Printf.sprintf "(%s)" inner
+  else inner

--- a/ast/cinaps/grammar.mli
+++ b/ast/cinaps/grammar.mli
@@ -7,13 +7,12 @@
     [Versions] only accept polymorphic types instantiated with other AST
     types. *)
 
-val string_of_targ : ?nodify: bool -> internal: bool -> Astlib.Grammar.targ -> string
+val string_of_targ : nodify: bool -> Astlib.Grammar.targ -> string
 
-val string_of_ty : ?nodify: bool -> internal: bool -> Astlib.Grammar.ty -> string
+val string_of_ty : nodify: bool -> Astlib.Grammar.ty -> string
 
-val string_of_tuple_type :
-  ?nodify: bool ->
-  internal: bool ->
-  ?parens: bool ->
-  Astlib.Grammar.ty list ->
-  string
+val string_of_tuple_type
+  :  nodify: bool
+  -> parens: bool
+  -> Astlib.Grammar.ty list
+  -> string

--- a/ast/ppx_ast.ml
+++ b/ast/ppx_ast.ml
@@ -2,10 +2,11 @@ module Compiler_types = Compiler_types
 module Conversion = Conversion
 module Traverse_builtins = Traverse_builtins
 include Unversioned.Types
+include Builder_common
 
 module V4_07 = struct
   include Versions.V4_07
-  include Builder.V4_07
+  include Builder_v4_07
   include Viewer.V4_07
   include Traverse.V4_07
   module Virtual = Virtual_traverse_v4_07
@@ -13,7 +14,7 @@ end
 
 module Unstable_for_testing = struct
   include Versions.Unstable_for_testing
-  include Builder.Unstable_for_testing
+  include Builder_unstable_for_testing
   include Viewer.Unstable_for_testing
   include Traverse.Unstable_for_testing
   module Virtual = Virtual_traverse_unstable_for_testing

--- a/ast/version_unstable_for_testing.mli
+++ b/ast/version_unstable_for_testing.mli
@@ -6,7 +6,7 @@ module rec Directive_argument : sig
 
   type concrete =
     | Pdir_bool of bool
-    | Pdir_ident of Longident.t
+    | Pdir_ident of longident
     | Pdir_int of char option * string
     | Pdir_string of string
     | Pdir_none
@@ -19,7 +19,7 @@ module rec Directive_argument : sig
     bool
     -> t
   val pdir_ident :
-    Longident.t
+    longident
     -> t
   val pdir_int :
     char option
@@ -35,19 +35,19 @@ and Toplevel_phrase : sig
   type t = toplevel_phrase
 
   type concrete =
-    | Ptop_dir of Directive_argument.t * string
-    | Ptop_def of Structure.t
+    | Ptop_dir of directive_argument * string
+    | Ptop_def of structure
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val ptop_dir :
-    Directive_argument.t
+    directive_argument
     -> string
     -> t
   val ptop_def :
-    Structure.t
+    structure
     -> t
 end
 
@@ -56,8 +56,8 @@ and Module_binding : sig
 
   type concrete =
     { pmb_loc : Astlib.Location.t
-    ; pmb_attributes : Attributes.t
-    ; pmb_expr : Module_expr.t
+    ; pmb_attributes : attributes
+    ; pmb_expr : module_expr
     ; pmb_name : string Astlib.Loc.t
     }
 
@@ -67,20 +67,20 @@ and Module_binding : sig
 
   val create :
     pmb_loc:Astlib.Location.t
-    -> pmb_attributes:Attributes.t
-    -> pmb_expr:Module_expr.t
+    -> pmb_attributes:attributes
+    -> pmb_expr:module_expr
     -> pmb_name:string Astlib.Loc.t
     -> t
   val update :
     ?pmb_loc:Astlib.Location.t
-    -> ?pmb_attributes:Attributes.t
-    -> ?pmb_expr:Module_expr.t
+    -> ?pmb_attributes:attributes
+    -> ?pmb_expr:module_expr
     -> ?pmb_name:string Astlib.Loc.t
     -> t -> t
 
   val pmb_loc : t -> Astlib.Location.t
-  val pmb_attributes : t -> Attributes.t
-  val pmb_expr : t -> Module_expr.t
+  val pmb_attributes : t -> attributes
+  val pmb_expr : t -> module_expr
   val pmb_name : t -> string Astlib.Loc.t
 end
 
@@ -89,9 +89,9 @@ and Value_binding : sig
 
   type concrete =
     { pvb_loc : Astlib.Location.t
-    ; pvb_attributes : Attributes.t
-    ; pvb_expr : Expression.t
-    ; pvb_pat : Pattern.t
+    ; pvb_attributes : attributes
+    ; pvb_expr : expression
+    ; pvb_pat : pattern
     }
 
   val of_concrete : concrete -> t
@@ -100,95 +100,95 @@ and Value_binding : sig
 
   val create :
     pvb_loc:Astlib.Location.t
-    -> pvb_attributes:Attributes.t
-    -> pvb_expr:Expression.t
-    -> pvb_pat:Pattern.t
+    -> pvb_attributes:attributes
+    -> pvb_expr:expression
+    -> pvb_pat:pattern
     -> t
   val update :
     ?pvb_loc:Astlib.Location.t
-    -> ?pvb_attributes:Attributes.t
-    -> ?pvb_expr:Expression.t
-    -> ?pvb_pat:Pattern.t
+    -> ?pvb_attributes:attributes
+    -> ?pvb_expr:expression
+    -> ?pvb_pat:pattern
     -> t -> t
 
   val pvb_loc : t -> Astlib.Location.t
-  val pvb_attributes : t -> Attributes.t
-  val pvb_expr : t -> Expression.t
-  val pvb_pat : t -> Pattern.t
+  val pvb_attributes : t -> attributes
+  val pvb_expr : t -> expression
+  val pvb_pat : t -> pattern
 end
 
 and Structure_item_desc : sig
   type t = structure_item_desc
 
   type concrete =
-    | Pstr_extension of Attributes.t * Extension.t
-    | Pstr_attribute of Attribute.t
-    | Pstr_include of Include_declaration.t
-    | Pstr_class_type of Class_type_declaration.t list
-    | Pstr_class of Class_declaration.t list
-    | Pstr_open of Open_description.t
-    | Pstr_modtype of Module_type_declaration.t
-    | Pstr_recmodule of Module_binding.t list
-    | Pstr_module of Module_binding.t
-    | Pstr_exception of Extension_constructor.t
-    | Pstr_typext of Type_extension.t
-    | Pstr_type of Type_declaration.t list * Rec_flag.t
-    | Pstr_primitive of Value_description.t
-    | Pstr_value of Value_binding.t list * Rec_flag.t
-    | Pstr_eval of Attributes.t * Expression.t
+    | Pstr_extension of attributes * extension
+    | Pstr_attribute of attribute
+    | Pstr_include of include_declaration
+    | Pstr_class_type of class_type_declaration list
+    | Pstr_class of class_declaration list
+    | Pstr_open of open_description
+    | Pstr_modtype of module_type_declaration
+    | Pstr_recmodule of module_binding list
+    | Pstr_module of module_binding
+    | Pstr_exception of extension_constructor
+    | Pstr_typext of type_extension
+    | Pstr_type of type_declaration list * rec_flag
+    | Pstr_primitive of value_description
+    | Pstr_value of value_binding list * rec_flag
+    | Pstr_eval of attributes * expression
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pstr_extension :
-    Attributes.t
-    -> Extension.t
+    attributes
+    -> extension
     -> t
   val pstr_attribute :
-    Attribute.t
+    attribute
     -> t
   val pstr_include :
-    Include_declaration.t
+    include_declaration
     -> t
   val pstr_class_type :
-    Class_type_declaration.t list
+    class_type_declaration list
     -> t
   val pstr_class :
-    Class_declaration.t list
+    class_declaration list
     -> t
   val pstr_open :
-    Open_description.t
+    open_description
     -> t
   val pstr_modtype :
-    Module_type_declaration.t
+    module_type_declaration
     -> t
   val pstr_recmodule :
-    Module_binding.t list
+    module_binding list
     -> t
   val pstr_module :
-    Module_binding.t
+    module_binding
     -> t
   val pstr_exception :
-    Extension_constructor.t
+    extension_constructor
     -> t
   val pstr_typext :
-    Type_extension.t
+    type_extension
     -> t
   val pstr_type :
-    Type_declaration.t list
-    -> Rec_flag.t
+    type_declaration list
+    -> rec_flag
     -> t
   val pstr_primitive :
-    Value_description.t
+    value_description
     -> t
   val pstr_value :
-    Value_binding.t list
-    -> Rec_flag.t
+    value_binding list
+    -> rec_flag
     -> t
   val pstr_eval :
-    Attributes.t
-    -> Expression.t
+    attributes
+    -> expression
     -> t
 end
 
@@ -197,7 +197,7 @@ and Structure_item : sig
 
   type concrete =
     { pstr_loc : Astlib.Location.t
-    ; pstr_desc : Structure_item_desc.t
+    ; pstr_desc : structure_item_desc
     }
 
   val of_concrete : concrete -> t
@@ -206,69 +206,69 @@ and Structure_item : sig
 
   val create :
     pstr_loc:Astlib.Location.t
-    -> pstr_desc:Structure_item_desc.t
+    -> pstr_desc:structure_item_desc
     -> t
   val update :
     ?pstr_loc:Astlib.Location.t
-    -> ?pstr_desc:Structure_item_desc.t
+    -> ?pstr_desc:structure_item_desc
     -> t -> t
 
   val pstr_loc : t -> Astlib.Location.t
-  val pstr_desc : t -> Structure_item_desc.t
+  val pstr_desc : t -> structure_item_desc
 end
 
 and Structure : sig
   type t = structure
 
-  type concrete = Structure_item.t list
+  type concrete = structure_item list
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Structure_item.t list -> t
+  val create : structure_item list -> t
 end
 
 and Module_expr_desc : sig
   type t = module_expr_desc
 
   type concrete =
-    | Pmod_extension of Extension.t
-    | Pmod_unpack of Expression.t
-    | Pmod_constraint of Module_type.t * Module_expr.t
-    | Pmod_apply of Module_expr.t * Module_expr.t
-    | Pmod_functor of Module_expr.t * Module_type.t option * string Astlib.Loc.t
-    | Pmod_structure of Structure.t
-    | Pmod_ident of Longident_loc.t
+    | Pmod_extension of extension
+    | Pmod_unpack of expression
+    | Pmod_constraint of module_type * module_expr
+    | Pmod_apply of module_expr * module_expr
+    | Pmod_functor of module_expr * module_type option * string Astlib.Loc.t
+    | Pmod_structure of structure
+    | Pmod_ident of longident_loc
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pmod_extension :
-    Extension.t
+    extension
     -> t
   val pmod_unpack :
-    Expression.t
+    expression
     -> t
   val pmod_constraint :
-    Module_type.t
-    -> Module_expr.t
+    module_type
+    -> module_expr
     -> t
   val pmod_apply :
-    Module_expr.t
-    -> Module_expr.t
+    module_expr
+    -> module_expr
     -> t
   val pmod_functor :
-    Module_expr.t
-    -> Module_type.t option
+    module_expr
+    -> module_type option
     -> string Astlib.Loc.t
     -> t
   val pmod_structure :
-    Structure.t
+    structure
     -> t
   val pmod_ident :
-    Longident_loc.t
+    longident_loc
     -> t
 end
 
@@ -276,9 +276,9 @@ and Module_expr : sig
   type t = module_expr
 
   type concrete =
-    { pmod_attributes : Attributes.t
+    { pmod_attributes : attributes
     ; pmod_loc : Astlib.Location.t
-    ; pmod_desc : Module_expr_desc.t
+    ; pmod_desc : module_expr_desc
     }
 
   val of_concrete : concrete -> t
@@ -286,81 +286,81 @@ and Module_expr : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pmod_attributes:Attributes.t
+    pmod_attributes:attributes
     -> pmod_loc:Astlib.Location.t
-    -> pmod_desc:Module_expr_desc.t
+    -> pmod_desc:module_expr_desc
     -> t
   val update :
-    ?pmod_attributes:Attributes.t
+    ?pmod_attributes:attributes
     -> ?pmod_loc:Astlib.Location.t
-    -> ?pmod_desc:Module_expr_desc.t
+    -> ?pmod_desc:module_expr_desc
     -> t -> t
 
-  val pmod_attributes : t -> Attributes.t
+  val pmod_attributes : t -> attributes
   val pmod_loc : t -> Astlib.Location.t
-  val pmod_desc : t -> Module_expr_desc.t
+  val pmod_desc : t -> module_expr_desc
 end
 
 and With_constraint : sig
   type t = with_constraint
 
   type concrete =
-    | Pwith_modsubst of Longident_loc.t * Longident_loc.t
-    | Pwith_typesubst of Type_declaration.t * Longident_loc.t
-    | Pwith_module of Longident_loc.t * Longident_loc.t
-    | Pwith_type of Type_declaration.t * Longident_loc.t
+    | Pwith_modsubst of longident_loc * longident_loc
+    | Pwith_typesubst of type_declaration * longident_loc
+    | Pwith_module of longident_loc * longident_loc
+    | Pwith_type of type_declaration * longident_loc
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pwith_modsubst :
-    Longident_loc.t
-    -> Longident_loc.t
+    longident_loc
+    -> longident_loc
     -> t
   val pwith_typesubst :
-    Type_declaration.t
-    -> Longident_loc.t
+    type_declaration
+    -> longident_loc
     -> t
   val pwith_module :
-    Longident_loc.t
-    -> Longident_loc.t
+    longident_loc
+    -> longident_loc
     -> t
   val pwith_type :
-    Type_declaration.t
-    -> Longident_loc.t
+    type_declaration
+    -> longident_loc
     -> t
 end
 
 and Include_declaration : sig
   type t = include_declaration
 
-  type concrete = Module_expr.t Include_infos.t
+  type concrete = module_expr include_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Module_expr.t Include_infos.t -> t
+  val create : module_expr include_infos -> t
 end
 
 and Include_description : sig
   type t = include_description
 
-  type concrete = Module_type.t Include_infos.t
+  type concrete = module_type include_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Module_type.t Include_infos.t -> t
+  val create : module_type include_infos -> t
 end
 
 and Include_infos : sig
   type 'a t = 'a include_infos
 
   type 'a concrete =
-    { pincl_attributes : Attributes.t
+    { pincl_attributes : attributes
     ; pincl_loc : Astlib.Location.t
     ; pincl_mod : 'a
     }
@@ -370,17 +370,17 @@ and Include_infos : sig
   val to_concrete_opt : 'a node t -> 'a node concrete option
 
   val create :
-    pincl_attributes:Attributes.t
+    pincl_attributes:attributes
     -> pincl_loc:Astlib.Location.t
     -> pincl_mod:'a node
     -> 'a node t
   val update :
-    ?pincl_attributes:Attributes.t
+    ?pincl_attributes:attributes
     -> ?pincl_loc:Astlib.Location.t
     -> ?pincl_mod:'a node
     -> 'a node t -> 'a node t
 
-  val pincl_attributes : 'a node t -> Attributes.t
+  val pincl_attributes : 'a node t -> attributes
   val pincl_loc : 'a node t -> Astlib.Location.t
   val pincl_mod : 'a node t -> 'a node
 end
@@ -389,10 +389,10 @@ and Open_description : sig
   type t = open_description
 
   type concrete =
-    { popen_attributes : Attributes.t
+    { popen_attributes : attributes
     ; popen_loc : Astlib.Location.t
-    ; popen_override : Override_flag.t
-    ; popen_lid : Longident_loc.t
+    ; popen_override : override_flag
+    ; popen_lid : longident_loc
     }
 
   val of_concrete : concrete -> t
@@ -400,22 +400,22 @@ and Open_description : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    popen_attributes:Attributes.t
+    popen_attributes:attributes
     -> popen_loc:Astlib.Location.t
-    -> popen_override:Override_flag.t
-    -> popen_lid:Longident_loc.t
+    -> popen_override:override_flag
+    -> popen_lid:longident_loc
     -> t
   val update :
-    ?popen_attributes:Attributes.t
+    ?popen_attributes:attributes
     -> ?popen_loc:Astlib.Location.t
-    -> ?popen_override:Override_flag.t
-    -> ?popen_lid:Longident_loc.t
+    -> ?popen_override:override_flag
+    -> ?popen_lid:longident_loc
     -> t -> t
 
-  val popen_attributes : t -> Attributes.t
+  val popen_attributes : t -> attributes
   val popen_loc : t -> Astlib.Location.t
-  val popen_override : t -> Override_flag.t
-  val popen_lid : t -> Longident_loc.t
+  val popen_override : t -> override_flag
+  val popen_lid : t -> longident_loc
 end
 
 and Module_type_declaration : sig
@@ -423,8 +423,8 @@ and Module_type_declaration : sig
 
   type concrete =
     { pmtd_loc : Astlib.Location.t
-    ; pmtd_attributes : Attributes.t
-    ; pmtd_type : Module_type.t option
+    ; pmtd_attributes : attributes
+    ; pmtd_type : module_type option
     ; pmtd_name : string Astlib.Loc.t
     }
 
@@ -434,20 +434,20 @@ and Module_type_declaration : sig
 
   val create :
     pmtd_loc:Astlib.Location.t
-    -> pmtd_attributes:Attributes.t
-    -> pmtd_type:Module_type.t option
+    -> pmtd_attributes:attributes
+    -> pmtd_type:module_type option
     -> pmtd_name:string Astlib.Loc.t
     -> t
   val update :
     ?pmtd_loc:Astlib.Location.t
-    -> ?pmtd_attributes:Attributes.t
-    -> ?pmtd_type:Module_type.t option
+    -> ?pmtd_attributes:attributes
+    -> ?pmtd_type:module_type option
     -> ?pmtd_name:string Astlib.Loc.t
     -> t -> t
 
   val pmtd_loc : t -> Astlib.Location.t
-  val pmtd_attributes : t -> Attributes.t
-  val pmtd_type : t -> Module_type.t option
+  val pmtd_attributes : t -> attributes
+  val pmtd_type : t -> module_type option
   val pmtd_name : t -> string Astlib.Loc.t
 end
 
@@ -456,8 +456,8 @@ and Module_declaration : sig
 
   type concrete =
     { pmd_loc : Astlib.Location.t
-    ; pmd_attributes : Attributes.t
-    ; pmd_type : Module_type.t
+    ; pmd_attributes : attributes
+    ; pmd_type : module_type
     ; pmd_name : string Astlib.Loc.t
     }
 
@@ -467,20 +467,20 @@ and Module_declaration : sig
 
   val create :
     pmd_loc:Astlib.Location.t
-    -> pmd_attributes:Attributes.t
-    -> pmd_type:Module_type.t
+    -> pmd_attributes:attributes
+    -> pmd_type:module_type
     -> pmd_name:string Astlib.Loc.t
     -> t
   val update :
     ?pmd_loc:Astlib.Location.t
-    -> ?pmd_attributes:Attributes.t
-    -> ?pmd_type:Module_type.t
+    -> ?pmd_attributes:attributes
+    -> ?pmd_type:module_type
     -> ?pmd_name:string Astlib.Loc.t
     -> t -> t
 
   val pmd_loc : t -> Astlib.Location.t
-  val pmd_attributes : t -> Attributes.t
-  val pmd_type : t -> Module_type.t
+  val pmd_attributes : t -> attributes
+  val pmd_type : t -> module_type
   val pmd_name : t -> string Astlib.Loc.t
 end
 
@@ -488,64 +488,64 @@ and Signature_item_desc : sig
   type t = signature_item_desc
 
   type concrete =
-    | Psig_extension of Attributes.t * Extension.t
-    | Psig_attribute of Attribute.t
-    | Psig_class_type of Class_type_declaration.t list
-    | Psig_class of Class_description.t list
-    | Psig_include of Include_description.t
-    | Psig_open of Open_description.t
-    | Psig_modtype of Module_type_declaration.t
-    | Psig_recmodule of Module_declaration.t list
-    | Psig_module of Module_declaration.t
-    | Psig_exception of Extension_constructor.t
-    | Psig_typext of Type_extension.t
-    | Psig_type of Type_declaration.t list * Rec_flag.t
-    | Psig_value of Value_description.t
+    | Psig_extension of attributes * extension
+    | Psig_attribute of attribute
+    | Psig_class_type of class_type_declaration list
+    | Psig_class of class_description list
+    | Psig_include of include_description
+    | Psig_open of open_description
+    | Psig_modtype of module_type_declaration
+    | Psig_recmodule of module_declaration list
+    | Psig_module of module_declaration
+    | Psig_exception of extension_constructor
+    | Psig_typext of type_extension
+    | Psig_type of type_declaration list * rec_flag
+    | Psig_value of value_description
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val psig_extension :
-    Attributes.t
-    -> Extension.t
+    attributes
+    -> extension
     -> t
   val psig_attribute :
-    Attribute.t
+    attribute
     -> t
   val psig_class_type :
-    Class_type_declaration.t list
+    class_type_declaration list
     -> t
   val psig_class :
-    Class_description.t list
+    class_description list
     -> t
   val psig_include :
-    Include_description.t
+    include_description
     -> t
   val psig_open :
-    Open_description.t
+    open_description
     -> t
   val psig_modtype :
-    Module_type_declaration.t
+    module_type_declaration
     -> t
   val psig_recmodule :
-    Module_declaration.t list
+    module_declaration list
     -> t
   val psig_module :
-    Module_declaration.t
+    module_declaration
     -> t
   val psig_exception :
-    Extension_constructor.t
+    extension_constructor
     -> t
   val psig_typext :
-    Type_extension.t
+    type_extension
     -> t
   val psig_type :
-    Type_declaration.t list
-    -> Rec_flag.t
+    type_declaration list
+    -> rec_flag
     -> t
   val psig_value :
-    Value_description.t
+    value_description
     -> t
 end
 
@@ -554,7 +554,7 @@ and Signature_item : sig
 
   type concrete =
     { psig_loc : Astlib.Location.t
-    ; psig_desc : Signature_item_desc.t
+    ; psig_desc : signature_item_desc
     }
 
   val of_concrete : concrete -> t
@@ -563,68 +563,68 @@ and Signature_item : sig
 
   val create :
     psig_loc:Astlib.Location.t
-    -> psig_desc:Signature_item_desc.t
+    -> psig_desc:signature_item_desc
     -> t
   val update :
     ?psig_loc:Astlib.Location.t
-    -> ?psig_desc:Signature_item_desc.t
+    -> ?psig_desc:signature_item_desc
     -> t -> t
 
   val psig_loc : t -> Astlib.Location.t
-  val psig_desc : t -> Signature_item_desc.t
+  val psig_desc : t -> signature_item_desc
 end
 
 and Signature : sig
   type t = signature
 
-  type concrete = Signature_item.t list
+  type concrete = signature_item list
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Signature_item.t list -> t
+  val create : signature_item list -> t
 end
 
 and Module_type_desc : sig
   type t = module_type_desc
 
   type concrete =
-    | Pmty_alias of Longident_loc.t
-    | Pmty_extension of Extension.t
-    | Pmty_typeof of Module_expr.t
-    | Pmty_with of With_constraint.t list * Module_type.t
-    | Pmty_functor of Module_type.t * Module_type.t option * string Astlib.Loc.t
-    | Pmty_signature of Signature.t
-    | Pmty_ident of Longident_loc.t
+    | Pmty_alias of longident_loc
+    | Pmty_extension of extension
+    | Pmty_typeof of module_expr
+    | Pmty_with of with_constraint list * module_type
+    | Pmty_functor of module_type * module_type option * string Astlib.Loc.t
+    | Pmty_signature of signature
+    | Pmty_ident of longident_loc
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pmty_alias :
-    Longident_loc.t
+    longident_loc
     -> t
   val pmty_extension :
-    Extension.t
+    extension
     -> t
   val pmty_typeof :
-    Module_expr.t
+    module_expr
     -> t
   val pmty_with :
-    With_constraint.t list
-    -> Module_type.t
+    with_constraint list
+    -> module_type
     -> t
   val pmty_functor :
-    Module_type.t
-    -> Module_type.t option
+    module_type
+    -> module_type option
     -> string Astlib.Loc.t
     -> t
   val pmty_signature :
-    Signature.t
+    signature
     -> t
   val pmty_ident :
-    Longident_loc.t
+    longident_loc
     -> t
 end
 
@@ -632,9 +632,9 @@ and Module_type : sig
   type t = module_type
 
   type concrete =
-    { pmty_attributes : Attributes.t
+    { pmty_attributes : attributes
     ; pmty_loc : Astlib.Location.t
-    ; pmty_desc : Module_type_desc.t
+    ; pmty_desc : module_type_desc
     }
 
   val of_concrete : concrete -> t
@@ -642,50 +642,50 @@ and Module_type : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pmty_attributes:Attributes.t
+    pmty_attributes:attributes
     -> pmty_loc:Astlib.Location.t
-    -> pmty_desc:Module_type_desc.t
+    -> pmty_desc:module_type_desc
     -> t
   val update :
-    ?pmty_attributes:Attributes.t
+    ?pmty_attributes:attributes
     -> ?pmty_loc:Astlib.Location.t
-    -> ?pmty_desc:Module_type_desc.t
+    -> ?pmty_desc:module_type_desc
     -> t -> t
 
-  val pmty_attributes : t -> Attributes.t
+  val pmty_attributes : t -> attributes
   val pmty_loc : t -> Astlib.Location.t
-  val pmty_desc : t -> Module_type_desc.t
+  val pmty_desc : t -> module_type_desc
 end
 
 and Class_declaration : sig
   type t = class_declaration
 
-  type concrete = Class_expr.t Class_infos.t
+  type concrete = class_expr class_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Class_expr.t Class_infos.t -> t
+  val create : class_expr class_infos -> t
 end
 
 and Class_field_kind : sig
   type t = class_field_kind
 
   type concrete =
-    | Cfk_concrete of Expression.t * Override_flag.t
-    | Cfk_virtual of Core_type.t
+    | Cfk_concrete of expression * override_flag
+    | Cfk_virtual of core_type
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val cfk_concrete :
-    Expression.t
-    -> Override_flag.t
+    expression
+    -> override_flag
     -> t
   val cfk_virtual :
-    Core_type.t
+    core_type
     -> t
 end
 
@@ -693,40 +693,40 @@ and Class_field_desc : sig
   type t = class_field_desc
 
   type concrete =
-    | Pcf_extension of Extension.t
-    | Pcf_attribute of Attribute.t
-    | Pcf_initializer of Expression.t
-    | Pcf_constraint of (Core_type.t * Core_type.t)
-    | Pcf_method of (Class_field_kind.t * Private_flag.t * string Astlib.Loc.t)
-    | Pcf_val of (Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t)
-    | Pcf_inherit of string Astlib.Loc.t option * Class_expr.t * Override_flag.t
+    | Pcf_extension of extension
+    | Pcf_attribute of attribute
+    | Pcf_initializer of expression
+    | Pcf_constraint of (core_type * core_type)
+    | Pcf_method of (class_field_kind * private_flag * string Astlib.Loc.t)
+    | Pcf_val of (class_field_kind * mutable_flag * string Astlib.Loc.t)
+    | Pcf_inherit of string Astlib.Loc.t option * class_expr * override_flag
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pcf_extension :
-    Extension.t
+    extension
     -> t
   val pcf_attribute :
-    Attribute.t
+    attribute
     -> t
   val pcf_initializer :
-    Expression.t
+    expression
     -> t
   val pcf_constraint :
-    (Core_type.t * Core_type.t)
+    (core_type * core_type)
     -> t
   val pcf_method :
-    (Class_field_kind.t * Private_flag.t * string Astlib.Loc.t)
+    (class_field_kind * private_flag * string Astlib.Loc.t)
     -> t
   val pcf_val :
-    (Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t)
+    (class_field_kind * mutable_flag * string Astlib.Loc.t)
     -> t
   val pcf_inherit :
     string Astlib.Loc.t option
-    -> Class_expr.t
-    -> Override_flag.t
+    -> class_expr
+    -> override_flag
     -> t
 end
 
@@ -734,9 +734,9 @@ and Class_field : sig
   type t = class_field
 
   type concrete =
-    { pcf_attributes : Attributes.t
+    { pcf_attributes : attributes
     ; pcf_loc : Astlib.Location.t
-    ; pcf_desc : Class_field_desc.t
+    ; pcf_desc : class_field_desc
     }
 
   val of_concrete : concrete -> t
@@ -744,27 +744,27 @@ and Class_field : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcf_attributes:Attributes.t
+    pcf_attributes:attributes
     -> pcf_loc:Astlib.Location.t
-    -> pcf_desc:Class_field_desc.t
+    -> pcf_desc:class_field_desc
     -> t
   val update :
-    ?pcf_attributes:Attributes.t
+    ?pcf_attributes:attributes
     -> ?pcf_loc:Astlib.Location.t
-    -> ?pcf_desc:Class_field_desc.t
+    -> ?pcf_desc:class_field_desc
     -> t -> t
 
-  val pcf_attributes : t -> Attributes.t
+  val pcf_attributes : t -> attributes
   val pcf_loc : t -> Astlib.Location.t
-  val pcf_desc : t -> Class_field_desc.t
+  val pcf_desc : t -> class_field_desc
 end
 
 and Class_structure : sig
   type t = class_structure
 
   type concrete =
-    { pcstr_fields : Class_field.t list
-    ; pcstr_self : Pattern.t
+    { pcstr_fields : class_field list
+    ; pcstr_self : pattern
     }
 
   val of_concrete : concrete -> t
@@ -772,68 +772,68 @@ and Class_structure : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcstr_fields:Class_field.t list
-    -> pcstr_self:Pattern.t
+    pcstr_fields:class_field list
+    -> pcstr_self:pattern
     -> t
   val update :
-    ?pcstr_fields:Class_field.t list
-    -> ?pcstr_self:Pattern.t
+    ?pcstr_fields:class_field list
+    -> ?pcstr_self:pattern
     -> t -> t
 
-  val pcstr_fields : t -> Class_field.t list
-  val pcstr_self : t -> Pattern.t
+  val pcstr_fields : t -> class_field list
+  val pcstr_self : t -> pattern
 end
 
 and Class_expr_desc : sig
   type t = class_expr_desc
 
   type concrete =
-    | Pcl_open of Class_expr.t * Longident_loc.t * Override_flag.t
-    | Pcl_extension of Extension.t
-    | Pcl_constraint of Class_type.t * Class_expr.t
-    | Pcl_let of Class_expr.t * Value_binding.t list * Rec_flag.t
-    | Pcl_apply of (Expression.t * Arg_label.t) list * Class_expr.t
-    | Pcl_fun of Class_expr.t * Pattern.t * Expression.t option * Arg_label.t
-    | Pcl_structure of Class_structure.t
-    | Pcl_constr of Core_type.t list * Longident_loc.t
+    | Pcl_open of class_expr * longident_loc * override_flag
+    | Pcl_extension of extension
+    | Pcl_constraint of class_type * class_expr
+    | Pcl_let of class_expr * value_binding list * rec_flag
+    | Pcl_apply of (expression * arg_label) list * class_expr
+    | Pcl_fun of class_expr * pattern * expression option * arg_label
+    | Pcl_structure of class_structure
+    | Pcl_constr of core_type list * longident_loc
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pcl_open :
-    Class_expr.t
-    -> Longident_loc.t
-    -> Override_flag.t
+    class_expr
+    -> longident_loc
+    -> override_flag
     -> t
   val pcl_extension :
-    Extension.t
+    extension
     -> t
   val pcl_constraint :
-    Class_type.t
-    -> Class_expr.t
+    class_type
+    -> class_expr
     -> t
   val pcl_let :
-    Class_expr.t
-    -> Value_binding.t list
-    -> Rec_flag.t
+    class_expr
+    -> value_binding list
+    -> rec_flag
     -> t
   val pcl_apply :
-    (Expression.t * Arg_label.t) list
-    -> Class_expr.t
+    (expression * arg_label) list
+    -> class_expr
     -> t
   val pcl_fun :
-    Class_expr.t
-    -> Pattern.t
-    -> Expression.t option
-    -> Arg_label.t
+    class_expr
+    -> pattern
+    -> expression option
+    -> arg_label
     -> t
   val pcl_structure :
-    Class_structure.t
+    class_structure
     -> t
   val pcl_constr :
-    Core_type.t list
-    -> Longident_loc.t
+    core_type list
+    -> longident_loc
     -> t
 end
 
@@ -841,9 +841,9 @@ and Class_expr : sig
   type t = class_expr
 
   type concrete =
-    { pcl_attributes : Attributes.t
+    { pcl_attributes : attributes
     ; pcl_loc : Astlib.Location.t
-    ; pcl_desc : Class_expr_desc.t
+    ; pcl_desc : class_expr_desc
     }
 
   val of_concrete : concrete -> t
@@ -851,55 +851,55 @@ and Class_expr : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcl_attributes:Attributes.t
+    pcl_attributes:attributes
     -> pcl_loc:Astlib.Location.t
-    -> pcl_desc:Class_expr_desc.t
+    -> pcl_desc:class_expr_desc
     -> t
   val update :
-    ?pcl_attributes:Attributes.t
+    ?pcl_attributes:attributes
     -> ?pcl_loc:Astlib.Location.t
-    -> ?pcl_desc:Class_expr_desc.t
+    -> ?pcl_desc:class_expr_desc
     -> t -> t
 
-  val pcl_attributes : t -> Attributes.t
+  val pcl_attributes : t -> attributes
   val pcl_loc : t -> Astlib.Location.t
-  val pcl_desc : t -> Class_expr_desc.t
+  val pcl_desc : t -> class_expr_desc
 end
 
 and Class_type_declaration : sig
   type t = class_type_declaration
 
-  type concrete = Class_type.t Class_infos.t
+  type concrete = class_type class_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Class_type.t Class_infos.t -> t
+  val create : class_type class_infos -> t
 end
 
 and Class_description : sig
   type t = class_description
 
-  type concrete = Class_type.t Class_infos.t
+  type concrete = class_type class_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Class_type.t Class_infos.t -> t
+  val create : class_type class_infos -> t
 end
 
 and Class_infos : sig
   type 'a t = 'a class_infos
 
   type 'a concrete =
-    { pci_attributes : Attributes.t
+    { pci_attributes : attributes
     ; pci_loc : Astlib.Location.t
     ; pci_expr : 'a
     ; pci_name : string Astlib.Loc.t
-    ; pci_params : (Variance.t * Core_type.t) list
-    ; pci_virt : Virtual_flag.t
+    ; pci_params : (variance * core_type) list
+    ; pci_virt : virtual_flag
     }
 
   val of_concrete : 'a node concrete -> 'a node t
@@ -907,62 +907,62 @@ and Class_infos : sig
   val to_concrete_opt : 'a node t -> 'a node concrete option
 
   val create :
-    pci_attributes:Attributes.t
+    pci_attributes:attributes
     -> pci_loc:Astlib.Location.t
     -> pci_expr:'a node
     -> pci_name:string Astlib.Loc.t
-    -> pci_params:(Variance.t * Core_type.t) list
-    -> pci_virt:Virtual_flag.t
+    -> pci_params:(variance * core_type) list
+    -> pci_virt:virtual_flag
     -> 'a node t
   val update :
-    ?pci_attributes:Attributes.t
+    ?pci_attributes:attributes
     -> ?pci_loc:Astlib.Location.t
     -> ?pci_expr:'a node
     -> ?pci_name:string Astlib.Loc.t
-    -> ?pci_params:(Variance.t * Core_type.t) list
-    -> ?pci_virt:Virtual_flag.t
+    -> ?pci_params:(variance * core_type) list
+    -> ?pci_virt:virtual_flag
     -> 'a node t -> 'a node t
 
-  val pci_attributes : 'a node t -> Attributes.t
+  val pci_attributes : 'a node t -> attributes
   val pci_loc : 'a node t -> Astlib.Location.t
   val pci_expr : 'a node t -> 'a node
   val pci_name : 'a node t -> string Astlib.Loc.t
-  val pci_params : 'a node t -> (Variance.t * Core_type.t) list
-  val pci_virt : 'a node t -> Virtual_flag.t
+  val pci_params : 'a node t -> (variance * core_type) list
+  val pci_virt : 'a node t -> virtual_flag
 end
 
 and Class_type_field_desc : sig
   type t = class_type_field_desc
 
   type concrete =
-    | Pctf_extension of Extension.t
-    | Pctf_attribute of Attribute.t
-    | Pctf_constraint of (Core_type.t * Core_type.t)
-    | Pctf_method of (Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t)
-    | Pctf_val of (Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t)
-    | Pctf_inherit of Class_type.t
+    | Pctf_extension of extension
+    | Pctf_attribute of attribute
+    | Pctf_constraint of (core_type * core_type)
+    | Pctf_method of (core_type * virtual_flag * private_flag * string Astlib.Loc.t)
+    | Pctf_val of (core_type * virtual_flag * mutable_flag * string Astlib.Loc.t)
+    | Pctf_inherit of class_type
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pctf_extension :
-    Extension.t
+    extension
     -> t
   val pctf_attribute :
-    Attribute.t
+    attribute
     -> t
   val pctf_constraint :
-    (Core_type.t * Core_type.t)
+    (core_type * core_type)
     -> t
   val pctf_method :
-    (Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t)
+    (core_type * virtual_flag * private_flag * string Astlib.Loc.t)
     -> t
   val pctf_val :
-    (Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t)
+    (core_type * virtual_flag * mutable_flag * string Astlib.Loc.t)
     -> t
   val pctf_inherit :
-    Class_type.t
+    class_type
     -> t
 end
 
@@ -970,9 +970,9 @@ and Class_type_field : sig
   type t = class_type_field
 
   type concrete =
-    { pctf_attributes : Attributes.t
+    { pctf_attributes : attributes
     ; pctf_loc : Astlib.Location.t
-    ; pctf_desc : Class_type_field_desc.t
+    ; pctf_desc : class_type_field_desc
     }
 
   val of_concrete : concrete -> t
@@ -980,27 +980,27 @@ and Class_type_field : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pctf_attributes:Attributes.t
+    pctf_attributes:attributes
     -> pctf_loc:Astlib.Location.t
-    -> pctf_desc:Class_type_field_desc.t
+    -> pctf_desc:class_type_field_desc
     -> t
   val update :
-    ?pctf_attributes:Attributes.t
+    ?pctf_attributes:attributes
     -> ?pctf_loc:Astlib.Location.t
-    -> ?pctf_desc:Class_type_field_desc.t
+    -> ?pctf_desc:class_type_field_desc
     -> t -> t
 
-  val pctf_attributes : t -> Attributes.t
+  val pctf_attributes : t -> attributes
   val pctf_loc : t -> Astlib.Location.t
-  val pctf_desc : t -> Class_type_field_desc.t
+  val pctf_desc : t -> class_type_field_desc
 end
 
 and Class_signature : sig
   type t = class_signature
 
   type concrete =
-    { pcsig_fields : Class_type_field.t list
-    ; pcsig_self : Core_type.t
+    { pcsig_fields : class_type_field list
+    ; pcsig_self : core_type
     }
 
   val of_concrete : concrete -> t
@@ -1008,51 +1008,51 @@ and Class_signature : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcsig_fields:Class_type_field.t list
-    -> pcsig_self:Core_type.t
+    pcsig_fields:class_type_field list
+    -> pcsig_self:core_type
     -> t
   val update :
-    ?pcsig_fields:Class_type_field.t list
-    -> ?pcsig_self:Core_type.t
+    ?pcsig_fields:class_type_field list
+    -> ?pcsig_self:core_type
     -> t -> t
 
-  val pcsig_fields : t -> Class_type_field.t list
-  val pcsig_self : t -> Core_type.t
+  val pcsig_fields : t -> class_type_field list
+  val pcsig_self : t -> core_type
 end
 
 and Class_type_desc : sig
   type t = class_type_desc
 
   type concrete =
-    | Pcty_open of Class_type.t * Longident_loc.t * Override_flag.t
-    | Pcty_extension of Extension.t
-    | Pcty_arrow of Class_type.t * Core_type.t * Arg_label.t
-    | Pcty_signature of Class_signature.t
-    | Pcty_constr of Core_type.t list * Longident_loc.t
+    | Pcty_open of class_type * longident_loc * override_flag
+    | Pcty_extension of extension
+    | Pcty_arrow of class_type * core_type * arg_label
+    | Pcty_signature of class_signature
+    | Pcty_constr of core_type list * longident_loc
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pcty_open :
-    Class_type.t
-    -> Longident_loc.t
-    -> Override_flag.t
+    class_type
+    -> longident_loc
+    -> override_flag
     -> t
   val pcty_extension :
-    Extension.t
+    extension
     -> t
   val pcty_arrow :
-    Class_type.t
-    -> Core_type.t
-    -> Arg_label.t
+    class_type
+    -> core_type
+    -> arg_label
     -> t
   val pcty_signature :
-    Class_signature.t
+    class_signature
     -> t
   val pcty_constr :
-    Core_type.t list
-    -> Longident_loc.t
+    core_type list
+    -> longident_loc
     -> t
 end
 
@@ -1060,9 +1060,9 @@ and Class_type : sig
   type t = class_type
 
   type concrete =
-    { pcty_attributes : Attributes.t
+    { pcty_attributes : attributes
     ; pcty_loc : Astlib.Location.t
-    ; pcty_desc : Class_type_desc.t
+    ; pcty_desc : class_type_desc
     }
 
   val of_concrete : concrete -> t
@@ -1070,38 +1070,38 @@ and Class_type : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcty_attributes:Attributes.t
+    pcty_attributes:attributes
     -> pcty_loc:Astlib.Location.t
-    -> pcty_desc:Class_type_desc.t
+    -> pcty_desc:class_type_desc
     -> t
   val update :
-    ?pcty_attributes:Attributes.t
+    ?pcty_attributes:attributes
     -> ?pcty_loc:Astlib.Location.t
-    -> ?pcty_desc:Class_type_desc.t
+    -> ?pcty_desc:class_type_desc
     -> t -> t
 
-  val pcty_attributes : t -> Attributes.t
+  val pcty_attributes : t -> attributes
   val pcty_loc : t -> Astlib.Location.t
-  val pcty_desc : t -> Class_type_desc.t
+  val pcty_desc : t -> class_type_desc
 end
 
 and Extension_constructor_kind : sig
   type t = extension_constructor_kind
 
   type concrete =
-    | Pext_rebind of Longident_loc.t
-    | Pext_decl of Core_type.t option * Constructor_arguments.t
+    | Pext_rebind of longident_loc
+    | Pext_decl of core_type option * constructor_arguments
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pext_rebind :
-    Longident_loc.t
+    longident_loc
     -> t
   val pext_decl :
-    Core_type.t option
-    -> Constructor_arguments.t
+    core_type option
+    -> constructor_arguments
     -> t
 end
 
@@ -1109,9 +1109,9 @@ and Extension_constructor : sig
   type t = extension_constructor
 
   type concrete =
-    { pext_attributes : Attributes.t
+    { pext_attributes : attributes
     ; pext_loc : Astlib.Location.t
-    ; pext_kind : Extension_constructor_kind.t
+    ; pext_kind : extension_constructor_kind
     ; pext_name : string Astlib.Loc.t
     }
 
@@ -1120,21 +1120,21 @@ and Extension_constructor : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pext_attributes:Attributes.t
+    pext_attributes:attributes
     -> pext_loc:Astlib.Location.t
-    -> pext_kind:Extension_constructor_kind.t
+    -> pext_kind:extension_constructor_kind
     -> pext_name:string Astlib.Loc.t
     -> t
   val update :
-    ?pext_attributes:Attributes.t
+    ?pext_attributes:attributes
     -> ?pext_loc:Astlib.Location.t
-    -> ?pext_kind:Extension_constructor_kind.t
+    -> ?pext_kind:extension_constructor_kind
     -> ?pext_name:string Astlib.Loc.t
     -> t -> t
 
-  val pext_attributes : t -> Attributes.t
+  val pext_attributes : t -> attributes
   val pext_loc : t -> Astlib.Location.t
-  val pext_kind : t -> Extension_constructor_kind.t
+  val pext_kind : t -> extension_constructor_kind
   val pext_name : t -> string Astlib.Loc.t
 end
 
@@ -1142,11 +1142,11 @@ and Type_extension : sig
   type t = type_extension
 
   type concrete =
-    { ptyext_attributes : Attributes.t
-    ; ptyext_private : Private_flag.t
-    ; ptyext_constructors : Extension_constructor.t list
-    ; ptyext_params : (Variance.t * Core_type.t) list
-    ; ptyext_path : Longident_loc.t
+    { ptyext_attributes : attributes
+    ; ptyext_private : private_flag
+    ; ptyext_constructors : extension_constructor list
+    ; ptyext_params : (variance * core_type) list
+    ; ptyext_path : longident_loc
     }
 
   val of_concrete : concrete -> t
@@ -1154,43 +1154,43 @@ and Type_extension : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    ptyext_attributes:Attributes.t
-    -> ptyext_private:Private_flag.t
-    -> ptyext_constructors:Extension_constructor.t list
-    -> ptyext_params:(Variance.t * Core_type.t) list
-    -> ptyext_path:Longident_loc.t
+    ptyext_attributes:attributes
+    -> ptyext_private:private_flag
+    -> ptyext_constructors:extension_constructor list
+    -> ptyext_params:(variance * core_type) list
+    -> ptyext_path:longident_loc
     -> t
   val update :
-    ?ptyext_attributes:Attributes.t
-    -> ?ptyext_private:Private_flag.t
-    -> ?ptyext_constructors:Extension_constructor.t list
-    -> ?ptyext_params:(Variance.t * Core_type.t) list
-    -> ?ptyext_path:Longident_loc.t
+    ?ptyext_attributes:attributes
+    -> ?ptyext_private:private_flag
+    -> ?ptyext_constructors:extension_constructor list
+    -> ?ptyext_params:(variance * core_type) list
+    -> ?ptyext_path:longident_loc
     -> t -> t
 
-  val ptyext_attributes : t -> Attributes.t
-  val ptyext_private : t -> Private_flag.t
-  val ptyext_constructors : t -> Extension_constructor.t list
-  val ptyext_params : t -> (Variance.t * Core_type.t) list
-  val ptyext_path : t -> Longident_loc.t
+  val ptyext_attributes : t -> attributes
+  val ptyext_private : t -> private_flag
+  val ptyext_constructors : t -> extension_constructor list
+  val ptyext_params : t -> (variance * core_type) list
+  val ptyext_path : t -> longident_loc
 end
 
 and Constructor_arguments : sig
   type t = constructor_arguments
 
   type concrete =
-    | Pcstr_record of Label_declaration.t list
-    | Pcstr_tuple of Core_type.t list
+    | Pcstr_record of label_declaration list
+    | Pcstr_tuple of core_type list
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pcstr_record :
-    Label_declaration.t list
+    label_declaration list
     -> t
   val pcstr_tuple :
-    Core_type.t list
+    core_type list
     -> t
 end
 
@@ -1198,10 +1198,10 @@ and Constructor_declaration : sig
   type t = constructor_declaration
 
   type concrete =
-    { pcd_attributes : Attributes.t
+    { pcd_attributes : attributes
     ; pcd_loc : Astlib.Location.t
-    ; pcd_res : Core_type.t option
-    ; pcd_args : Constructor_arguments.t
+    ; pcd_res : core_type option
+    ; pcd_args : constructor_arguments
     ; pcd_name : string Astlib.Loc.t
     }
 
@@ -1210,24 +1210,24 @@ and Constructor_declaration : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcd_attributes:Attributes.t
+    pcd_attributes:attributes
     -> pcd_loc:Astlib.Location.t
-    -> pcd_res:Core_type.t option
-    -> pcd_args:Constructor_arguments.t
+    -> pcd_res:core_type option
+    -> pcd_args:constructor_arguments
     -> pcd_name:string Astlib.Loc.t
     -> t
   val update :
-    ?pcd_attributes:Attributes.t
+    ?pcd_attributes:attributes
     -> ?pcd_loc:Astlib.Location.t
-    -> ?pcd_res:Core_type.t option
-    -> ?pcd_args:Constructor_arguments.t
+    -> ?pcd_res:core_type option
+    -> ?pcd_args:constructor_arguments
     -> ?pcd_name:string Astlib.Loc.t
     -> t -> t
 
-  val pcd_attributes : t -> Attributes.t
+  val pcd_attributes : t -> attributes
   val pcd_loc : t -> Astlib.Location.t
-  val pcd_res : t -> Core_type.t option
-  val pcd_args : t -> Constructor_arguments.t
+  val pcd_res : t -> core_type option
+  val pcd_args : t -> constructor_arguments
   val pcd_name : t -> string Astlib.Loc.t
 end
 
@@ -1235,10 +1235,10 @@ and Label_declaration : sig
   type t = label_declaration
 
   type concrete =
-    { pld_attributes : Attributes.t
+    { pld_attributes : attributes
     ; pld_loc : Astlib.Location.t
-    ; pld_type : Core_type.t
-    ; pld_mutable : Mutable_flag.t
+    ; pld_type : core_type
+    ; pld_mutable : mutable_flag
     ; pld_name : string Astlib.Loc.t
     }
 
@@ -1247,24 +1247,24 @@ and Label_declaration : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pld_attributes:Attributes.t
+    pld_attributes:attributes
     -> pld_loc:Astlib.Location.t
-    -> pld_type:Core_type.t
-    -> pld_mutable:Mutable_flag.t
+    -> pld_type:core_type
+    -> pld_mutable:mutable_flag
     -> pld_name:string Astlib.Loc.t
     -> t
   val update :
-    ?pld_attributes:Attributes.t
+    ?pld_attributes:attributes
     -> ?pld_loc:Astlib.Location.t
-    -> ?pld_type:Core_type.t
-    -> ?pld_mutable:Mutable_flag.t
+    -> ?pld_type:core_type
+    -> ?pld_mutable:mutable_flag
     -> ?pld_name:string Astlib.Loc.t
     -> t -> t
 
-  val pld_attributes : t -> Attributes.t
+  val pld_attributes : t -> attributes
   val pld_loc : t -> Astlib.Location.t
-  val pld_type : t -> Core_type.t
-  val pld_mutable : t -> Mutable_flag.t
+  val pld_type : t -> core_type
+  val pld_mutable : t -> mutable_flag
   val pld_name : t -> string Astlib.Loc.t
 end
 
@@ -1273,8 +1273,8 @@ and Type_kind : sig
 
   type concrete =
     | Ptype_open
-    | Ptype_record of Label_declaration.t list
-    | Ptype_variant of Constructor_declaration.t list
+    | Ptype_record of label_declaration list
+    | Ptype_variant of constructor_declaration list
     | Ptype_abstract
 
   val of_concrete : concrete -> t
@@ -1283,10 +1283,10 @@ and Type_kind : sig
 
   val ptype_open : t
   val ptype_record :
-    Label_declaration.t list
+    label_declaration list
     -> t
   val ptype_variant :
-    Constructor_declaration.t list
+    constructor_declaration list
     -> t
   val ptype_abstract : t
 end
@@ -1296,12 +1296,12 @@ and Type_declaration : sig
 
   type concrete =
     { ptype_loc : Astlib.Location.t
-    ; ptype_attributes : Attributes.t
-    ; ptype_manifest : Core_type.t option
-    ; ptype_private : Private_flag.t
-    ; ptype_kind : Type_kind.t
-    ; ptype_cstrs : (Astlib.Location.t * Core_type.t * Core_type.t) list
-    ; ptype_params : (Variance.t * Core_type.t) list
+    ; ptype_attributes : attributes
+    ; ptype_manifest : core_type option
+    ; ptype_private : private_flag
+    ; ptype_kind : type_kind
+    ; ptype_cstrs : (Astlib.Location.t * core_type * core_type) list
+    ; ptype_params : (variance * core_type) list
     ; ptype_name : string Astlib.Loc.t
     }
 
@@ -1311,32 +1311,32 @@ and Type_declaration : sig
 
   val create :
     ptype_loc:Astlib.Location.t
-    -> ptype_attributes:Attributes.t
-    -> ptype_manifest:Core_type.t option
-    -> ptype_private:Private_flag.t
-    -> ptype_kind:Type_kind.t
-    -> ptype_cstrs:(Astlib.Location.t * Core_type.t * Core_type.t) list
-    -> ptype_params:(Variance.t * Core_type.t) list
+    -> ptype_attributes:attributes
+    -> ptype_manifest:core_type option
+    -> ptype_private:private_flag
+    -> ptype_kind:type_kind
+    -> ptype_cstrs:(Astlib.Location.t * core_type * core_type) list
+    -> ptype_params:(variance * core_type) list
     -> ptype_name:string Astlib.Loc.t
     -> t
   val update :
     ?ptype_loc:Astlib.Location.t
-    -> ?ptype_attributes:Attributes.t
-    -> ?ptype_manifest:Core_type.t option
-    -> ?ptype_private:Private_flag.t
-    -> ?ptype_kind:Type_kind.t
-    -> ?ptype_cstrs:(Astlib.Location.t * Core_type.t * Core_type.t) list
-    -> ?ptype_params:(Variance.t * Core_type.t) list
+    -> ?ptype_attributes:attributes
+    -> ?ptype_manifest:core_type option
+    -> ?ptype_private:private_flag
+    -> ?ptype_kind:type_kind
+    -> ?ptype_cstrs:(Astlib.Location.t * core_type * core_type) list
+    -> ?ptype_params:(variance * core_type) list
     -> ?ptype_name:string Astlib.Loc.t
     -> t -> t
 
   val ptype_loc : t -> Astlib.Location.t
-  val ptype_attributes : t -> Attributes.t
-  val ptype_manifest : t -> Core_type.t option
-  val ptype_private : t -> Private_flag.t
-  val ptype_kind : t -> Type_kind.t
-  val ptype_cstrs : t -> (Astlib.Location.t * Core_type.t * Core_type.t) list
-  val ptype_params : t -> (Variance.t * Core_type.t) list
+  val ptype_attributes : t -> attributes
+  val ptype_manifest : t -> core_type option
+  val ptype_private : t -> private_flag
+  val ptype_kind : t -> type_kind
+  val ptype_cstrs : t -> (Astlib.Location.t * core_type * core_type) list
+  val ptype_params : t -> (variance * core_type) list
   val ptype_name : t -> string Astlib.Loc.t
 end
 
@@ -1345,9 +1345,9 @@ and Value_description : sig
 
   type concrete =
     { pval_loc : Astlib.Location.t
-    ; pval_attributes : Attributes.t
+    ; pval_attributes : attributes
     ; pval_prim : string list
-    ; pval_type : Core_type.t
+    ; pval_type : core_type
     ; pval_name : string Astlib.Loc.t
     }
 
@@ -1357,23 +1357,23 @@ and Value_description : sig
 
   val create :
     pval_loc:Astlib.Location.t
-    -> pval_attributes:Attributes.t
+    -> pval_attributes:attributes
     -> pval_prim:string list
-    -> pval_type:Core_type.t
+    -> pval_type:core_type
     -> pval_name:string Astlib.Loc.t
     -> t
   val update :
     ?pval_loc:Astlib.Location.t
-    -> ?pval_attributes:Attributes.t
+    -> ?pval_attributes:attributes
     -> ?pval_prim:string list
-    -> ?pval_type:Core_type.t
+    -> ?pval_type:core_type
     -> ?pval_name:string Astlib.Loc.t
     -> t -> t
 
   val pval_loc : t -> Astlib.Location.t
-  val pval_attributes : t -> Attributes.t
+  val pval_attributes : t -> attributes
   val pval_prim : t -> string list
-  val pval_type : t -> Core_type.t
+  val pval_type : t -> core_type
   val pval_name : t -> string Astlib.Loc.t
 end
 
@@ -1381,9 +1381,9 @@ and Case : sig
   type t = case
 
   type concrete =
-    { pc_rhs : Expression.t
-    ; pc_guard : Expression.t option
-    ; pc_lhs : Pattern.t
+    { pc_rhs : expression
+    ; pc_guard : expression option
+    ; pc_lhs : pattern
     }
 
   val of_concrete : concrete -> t
@@ -1391,19 +1391,19 @@ and Case : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pc_rhs:Expression.t
-    -> pc_guard:Expression.t option
-    -> pc_lhs:Pattern.t
+    pc_rhs:expression
+    -> pc_guard:expression option
+    -> pc_lhs:pattern
     -> t
   val update :
-    ?pc_rhs:Expression.t
-    -> ?pc_guard:Expression.t option
-    -> ?pc_lhs:Pattern.t
+    ?pc_rhs:expression
+    -> ?pc_guard:expression option
+    -> ?pc_lhs:pattern
     -> t -> t
 
-  val pc_rhs : t -> Expression.t
-  val pc_guard : t -> Expression.t option
-  val pc_lhs : t -> Pattern.t
+  val pc_rhs : t -> expression
+  val pc_guard : t -> expression option
+  val pc_lhs : t -> pattern
 end
 
 and Expression_desc : sig
@@ -1411,41 +1411,41 @@ and Expression_desc : sig
 
   type concrete =
     | Pexp_unreachable
-    | Pexp_extension of Extension.t
-    | Pexp_open of Expression.t * Longident_loc.t * Override_flag.t
-    | Pexp_pack of Module_expr.t
-    | Pexp_newtype of Expression.t * string Astlib.Loc.t
-    | Pexp_object of Class_structure.t
-    | Pexp_poly of Core_type.t option * Expression.t
-    | Pexp_lazy of Expression.t
-    | Pexp_assert of Expression.t
-    | Pexp_letexception of Expression.t * Extension_constructor.t
-    | Pexp_letmodule of Expression.t * Module_expr.t * string Astlib.Loc.t
-    | Pexp_override of (Expression.t * string Astlib.Loc.t) list
-    | Pexp_setinstvar of Expression.t * string Astlib.Loc.t
-    | Pexp_new of Longident_loc.t
-    | Pexp_send of string Astlib.Loc.t * Expression.t
-    | Pexp_coerce of Core_type.t * Core_type.t option * Expression.t
-    | Pexp_constraint of Core_type.t * Expression.t
-    | Pexp_for of Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t
-    | Pexp_while of Expression.t * Expression.t
-    | Pexp_sequence of Expression.t * Expression.t
-    | Pexp_ifthenelse of Expression.t option * Expression.t * Expression.t
-    | Pexp_array of Expression.t list
-    | Pexp_setfield of Expression.t * Longident_loc.t * Expression.t
-    | Pexp_field of Longident_loc.t * Expression.t
-    | Pexp_record of Expression.t option * (Expression.t * Longident_loc.t) list
-    | Pexp_variant of Expression.t option * string
-    | Pexp_construct of Expression.t option * Longident_loc.t
-    | Pexp_tuple of Expression.t list
-    | Pexp_try of Case.t list * Expression.t
-    | Pexp_match of Case.t list * Expression.t
-    | Pexp_apply of (Expression.t * Arg_label.t) list * Expression.t
-    | Pexp_fun of Expression.t * Pattern.t * Expression.t option * Arg_label.t
-    | Pexp_function of Case.t list
-    | Pexp_let of Expression.t * Value_binding.t list * Rec_flag.t
-    | Pexp_constant of Constant.t
-    | Pexp_ident of Longident_loc.t
+    | Pexp_extension of extension
+    | Pexp_open of expression * longident_loc * override_flag
+    | Pexp_pack of module_expr
+    | Pexp_newtype of expression * string Astlib.Loc.t
+    | Pexp_object of class_structure
+    | Pexp_poly of core_type option * expression
+    | Pexp_lazy of expression
+    | Pexp_assert of expression
+    | Pexp_letexception of expression * extension_constructor
+    | Pexp_letmodule of expression * module_expr * string Astlib.Loc.t
+    | Pexp_override of (expression * string Astlib.Loc.t) list
+    | Pexp_setinstvar of expression * string Astlib.Loc.t
+    | Pexp_new of longident_loc
+    | Pexp_send of string Astlib.Loc.t * expression
+    | Pexp_coerce of core_type * core_type option * expression
+    | Pexp_constraint of core_type * expression
+    | Pexp_for of expression * direction_flag * expression * expression * pattern
+    | Pexp_while of expression * expression
+    | Pexp_sequence of expression * expression
+    | Pexp_ifthenelse of expression option * expression * expression
+    | Pexp_array of expression list
+    | Pexp_setfield of expression * longident_loc * expression
+    | Pexp_field of longident_loc * expression
+    | Pexp_record of expression option * (expression * longident_loc) list
+    | Pexp_variant of expression option * string
+    | Pexp_construct of expression option * longident_loc
+    | Pexp_tuple of expression list
+    | Pexp_try of case list * expression
+    | Pexp_match of case list * expression
+    | Pexp_apply of (expression * arg_label) list * expression
+    | Pexp_fun of expression * pattern * expression option * arg_label
+    | Pexp_function of case list
+    | Pexp_let of expression * value_binding list * rec_flag
+    | Pexp_constant of constant
+    | Pexp_ident of longident_loc
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
@@ -1453,143 +1453,143 @@ and Expression_desc : sig
 
   val pexp_unreachable : t
   val pexp_extension :
-    Extension.t
+    extension
     -> t
   val pexp_open :
-    Expression.t
-    -> Longident_loc.t
-    -> Override_flag.t
+    expression
+    -> longident_loc
+    -> override_flag
     -> t
   val pexp_pack :
-    Module_expr.t
+    module_expr
     -> t
   val pexp_newtype :
-    Expression.t
+    expression
     -> string Astlib.Loc.t
     -> t
   val pexp_object :
-    Class_structure.t
+    class_structure
     -> t
   val pexp_poly :
-    Core_type.t option
-    -> Expression.t
+    core_type option
+    -> expression
     -> t
   val pexp_lazy :
-    Expression.t
+    expression
     -> t
   val pexp_assert :
-    Expression.t
+    expression
     -> t
   val pexp_letexception :
-    Expression.t
-    -> Extension_constructor.t
+    expression
+    -> extension_constructor
     -> t
   val pexp_letmodule :
-    Expression.t
-    -> Module_expr.t
+    expression
+    -> module_expr
     -> string Astlib.Loc.t
     -> t
   val pexp_override :
-    (Expression.t * string Astlib.Loc.t) list
+    (expression * string Astlib.Loc.t) list
     -> t
   val pexp_setinstvar :
-    Expression.t
+    expression
     -> string Astlib.Loc.t
     -> t
   val pexp_new :
-    Longident_loc.t
+    longident_loc
     -> t
   val pexp_send :
     string Astlib.Loc.t
-    -> Expression.t
+    -> expression
     -> t
   val pexp_coerce :
-    Core_type.t
-    -> Core_type.t option
-    -> Expression.t
+    core_type
+    -> core_type option
+    -> expression
     -> t
   val pexp_constraint :
-    Core_type.t
-    -> Expression.t
+    core_type
+    -> expression
     -> t
   val pexp_for :
-    Expression.t
-    -> Direction_flag.t
-    -> Expression.t
-    -> Expression.t
-    -> Pattern.t
+    expression
+    -> direction_flag
+    -> expression
+    -> expression
+    -> pattern
     -> t
   val pexp_while :
-    Expression.t
-    -> Expression.t
+    expression
+    -> expression
     -> t
   val pexp_sequence :
-    Expression.t
-    -> Expression.t
+    expression
+    -> expression
     -> t
   val pexp_ifthenelse :
-    Expression.t option
-    -> Expression.t
-    -> Expression.t
+    expression option
+    -> expression
+    -> expression
     -> t
   val pexp_array :
-    Expression.t list
+    expression list
     -> t
   val pexp_setfield :
-    Expression.t
-    -> Longident_loc.t
-    -> Expression.t
+    expression
+    -> longident_loc
+    -> expression
     -> t
   val pexp_field :
-    Longident_loc.t
-    -> Expression.t
+    longident_loc
+    -> expression
     -> t
   val pexp_record :
-    Expression.t option
-    -> (Expression.t * Longident_loc.t) list
+    expression option
+    -> (expression * longident_loc) list
     -> t
   val pexp_variant :
-    Expression.t option
+    expression option
     -> string
     -> t
   val pexp_construct :
-    Expression.t option
-    -> Longident_loc.t
+    expression option
+    -> longident_loc
     -> t
   val pexp_tuple :
-    Expression.t list
+    expression list
     -> t
   val pexp_try :
-    Case.t list
-    -> Expression.t
+    case list
+    -> expression
     -> t
   val pexp_match :
-    Case.t list
-    -> Expression.t
+    case list
+    -> expression
     -> t
   val pexp_apply :
-    (Expression.t * Arg_label.t) list
-    -> Expression.t
+    (expression * arg_label) list
+    -> expression
     -> t
   val pexp_fun :
-    Expression.t
-    -> Pattern.t
-    -> Expression.t option
-    -> Arg_label.t
+    expression
+    -> pattern
+    -> expression option
+    -> arg_label
     -> t
   val pexp_function :
-    Case.t list
+    case list
     -> t
   val pexp_let :
-    Expression.t
-    -> Value_binding.t list
-    -> Rec_flag.t
+    expression
+    -> value_binding list
+    -> rec_flag
     -> t
   val pexp_constant :
-    Constant.t
+    constant
     -> t
   val pexp_ident :
-    Longident_loc.t
+    longident_loc
     -> t
 end
 
@@ -1597,9 +1597,9 @@ and Expression : sig
   type t = expression
 
   type concrete =
-    { pexp_attributes : Attributes.t
+    { pexp_attributes : attributes
     ; pexp_loc : Astlib.Location.t
-    ; pexp_desc : Expression_desc.t
+    ; pexp_desc : expression_desc
     }
 
   val of_concrete : concrete -> t
@@ -1607,41 +1607,41 @@ and Expression : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pexp_attributes:Attributes.t
+    pexp_attributes:attributes
     -> pexp_loc:Astlib.Location.t
-    -> pexp_desc:Expression_desc.t
+    -> pexp_desc:expression_desc
     -> t
   val update :
-    ?pexp_attributes:Attributes.t
+    ?pexp_attributes:attributes
     -> ?pexp_loc:Astlib.Location.t
-    -> ?pexp_desc:Expression_desc.t
+    -> ?pexp_desc:expression_desc
     -> t -> t
 
-  val pexp_attributes : t -> Attributes.t
+  val pexp_attributes : t -> attributes
   val pexp_loc : t -> Astlib.Location.t
-  val pexp_desc : t -> Expression_desc.t
+  val pexp_desc : t -> expression_desc
 end
 
 and Pattern_desc : sig
   type t = pattern_desc
 
   type concrete =
-    | Ppat_open of Pattern.t * Longident_loc.t
-    | Ppat_extension of Extension.t
-    | Ppat_exception of Pattern.t
+    | Ppat_open of pattern * longident_loc
+    | Ppat_extension of extension
+    | Ppat_exception of pattern
     | Ppat_unpack of string Astlib.Loc.t
-    | Ppat_lazy of Pattern.t
-    | Ppat_type of Longident_loc.t
-    | Ppat_constraint of Core_type.t * Pattern.t
-    | Ppat_or of Pattern.t * Pattern.t
-    | Ppat_array of Pattern.t list
-    | Ppat_record of Closed_flag.t * (Pattern.t * Longident_loc.t) list
-    | Ppat_variant of Pattern.t option * string
-    | Ppat_construct of Pattern.t option * Longident_loc.t
-    | Ppat_tuple of Pattern.t list
-    | Ppat_interval of Constant.t * Constant.t
-    | Ppat_constant of Constant.t
-    | Ppat_alias of string Astlib.Loc.t * Pattern.t
+    | Ppat_lazy of pattern
+    | Ppat_type of longident_loc
+    | Ppat_constraint of core_type * pattern
+    | Ppat_or of pattern * pattern
+    | Ppat_array of pattern list
+    | Ppat_record of closed_flag * (pattern * longident_loc) list
+    | Ppat_variant of pattern option * string
+    | Ppat_construct of pattern option * longident_loc
+    | Ppat_tuple of pattern list
+    | Ppat_interval of constant * constant
+    | Ppat_constant of constant
+    | Ppat_alias of string Astlib.Loc.t * pattern
     | Ppat_var of string Astlib.Loc.t
     | Ppat_any
 
@@ -1650,60 +1650,60 @@ and Pattern_desc : sig
   val to_concrete_opt : t -> concrete option
 
   val ppat_open :
-    Pattern.t
-    -> Longident_loc.t
+    pattern
+    -> longident_loc
     -> t
   val ppat_extension :
-    Extension.t
+    extension
     -> t
   val ppat_exception :
-    Pattern.t
+    pattern
     -> t
   val ppat_unpack :
     string Astlib.Loc.t
     -> t
   val ppat_lazy :
-    Pattern.t
+    pattern
     -> t
   val ppat_type :
-    Longident_loc.t
+    longident_loc
     -> t
   val ppat_constraint :
-    Core_type.t
-    -> Pattern.t
+    core_type
+    -> pattern
     -> t
   val ppat_or :
-    Pattern.t
-    -> Pattern.t
+    pattern
+    -> pattern
     -> t
   val ppat_array :
-    Pattern.t list
+    pattern list
     -> t
   val ppat_record :
-    Closed_flag.t
-    -> (Pattern.t * Longident_loc.t) list
+    closed_flag
+    -> (pattern * longident_loc) list
     -> t
   val ppat_variant :
-    Pattern.t option
+    pattern option
     -> string
     -> t
   val ppat_construct :
-    Pattern.t option
-    -> Longident_loc.t
+    pattern option
+    -> longident_loc
     -> t
   val ppat_tuple :
-    Pattern.t list
+    pattern list
     -> t
   val ppat_interval :
-    Constant.t
-    -> Constant.t
+    constant
+    -> constant
     -> t
   val ppat_constant :
-    Constant.t
+    constant
     -> t
   val ppat_alias :
     string Astlib.Loc.t
-    -> Pattern.t
+    -> pattern
     -> t
   val ppat_var :
     string Astlib.Loc.t
@@ -1715,9 +1715,9 @@ and Pattern : sig
   type t = pattern
 
   type concrete =
-    { ppat_attributes : Attributes.t
+    { ppat_attributes : attributes
     ; ppat_loc : Astlib.Location.t
-    ; ppat_desc : Pattern_desc.t
+    ; ppat_desc : pattern_desc
     }
 
   val of_concrete : concrete -> t
@@ -1725,38 +1725,38 @@ and Pattern : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    ppat_attributes:Attributes.t
+    ppat_attributes:attributes
     -> ppat_loc:Astlib.Location.t
-    -> ppat_desc:Pattern_desc.t
+    -> ppat_desc:pattern_desc
     -> t
   val update :
-    ?ppat_attributes:Attributes.t
+    ?ppat_attributes:attributes
     -> ?ppat_loc:Astlib.Location.t
-    -> ?ppat_desc:Pattern_desc.t
+    -> ?ppat_desc:pattern_desc
     -> t -> t
 
-  val ppat_attributes : t -> Attributes.t
+  val ppat_attributes : t -> attributes
   val ppat_loc : t -> Astlib.Location.t
-  val ppat_desc : t -> Pattern_desc.t
+  val ppat_desc : t -> pattern_desc
 end
 
 and Object_field : sig
   type t = object_field
 
   type concrete =
-    | Oinherit of Core_type.t
-    | Otag of Core_type.t * Attributes.t * string Astlib.Loc.t
+    | Oinherit of core_type
+    | Otag of core_type * attributes * string Astlib.Loc.t
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val oinherit :
-    Core_type.t
+    core_type
     -> t
   val otag :
-    Core_type.t
-    -> Attributes.t
+    core_type
+    -> attributes
     -> string Astlib.Loc.t
     -> t
 end
@@ -1765,20 +1765,20 @@ and Row_field : sig
   type t = row_field
 
   type concrete =
-    | Rinherit of Core_type.t
-    | Rtag of Core_type.t list * bool * Attributes.t * string Astlib.Loc.t
+    | Rinherit of core_type
+    | Rtag of core_type list * bool * attributes * string Astlib.Loc.t
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val rinherit :
-    Core_type.t
+    core_type
     -> t
   val rtag :
-    Core_type.t list
+    core_type list
     -> bool
-    -> Attributes.t
+    -> attributes
     -> string Astlib.Loc.t
     -> t
 end
@@ -1786,29 +1786,29 @@ end
 and Package_type : sig
   type t = package_type
 
-  type concrete = ((Core_type.t * Longident_loc.t) list * Longident_loc.t)
+  type concrete = ((core_type * longident_loc) list * longident_loc)
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : ((Core_type.t * Longident_loc.t) list * Longident_loc.t) -> t
+  val create : ((core_type * longident_loc) list * longident_loc) -> t
 end
 
 and Core_type_desc : sig
   type t = core_type_desc
 
   type concrete =
-    | Ptyp_extension of Extension.t
-    | Ptyp_package of Package_type.t
-    | Ptyp_poly of Core_type.t * string Astlib.Loc.t list
-    | Ptyp_variant of string list option * Closed_flag.t * Row_field.t list
-    | Ptyp_alias of string * Core_type.t
-    | Ptyp_class of Core_type.t list * Longident_loc.t
-    | Ptyp_object of Closed_flag.t * Object_field.t list
-    | Ptyp_constr of Core_type.t list * Longident_loc.t
-    | Ptyp_tuple of Core_type.t list
-    | Ptyp_arrow of Core_type.t * Core_type.t * Arg_label.t
+    | Ptyp_extension of extension
+    | Ptyp_package of package_type
+    | Ptyp_poly of core_type * string Astlib.Loc.t list
+    | Ptyp_variant of string list option * closed_flag * row_field list
+    | Ptyp_alias of string * core_type
+    | Ptyp_class of core_type list * longident_loc
+    | Ptyp_object of closed_flag * object_field list
+    | Ptyp_constr of core_type list * longident_loc
+    | Ptyp_tuple of core_type list
+    | Ptyp_arrow of core_type * core_type * arg_label
     | Ptyp_var of string
     | Ptyp_any
 
@@ -1817,43 +1817,43 @@ and Core_type_desc : sig
   val to_concrete_opt : t -> concrete option
 
   val ptyp_extension :
-    Extension.t
+    extension
     -> t
   val ptyp_package :
-    Package_type.t
+    package_type
     -> t
   val ptyp_poly :
-    Core_type.t
+    core_type
     -> string Astlib.Loc.t list
     -> t
   val ptyp_variant :
     string list option
-    -> Closed_flag.t
-    -> Row_field.t list
+    -> closed_flag
+    -> row_field list
     -> t
   val ptyp_alias :
     string
-    -> Core_type.t
+    -> core_type
     -> t
   val ptyp_class :
-    Core_type.t list
-    -> Longident_loc.t
+    core_type list
+    -> longident_loc
     -> t
   val ptyp_object :
-    Closed_flag.t
-    -> Object_field.t list
+    closed_flag
+    -> object_field list
     -> t
   val ptyp_constr :
-    Core_type.t list
-    -> Longident_loc.t
+    core_type list
+    -> longident_loc
     -> t
   val ptyp_tuple :
-    Core_type.t list
+    core_type list
     -> t
   val ptyp_arrow :
-    Core_type.t
-    -> Core_type.t
-    -> Arg_label.t
+    core_type
+    -> core_type
+    -> arg_label
     -> t
   val ptyp_var :
     string
@@ -1865,9 +1865,9 @@ and Core_type : sig
   type t = core_type
 
   type concrete =
-    { ptyp_attributes : Attributes.t
+    { ptyp_attributes : attributes
     ; ptyp_loc : Astlib.Location.t
-    ; ptyp_desc : Core_type_desc.t
+    ; ptyp_desc : core_type_desc
     }
 
   val of_concrete : concrete -> t
@@ -1875,83 +1875,83 @@ and Core_type : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    ptyp_attributes:Attributes.t
+    ptyp_attributes:attributes
     -> ptyp_loc:Astlib.Location.t
-    -> ptyp_desc:Core_type_desc.t
+    -> ptyp_desc:core_type_desc
     -> t
   val update :
-    ?ptyp_attributes:Attributes.t
+    ?ptyp_attributes:attributes
     -> ?ptyp_loc:Astlib.Location.t
-    -> ?ptyp_desc:Core_type_desc.t
+    -> ?ptyp_desc:core_type_desc
     -> t -> t
 
-  val ptyp_attributes : t -> Attributes.t
+  val ptyp_attributes : t -> attributes
   val ptyp_loc : t -> Astlib.Location.t
-  val ptyp_desc : t -> Core_type_desc.t
+  val ptyp_desc : t -> core_type_desc
 end
 
 and Payload : sig
   type t = payload
 
   type concrete =
-    | PPat of Expression.t option * Pattern.t
-    | PTyp of Core_type.t
-    | PSig of Signature.t
-    | PStr of Structure.t
+    | PPat of expression option * pattern
+    | PTyp of core_type
+    | PSig of signature
+    | PStr of structure
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pPat :
-    Expression.t option
-    -> Pattern.t
+    expression option
+    -> pattern
     -> t
   val pTyp :
-    Core_type.t
+    core_type
     -> t
   val pSig :
-    Signature.t
+    signature
     -> t
   val pStr :
-    Structure.t
+    structure
     -> t
 end
 
 and Attributes : sig
   type t = attributes
 
-  type concrete = Attribute.t list
+  type concrete = attribute list
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Attribute.t list -> t
+  val create : attribute list -> t
 end
 
 and Extension : sig
   type t = extension
 
-  type concrete = (Payload.t * string Astlib.Loc.t)
+  type concrete = (payload * string Astlib.Loc.t)
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : (Payload.t * string Astlib.Loc.t) -> t
+  val create : (payload * string Astlib.Loc.t) -> t
 end
 
 and Attribute : sig
   type t = attribute
 
-  type concrete = (Payload.t * string Astlib.Loc.t)
+  type concrete = (payload * string Astlib.Loc.t)
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : (Payload.t * string Astlib.Loc.t) -> t
+  val create : (payload * string Astlib.Loc.t) -> t
 end
 
 and Constant : sig
@@ -2130,21 +2130,21 @@ end
 and Longident_loc : sig
   type t = longident_loc
 
-  type concrete = Longident.t Astlib.Loc.t
+  type concrete = longident Astlib.Loc.t
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Longident.t Astlib.Loc.t -> t
+  val create : longident Astlib.Loc.t -> t
 end
 
 and Longident : sig
   type t = longident
 
   type concrete =
-    | Lapply of Longident.t * Longident.t
-    | Ldot of string * Longident.t
+    | Lapply of longident * longident
+    | Ldot of string * longident
     | Lident of string
 
   val of_concrete : concrete -> t
@@ -2152,12 +2152,12 @@ and Longident : sig
   val to_concrete_opt : t -> concrete option
 
   val lapply :
-    Longident.t
-    -> Longident.t
+    longident
+    -> longident
     -> t
   val ldot :
     string
-    -> Longident.t
+    -> longident
     -> t
   val lident :
     string

--- a/ast/version_v4_07.mli
+++ b/ast/version_v4_07.mli
@@ -6,8 +6,8 @@ module rec Longident : sig
 
   type concrete =
     | Lident of string
-    | Ldot of Longident.t * string
-    | Lapply of Longident.t * Longident.t
+    | Ldot of longident * string
+    | Lapply of longident * longident
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
@@ -17,25 +17,25 @@ module rec Longident : sig
     string
     -> t
   val ldot :
-    Longident.t
+    longident
     -> string
     -> t
   val lapply :
-    Longident.t
-    -> Longident.t
+    longident
+    -> longident
     -> t
 end
 
 and Longident_loc : sig
   type t = longident_loc
 
-  type concrete = Longident.t Astlib.Loc.t
+  type concrete = longident Astlib.Loc.t
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Longident.t Astlib.Loc.t -> t
+  val create : longident Astlib.Loc.t -> t
 end
 
 and Rec_flag : sig
@@ -214,64 +214,64 @@ end
 and Attribute : sig
   type t = attribute
 
-  type concrete = (string Astlib.Loc.t * Payload.t)
+  type concrete = (string Astlib.Loc.t * payload)
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : (string Astlib.Loc.t * Payload.t) -> t
+  val create : (string Astlib.Loc.t * payload) -> t
 end
 
 and Extension : sig
   type t = extension
 
-  type concrete = (string Astlib.Loc.t * Payload.t)
+  type concrete = (string Astlib.Loc.t * payload)
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : (string Astlib.Loc.t * Payload.t) -> t
+  val create : (string Astlib.Loc.t * payload) -> t
 end
 
 and Attributes : sig
   type t = attributes
 
-  type concrete = Attribute.t list
+  type concrete = attribute list
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Attribute.t list -> t
+  val create : attribute list -> t
 end
 
 and Payload : sig
   type t = payload
 
   type concrete =
-    | PStr of Structure.t
-    | PSig of Signature.t
-    | PTyp of Core_type.t
-    | PPat of Pattern.t * Expression.t option
+    | PStr of structure
+    | PSig of signature
+    | PTyp of core_type
+    | PPat of pattern * expression option
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pStr :
-    Structure.t
+    structure
     -> t
   val pSig :
-    Signature.t
+    signature
     -> t
   val pTyp :
-    Core_type.t
+    core_type
     -> t
   val pPat :
-    Pattern.t
-    -> Expression.t option
+    pattern
+    -> expression option
     -> t
 end
 
@@ -279,9 +279,9 @@ and Core_type : sig
   type t = core_type
 
   type concrete =
-    { ptyp_desc : Core_type_desc.t
+    { ptyp_desc : core_type_desc
     ; ptyp_loc : Astlib.Location.t
-    ; ptyp_attributes : Attributes.t
+    ; ptyp_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -289,19 +289,19 @@ and Core_type : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    ptyp_desc:Core_type_desc.t
+    ptyp_desc:core_type_desc
     -> ptyp_loc:Astlib.Location.t
-    -> ptyp_attributes:Attributes.t
+    -> ptyp_attributes:attributes
     -> t
   val update :
-    ?ptyp_desc:Core_type_desc.t
+    ?ptyp_desc:core_type_desc
     -> ?ptyp_loc:Astlib.Location.t
-    -> ?ptyp_attributes:Attributes.t
+    -> ?ptyp_attributes:attributes
     -> t -> t
 
-  val ptyp_desc : t -> Core_type_desc.t
+  val ptyp_desc : t -> core_type_desc
   val ptyp_loc : t -> Astlib.Location.t
-  val ptyp_attributes : t -> Attributes.t
+  val ptyp_attributes : t -> attributes
 end
 
 and Core_type_desc : sig
@@ -310,16 +310,16 @@ and Core_type_desc : sig
   type concrete =
     | Ptyp_any
     | Ptyp_var of string
-    | Ptyp_arrow of Arg_label.t * Core_type.t * Core_type.t
-    | Ptyp_tuple of Core_type.t list
-    | Ptyp_constr of Longident_loc.t * Core_type.t list
-    | Ptyp_object of Object_field.t list * Closed_flag.t
-    | Ptyp_class of Longident_loc.t * Core_type.t list
-    | Ptyp_alias of Core_type.t * string
-    | Ptyp_variant of Row_field.t list * Closed_flag.t * string list option
-    | Ptyp_poly of string Astlib.Loc.t list * Core_type.t
-    | Ptyp_package of Package_type.t
-    | Ptyp_extension of Extension.t
+    | Ptyp_arrow of arg_label * core_type * core_type
+    | Ptyp_tuple of core_type list
+    | Ptyp_constr of longident_loc * core_type list
+    | Ptyp_object of object_field list * closed_flag
+    | Ptyp_class of longident_loc * core_type list
+    | Ptyp_alias of core_type * string
+    | Ptyp_variant of row_field list * closed_flag * string list option
+    | Ptyp_poly of string Astlib.Loc.t list * core_type
+    | Ptyp_package of package_type
+    | Ptyp_extension of extension
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
@@ -330,64 +330,64 @@ and Core_type_desc : sig
     string
     -> t
   val ptyp_arrow :
-    Arg_label.t
-    -> Core_type.t
-    -> Core_type.t
+    arg_label
+    -> core_type
+    -> core_type
     -> t
   val ptyp_tuple :
-    Core_type.t list
+    core_type list
     -> t
   val ptyp_constr :
-    Longident_loc.t
-    -> Core_type.t list
+    longident_loc
+    -> core_type list
     -> t
   val ptyp_object :
-    Object_field.t list
-    -> Closed_flag.t
+    object_field list
+    -> closed_flag
     -> t
   val ptyp_class :
-    Longident_loc.t
-    -> Core_type.t list
+    longident_loc
+    -> core_type list
     -> t
   val ptyp_alias :
-    Core_type.t
+    core_type
     -> string
     -> t
   val ptyp_variant :
-    Row_field.t list
-    -> Closed_flag.t
+    row_field list
+    -> closed_flag
     -> string list option
     -> t
   val ptyp_poly :
     string Astlib.Loc.t list
-    -> Core_type.t
+    -> core_type
     -> t
   val ptyp_package :
-    Package_type.t
+    package_type
     -> t
   val ptyp_extension :
-    Extension.t
+    extension
     -> t
 end
 
 and Package_type : sig
   type t = package_type
 
-  type concrete = (Longident_loc.t * (Longident_loc.t * Core_type.t) list)
+  type concrete = (longident_loc * (longident_loc * core_type) list)
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : (Longident_loc.t * (Longident_loc.t * Core_type.t) list) -> t
+  val create : (longident_loc * (longident_loc * core_type) list) -> t
 end
 
 and Row_field : sig
   type t = row_field
 
   type concrete =
-    | Rtag of string Astlib.Loc.t * Attributes.t * bool * Core_type.t list
-    | Rinherit of Core_type.t
+    | Rtag of string Astlib.Loc.t * attributes * bool * core_type list
+    | Rinherit of core_type
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
@@ -395,12 +395,12 @@ and Row_field : sig
 
   val rtag :
     string Astlib.Loc.t
-    -> Attributes.t
+    -> attributes
     -> bool
-    -> Core_type.t list
+    -> core_type list
     -> t
   val rinherit :
-    Core_type.t
+    core_type
     -> t
 end
 
@@ -408,8 +408,8 @@ and Object_field : sig
   type t = object_field
 
   type concrete =
-    | Otag of string Astlib.Loc.t * Attributes.t * Core_type.t
-    | Oinherit of Core_type.t
+    | Otag of string Astlib.Loc.t * attributes * core_type
+    | Oinherit of core_type
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
@@ -417,11 +417,11 @@ and Object_field : sig
 
   val otag :
     string Astlib.Loc.t
-    -> Attributes.t
-    -> Core_type.t
+    -> attributes
+    -> core_type
     -> t
   val oinherit :
-    Core_type.t
+    core_type
     -> t
 end
 
@@ -429,9 +429,9 @@ and Pattern : sig
   type t = pattern
 
   type concrete =
-    { ppat_desc : Pattern_desc.t
+    { ppat_desc : pattern_desc
     ; ppat_loc : Astlib.Location.t
-    ; ppat_attributes : Attributes.t
+    ; ppat_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -439,19 +439,19 @@ and Pattern : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    ppat_desc:Pattern_desc.t
+    ppat_desc:pattern_desc
     -> ppat_loc:Astlib.Location.t
-    -> ppat_attributes:Attributes.t
+    -> ppat_attributes:attributes
     -> t
   val update :
-    ?ppat_desc:Pattern_desc.t
+    ?ppat_desc:pattern_desc
     -> ?ppat_loc:Astlib.Location.t
-    -> ?ppat_attributes:Attributes.t
+    -> ?ppat_attributes:attributes
     -> t -> t
 
-  val ppat_desc : t -> Pattern_desc.t
+  val ppat_desc : t -> pattern_desc
   val ppat_loc : t -> Astlib.Location.t
-  val ppat_attributes : t -> Attributes.t
+  val ppat_attributes : t -> attributes
 end
 
 and Pattern_desc : sig
@@ -460,22 +460,22 @@ and Pattern_desc : sig
   type concrete =
     | Ppat_any
     | Ppat_var of string Astlib.Loc.t
-    | Ppat_alias of Pattern.t * string Astlib.Loc.t
-    | Ppat_constant of Constant.t
-    | Ppat_interval of Constant.t * Constant.t
-    | Ppat_tuple of Pattern.t list
-    | Ppat_construct of Longident_loc.t * Pattern.t option
-    | Ppat_variant of string * Pattern.t option
-    | Ppat_record of (Longident_loc.t * Pattern.t) list * Closed_flag.t
-    | Ppat_array of Pattern.t list
-    | Ppat_or of Pattern.t * Pattern.t
-    | Ppat_constraint of Pattern.t * Core_type.t
-    | Ppat_type of Longident_loc.t
-    | Ppat_lazy of Pattern.t
+    | Ppat_alias of pattern * string Astlib.Loc.t
+    | Ppat_constant of constant
+    | Ppat_interval of constant * constant
+    | Ppat_tuple of pattern list
+    | Ppat_construct of longident_loc * pattern option
+    | Ppat_variant of string * pattern option
+    | Ppat_record of (longident_loc * pattern) list * closed_flag
+    | Ppat_array of pattern list
+    | Ppat_or of pattern * pattern
+    | Ppat_constraint of pattern * core_type
+    | Ppat_type of longident_loc
+    | Ppat_lazy of pattern
     | Ppat_unpack of string Astlib.Loc.t
-    | Ppat_exception of Pattern.t
-    | Ppat_extension of Extension.t
-    | Ppat_open of Longident_loc.t * Pattern.t
+    | Ppat_exception of pattern
+    | Ppat_extension of extension
+    | Ppat_open of longident_loc * pattern
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
@@ -486,60 +486,60 @@ and Pattern_desc : sig
     string Astlib.Loc.t
     -> t
   val ppat_alias :
-    Pattern.t
+    pattern
     -> string Astlib.Loc.t
     -> t
   val ppat_constant :
-    Constant.t
+    constant
     -> t
   val ppat_interval :
-    Constant.t
-    -> Constant.t
+    constant
+    -> constant
     -> t
   val ppat_tuple :
-    Pattern.t list
+    pattern list
     -> t
   val ppat_construct :
-    Longident_loc.t
-    -> Pattern.t option
+    longident_loc
+    -> pattern option
     -> t
   val ppat_variant :
     string
-    -> Pattern.t option
+    -> pattern option
     -> t
   val ppat_record :
-    (Longident_loc.t * Pattern.t) list
-    -> Closed_flag.t
+    (longident_loc * pattern) list
+    -> closed_flag
     -> t
   val ppat_array :
-    Pattern.t list
+    pattern list
     -> t
   val ppat_or :
-    Pattern.t
-    -> Pattern.t
+    pattern
+    -> pattern
     -> t
   val ppat_constraint :
-    Pattern.t
-    -> Core_type.t
+    pattern
+    -> core_type
     -> t
   val ppat_type :
-    Longident_loc.t
+    longident_loc
     -> t
   val ppat_lazy :
-    Pattern.t
+    pattern
     -> t
   val ppat_unpack :
     string Astlib.Loc.t
     -> t
   val ppat_exception :
-    Pattern.t
+    pattern
     -> t
   val ppat_extension :
-    Extension.t
+    extension
     -> t
   val ppat_open :
-    Longident_loc.t
-    -> Pattern.t
+    longident_loc
+    -> pattern
     -> t
 end
 
@@ -547,9 +547,9 @@ and Expression : sig
   type t = expression
 
   type concrete =
-    { pexp_desc : Expression_desc.t
+    { pexp_desc : expression_desc
     ; pexp_loc : Astlib.Location.t
-    ; pexp_attributes : Attributes.t
+    ; pexp_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -557,60 +557,60 @@ and Expression : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pexp_desc:Expression_desc.t
+    pexp_desc:expression_desc
     -> pexp_loc:Astlib.Location.t
-    -> pexp_attributes:Attributes.t
+    -> pexp_attributes:attributes
     -> t
   val update :
-    ?pexp_desc:Expression_desc.t
+    ?pexp_desc:expression_desc
     -> ?pexp_loc:Astlib.Location.t
-    -> ?pexp_attributes:Attributes.t
+    -> ?pexp_attributes:attributes
     -> t -> t
 
-  val pexp_desc : t -> Expression_desc.t
+  val pexp_desc : t -> expression_desc
   val pexp_loc : t -> Astlib.Location.t
-  val pexp_attributes : t -> Attributes.t
+  val pexp_attributes : t -> attributes
 end
 
 and Expression_desc : sig
   type t = expression_desc
 
   type concrete =
-    | Pexp_ident of Longident_loc.t
-    | Pexp_constant of Constant.t
-    | Pexp_let of Rec_flag.t * Value_binding.t list * Expression.t
-    | Pexp_function of Case.t list
-    | Pexp_fun of Arg_label.t * Expression.t option * Pattern.t * Expression.t
-    | Pexp_apply of Expression.t * (Arg_label.t * Expression.t) list
-    | Pexp_match of Expression.t * Case.t list
-    | Pexp_try of Expression.t * Case.t list
-    | Pexp_tuple of Expression.t list
-    | Pexp_construct of Longident_loc.t * Expression.t option
-    | Pexp_variant of string * Expression.t option
-    | Pexp_record of (Longident_loc.t * Expression.t) list * Expression.t option
-    | Pexp_field of Expression.t * Longident_loc.t
-    | Pexp_setfield of Expression.t * Longident_loc.t * Expression.t
-    | Pexp_array of Expression.t list
-    | Pexp_ifthenelse of Expression.t * Expression.t * Expression.t option
-    | Pexp_sequence of Expression.t * Expression.t
-    | Pexp_while of Expression.t * Expression.t
-    | Pexp_for of Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t
-    | Pexp_constraint of Expression.t * Core_type.t
-    | Pexp_coerce of Expression.t * Core_type.t option * Core_type.t
-    | Pexp_send of Expression.t * string Astlib.Loc.t
-    | Pexp_new of Longident_loc.t
-    | Pexp_setinstvar of string Astlib.Loc.t * Expression.t
-    | Pexp_override of (string Astlib.Loc.t * Expression.t) list
-    | Pexp_letmodule of string Astlib.Loc.t * Module_expr.t * Expression.t
-    | Pexp_letexception of Extension_constructor.t * Expression.t
-    | Pexp_assert of Expression.t
-    | Pexp_lazy of Expression.t
-    | Pexp_poly of Expression.t * Core_type.t option
-    | Pexp_object of Class_structure.t
-    | Pexp_newtype of string Astlib.Loc.t * Expression.t
-    | Pexp_pack of Module_expr.t
-    | Pexp_open of Override_flag.t * Longident_loc.t * Expression.t
-    | Pexp_extension of Extension.t
+    | Pexp_ident of longident_loc
+    | Pexp_constant of constant
+    | Pexp_let of rec_flag * value_binding list * expression
+    | Pexp_function of case list
+    | Pexp_fun of arg_label * expression option * pattern * expression
+    | Pexp_apply of expression * (arg_label * expression) list
+    | Pexp_match of expression * case list
+    | Pexp_try of expression * case list
+    | Pexp_tuple of expression list
+    | Pexp_construct of longident_loc * expression option
+    | Pexp_variant of string * expression option
+    | Pexp_record of (longident_loc * expression) list * expression option
+    | Pexp_field of expression * longident_loc
+    | Pexp_setfield of expression * longident_loc * expression
+    | Pexp_array of expression list
+    | Pexp_ifthenelse of expression * expression * expression option
+    | Pexp_sequence of expression * expression
+    | Pexp_while of expression * expression
+    | Pexp_for of pattern * expression * expression * direction_flag * expression
+    | Pexp_constraint of expression * core_type
+    | Pexp_coerce of expression * core_type option * core_type
+    | Pexp_send of expression * string Astlib.Loc.t
+    | Pexp_new of longident_loc
+    | Pexp_setinstvar of string Astlib.Loc.t * expression
+    | Pexp_override of (string Astlib.Loc.t * expression) list
+    | Pexp_letmodule of string Astlib.Loc.t * module_expr * expression
+    | Pexp_letexception of extension_constructor * expression
+    | Pexp_assert of expression
+    | Pexp_lazy of expression
+    | Pexp_poly of expression * core_type option
+    | Pexp_object of class_structure
+    | Pexp_newtype of string Astlib.Loc.t * expression
+    | Pexp_pack of module_expr
+    | Pexp_open of override_flag * longident_loc * expression
+    | Pexp_extension of extension
     | Pexp_unreachable
 
   val of_concrete : concrete -> t
@@ -618,143 +618,143 @@ and Expression_desc : sig
   val to_concrete_opt : t -> concrete option
 
   val pexp_ident :
-    Longident_loc.t
+    longident_loc
     -> t
   val pexp_constant :
-    Constant.t
+    constant
     -> t
   val pexp_let :
-    Rec_flag.t
-    -> Value_binding.t list
-    -> Expression.t
+    rec_flag
+    -> value_binding list
+    -> expression
     -> t
   val pexp_function :
-    Case.t list
+    case list
     -> t
   val pexp_fun :
-    Arg_label.t
-    -> Expression.t option
-    -> Pattern.t
-    -> Expression.t
+    arg_label
+    -> expression option
+    -> pattern
+    -> expression
     -> t
   val pexp_apply :
-    Expression.t
-    -> (Arg_label.t * Expression.t) list
+    expression
+    -> (arg_label * expression) list
     -> t
   val pexp_match :
-    Expression.t
-    -> Case.t list
+    expression
+    -> case list
     -> t
   val pexp_try :
-    Expression.t
-    -> Case.t list
+    expression
+    -> case list
     -> t
   val pexp_tuple :
-    Expression.t list
+    expression list
     -> t
   val pexp_construct :
-    Longident_loc.t
-    -> Expression.t option
+    longident_loc
+    -> expression option
     -> t
   val pexp_variant :
     string
-    -> Expression.t option
+    -> expression option
     -> t
   val pexp_record :
-    (Longident_loc.t * Expression.t) list
-    -> Expression.t option
+    (longident_loc * expression) list
+    -> expression option
     -> t
   val pexp_field :
-    Expression.t
-    -> Longident_loc.t
+    expression
+    -> longident_loc
     -> t
   val pexp_setfield :
-    Expression.t
-    -> Longident_loc.t
-    -> Expression.t
+    expression
+    -> longident_loc
+    -> expression
     -> t
   val pexp_array :
-    Expression.t list
+    expression list
     -> t
   val pexp_ifthenelse :
-    Expression.t
-    -> Expression.t
-    -> Expression.t option
+    expression
+    -> expression
+    -> expression option
     -> t
   val pexp_sequence :
-    Expression.t
-    -> Expression.t
+    expression
+    -> expression
     -> t
   val pexp_while :
-    Expression.t
-    -> Expression.t
+    expression
+    -> expression
     -> t
   val pexp_for :
-    Pattern.t
-    -> Expression.t
-    -> Expression.t
-    -> Direction_flag.t
-    -> Expression.t
+    pattern
+    -> expression
+    -> expression
+    -> direction_flag
+    -> expression
     -> t
   val pexp_constraint :
-    Expression.t
-    -> Core_type.t
+    expression
+    -> core_type
     -> t
   val pexp_coerce :
-    Expression.t
-    -> Core_type.t option
-    -> Core_type.t
+    expression
+    -> core_type option
+    -> core_type
     -> t
   val pexp_send :
-    Expression.t
+    expression
     -> string Astlib.Loc.t
     -> t
   val pexp_new :
-    Longident_loc.t
+    longident_loc
     -> t
   val pexp_setinstvar :
     string Astlib.Loc.t
-    -> Expression.t
+    -> expression
     -> t
   val pexp_override :
-    (string Astlib.Loc.t * Expression.t) list
+    (string Astlib.Loc.t * expression) list
     -> t
   val pexp_letmodule :
     string Astlib.Loc.t
-    -> Module_expr.t
-    -> Expression.t
+    -> module_expr
+    -> expression
     -> t
   val pexp_letexception :
-    Extension_constructor.t
-    -> Expression.t
+    extension_constructor
+    -> expression
     -> t
   val pexp_assert :
-    Expression.t
+    expression
     -> t
   val pexp_lazy :
-    Expression.t
+    expression
     -> t
   val pexp_poly :
-    Expression.t
-    -> Core_type.t option
+    expression
+    -> core_type option
     -> t
   val pexp_object :
-    Class_structure.t
+    class_structure
     -> t
   val pexp_newtype :
     string Astlib.Loc.t
-    -> Expression.t
+    -> expression
     -> t
   val pexp_pack :
-    Module_expr.t
+    module_expr
     -> t
   val pexp_open :
-    Override_flag.t
-    -> Longident_loc.t
-    -> Expression.t
+    override_flag
+    -> longident_loc
+    -> expression
     -> t
   val pexp_extension :
-    Extension.t
+    extension
     -> t
   val pexp_unreachable : t
 end
@@ -763,9 +763,9 @@ and Case : sig
   type t = case
 
   type concrete =
-    { pc_lhs : Pattern.t
-    ; pc_guard : Expression.t option
-    ; pc_rhs : Expression.t
+    { pc_lhs : pattern
+    ; pc_guard : expression option
+    ; pc_rhs : expression
     }
 
   val of_concrete : concrete -> t
@@ -773,19 +773,19 @@ and Case : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pc_lhs:Pattern.t
-    -> pc_guard:Expression.t option
-    -> pc_rhs:Expression.t
+    pc_lhs:pattern
+    -> pc_guard:expression option
+    -> pc_rhs:expression
     -> t
   val update :
-    ?pc_lhs:Pattern.t
-    -> ?pc_guard:Expression.t option
-    -> ?pc_rhs:Expression.t
+    ?pc_lhs:pattern
+    -> ?pc_guard:expression option
+    -> ?pc_rhs:expression
     -> t -> t
 
-  val pc_lhs : t -> Pattern.t
-  val pc_guard : t -> Expression.t option
-  val pc_rhs : t -> Expression.t
+  val pc_lhs : t -> pattern
+  val pc_guard : t -> expression option
+  val pc_rhs : t -> expression
 end
 
 and Value_description : sig
@@ -793,9 +793,9 @@ and Value_description : sig
 
   type concrete =
     { pval_name : string Astlib.Loc.t
-    ; pval_type : Core_type.t
+    ; pval_type : core_type
     ; pval_prim : string list
-    ; pval_attributes : Attributes.t
+    ; pval_attributes : attributes
     ; pval_loc : Astlib.Location.t
     }
 
@@ -805,23 +805,23 @@ and Value_description : sig
 
   val create :
     pval_name:string Astlib.Loc.t
-    -> pval_type:Core_type.t
+    -> pval_type:core_type
     -> pval_prim:string list
-    -> pval_attributes:Attributes.t
+    -> pval_attributes:attributes
     -> pval_loc:Astlib.Location.t
     -> t
   val update :
     ?pval_name:string Astlib.Loc.t
-    -> ?pval_type:Core_type.t
+    -> ?pval_type:core_type
     -> ?pval_prim:string list
-    -> ?pval_attributes:Attributes.t
+    -> ?pval_attributes:attributes
     -> ?pval_loc:Astlib.Location.t
     -> t -> t
 
   val pval_name : t -> string Astlib.Loc.t
-  val pval_type : t -> Core_type.t
+  val pval_type : t -> core_type
   val pval_prim : t -> string list
-  val pval_attributes : t -> Attributes.t
+  val pval_attributes : t -> attributes
   val pval_loc : t -> Astlib.Location.t
 end
 
@@ -830,12 +830,12 @@ and Type_declaration : sig
 
   type concrete =
     { ptype_name : string Astlib.Loc.t
-    ; ptype_params : (Core_type.t * Variance.t) list
-    ; ptype_cstrs : (Core_type.t * Core_type.t * Astlib.Location.t) list
-    ; ptype_kind : Type_kind.t
-    ; ptype_private : Private_flag.t
-    ; ptype_manifest : Core_type.t option
-    ; ptype_attributes : Attributes.t
+    ; ptype_params : (core_type * variance) list
+    ; ptype_cstrs : (core_type * core_type * Astlib.Location.t) list
+    ; ptype_kind : type_kind
+    ; ptype_private : private_flag
+    ; ptype_manifest : core_type option
+    ; ptype_attributes : attributes
     ; ptype_loc : Astlib.Location.t
     }
 
@@ -845,32 +845,32 @@ and Type_declaration : sig
 
   val create :
     ptype_name:string Astlib.Loc.t
-    -> ptype_params:(Core_type.t * Variance.t) list
-    -> ptype_cstrs:(Core_type.t * Core_type.t * Astlib.Location.t) list
-    -> ptype_kind:Type_kind.t
-    -> ptype_private:Private_flag.t
-    -> ptype_manifest:Core_type.t option
-    -> ptype_attributes:Attributes.t
+    -> ptype_params:(core_type * variance) list
+    -> ptype_cstrs:(core_type * core_type * Astlib.Location.t) list
+    -> ptype_kind:type_kind
+    -> ptype_private:private_flag
+    -> ptype_manifest:core_type option
+    -> ptype_attributes:attributes
     -> ptype_loc:Astlib.Location.t
     -> t
   val update :
     ?ptype_name:string Astlib.Loc.t
-    -> ?ptype_params:(Core_type.t * Variance.t) list
-    -> ?ptype_cstrs:(Core_type.t * Core_type.t * Astlib.Location.t) list
-    -> ?ptype_kind:Type_kind.t
-    -> ?ptype_private:Private_flag.t
-    -> ?ptype_manifest:Core_type.t option
-    -> ?ptype_attributes:Attributes.t
+    -> ?ptype_params:(core_type * variance) list
+    -> ?ptype_cstrs:(core_type * core_type * Astlib.Location.t) list
+    -> ?ptype_kind:type_kind
+    -> ?ptype_private:private_flag
+    -> ?ptype_manifest:core_type option
+    -> ?ptype_attributes:attributes
     -> ?ptype_loc:Astlib.Location.t
     -> t -> t
 
   val ptype_name : t -> string Astlib.Loc.t
-  val ptype_params : t -> (Core_type.t * Variance.t) list
-  val ptype_cstrs : t -> (Core_type.t * Core_type.t * Astlib.Location.t) list
-  val ptype_kind : t -> Type_kind.t
-  val ptype_private : t -> Private_flag.t
-  val ptype_manifest : t -> Core_type.t option
-  val ptype_attributes : t -> Attributes.t
+  val ptype_params : t -> (core_type * variance) list
+  val ptype_cstrs : t -> (core_type * core_type * Astlib.Location.t) list
+  val ptype_kind : t -> type_kind
+  val ptype_private : t -> private_flag
+  val ptype_manifest : t -> core_type option
+  val ptype_attributes : t -> attributes
   val ptype_loc : t -> Astlib.Location.t
 end
 
@@ -879,8 +879,8 @@ and Type_kind : sig
 
   type concrete =
     | Ptype_abstract
-    | Ptype_variant of Constructor_declaration.t list
-    | Ptype_record of Label_declaration.t list
+    | Ptype_variant of constructor_declaration list
+    | Ptype_record of label_declaration list
     | Ptype_open
 
   val of_concrete : concrete -> t
@@ -889,10 +889,10 @@ and Type_kind : sig
 
   val ptype_abstract : t
   val ptype_variant :
-    Constructor_declaration.t list
+    constructor_declaration list
     -> t
   val ptype_record :
-    Label_declaration.t list
+    label_declaration list
     -> t
   val ptype_open : t
 end
@@ -902,10 +902,10 @@ and Label_declaration : sig
 
   type concrete =
     { pld_name : string Astlib.Loc.t
-    ; pld_mutable : Mutable_flag.t
-    ; pld_type : Core_type.t
+    ; pld_mutable : mutable_flag
+    ; pld_type : core_type
     ; pld_loc : Astlib.Location.t
-    ; pld_attributes : Attributes.t
+    ; pld_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -914,24 +914,24 @@ and Label_declaration : sig
 
   val create :
     pld_name:string Astlib.Loc.t
-    -> pld_mutable:Mutable_flag.t
-    -> pld_type:Core_type.t
+    -> pld_mutable:mutable_flag
+    -> pld_type:core_type
     -> pld_loc:Astlib.Location.t
-    -> pld_attributes:Attributes.t
+    -> pld_attributes:attributes
     -> t
   val update :
     ?pld_name:string Astlib.Loc.t
-    -> ?pld_mutable:Mutable_flag.t
-    -> ?pld_type:Core_type.t
+    -> ?pld_mutable:mutable_flag
+    -> ?pld_type:core_type
     -> ?pld_loc:Astlib.Location.t
-    -> ?pld_attributes:Attributes.t
+    -> ?pld_attributes:attributes
     -> t -> t
 
   val pld_name : t -> string Astlib.Loc.t
-  val pld_mutable : t -> Mutable_flag.t
-  val pld_type : t -> Core_type.t
+  val pld_mutable : t -> mutable_flag
+  val pld_type : t -> core_type
   val pld_loc : t -> Astlib.Location.t
-  val pld_attributes : t -> Attributes.t
+  val pld_attributes : t -> attributes
 end
 
 and Constructor_declaration : sig
@@ -939,10 +939,10 @@ and Constructor_declaration : sig
 
   type concrete =
     { pcd_name : string Astlib.Loc.t
-    ; pcd_args : Constructor_arguments.t
-    ; pcd_res : Core_type.t option
+    ; pcd_args : constructor_arguments
+    ; pcd_res : core_type option
     ; pcd_loc : Astlib.Location.t
-    ; pcd_attributes : Attributes.t
+    ; pcd_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -951,42 +951,42 @@ and Constructor_declaration : sig
 
   val create :
     pcd_name:string Astlib.Loc.t
-    -> pcd_args:Constructor_arguments.t
-    -> pcd_res:Core_type.t option
+    -> pcd_args:constructor_arguments
+    -> pcd_res:core_type option
     -> pcd_loc:Astlib.Location.t
-    -> pcd_attributes:Attributes.t
+    -> pcd_attributes:attributes
     -> t
   val update :
     ?pcd_name:string Astlib.Loc.t
-    -> ?pcd_args:Constructor_arguments.t
-    -> ?pcd_res:Core_type.t option
+    -> ?pcd_args:constructor_arguments
+    -> ?pcd_res:core_type option
     -> ?pcd_loc:Astlib.Location.t
-    -> ?pcd_attributes:Attributes.t
+    -> ?pcd_attributes:attributes
     -> t -> t
 
   val pcd_name : t -> string Astlib.Loc.t
-  val pcd_args : t -> Constructor_arguments.t
-  val pcd_res : t -> Core_type.t option
+  val pcd_args : t -> constructor_arguments
+  val pcd_res : t -> core_type option
   val pcd_loc : t -> Astlib.Location.t
-  val pcd_attributes : t -> Attributes.t
+  val pcd_attributes : t -> attributes
 end
 
 and Constructor_arguments : sig
   type t = constructor_arguments
 
   type concrete =
-    | Pcstr_tuple of Core_type.t list
-    | Pcstr_record of Label_declaration.t list
+    | Pcstr_tuple of core_type list
+    | Pcstr_record of label_declaration list
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pcstr_tuple :
-    Core_type.t list
+    core_type list
     -> t
   val pcstr_record :
-    Label_declaration.t list
+    label_declaration list
     -> t
 end
 
@@ -994,11 +994,11 @@ and Type_extension : sig
   type t = type_extension
 
   type concrete =
-    { ptyext_path : Longident_loc.t
-    ; ptyext_params : (Core_type.t * Variance.t) list
-    ; ptyext_constructors : Extension_constructor.t list
-    ; ptyext_private : Private_flag.t
-    ; ptyext_attributes : Attributes.t
+    { ptyext_path : longident_loc
+    ; ptyext_params : (core_type * variance) list
+    ; ptyext_constructors : extension_constructor list
+    ; ptyext_private : private_flag
+    ; ptyext_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -1006,25 +1006,25 @@ and Type_extension : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    ptyext_path:Longident_loc.t
-    -> ptyext_params:(Core_type.t * Variance.t) list
-    -> ptyext_constructors:Extension_constructor.t list
-    -> ptyext_private:Private_flag.t
-    -> ptyext_attributes:Attributes.t
+    ptyext_path:longident_loc
+    -> ptyext_params:(core_type * variance) list
+    -> ptyext_constructors:extension_constructor list
+    -> ptyext_private:private_flag
+    -> ptyext_attributes:attributes
     -> t
   val update :
-    ?ptyext_path:Longident_loc.t
-    -> ?ptyext_params:(Core_type.t * Variance.t) list
-    -> ?ptyext_constructors:Extension_constructor.t list
-    -> ?ptyext_private:Private_flag.t
-    -> ?ptyext_attributes:Attributes.t
+    ?ptyext_path:longident_loc
+    -> ?ptyext_params:(core_type * variance) list
+    -> ?ptyext_constructors:extension_constructor list
+    -> ?ptyext_private:private_flag
+    -> ?ptyext_attributes:attributes
     -> t -> t
 
-  val ptyext_path : t -> Longident_loc.t
-  val ptyext_params : t -> (Core_type.t * Variance.t) list
-  val ptyext_constructors : t -> Extension_constructor.t list
-  val ptyext_private : t -> Private_flag.t
-  val ptyext_attributes : t -> Attributes.t
+  val ptyext_path : t -> longident_loc
+  val ptyext_params : t -> (core_type * variance) list
+  val ptyext_constructors : t -> extension_constructor list
+  val ptyext_private : t -> private_flag
+  val ptyext_attributes : t -> attributes
 end
 
 and Extension_constructor : sig
@@ -1032,9 +1032,9 @@ and Extension_constructor : sig
 
   type concrete =
     { pext_name : string Astlib.Loc.t
-    ; pext_kind : Extension_constructor_kind.t
+    ; pext_kind : extension_constructor_kind
     ; pext_loc : Astlib.Location.t
-    ; pext_attributes : Attributes.t
+    ; pext_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -1043,40 +1043,40 @@ and Extension_constructor : sig
 
   val create :
     pext_name:string Astlib.Loc.t
-    -> pext_kind:Extension_constructor_kind.t
+    -> pext_kind:extension_constructor_kind
     -> pext_loc:Astlib.Location.t
-    -> pext_attributes:Attributes.t
+    -> pext_attributes:attributes
     -> t
   val update :
     ?pext_name:string Astlib.Loc.t
-    -> ?pext_kind:Extension_constructor_kind.t
+    -> ?pext_kind:extension_constructor_kind
     -> ?pext_loc:Astlib.Location.t
-    -> ?pext_attributes:Attributes.t
+    -> ?pext_attributes:attributes
     -> t -> t
 
   val pext_name : t -> string Astlib.Loc.t
-  val pext_kind : t -> Extension_constructor_kind.t
+  val pext_kind : t -> extension_constructor_kind
   val pext_loc : t -> Astlib.Location.t
-  val pext_attributes : t -> Attributes.t
+  val pext_attributes : t -> attributes
 end
 
 and Extension_constructor_kind : sig
   type t = extension_constructor_kind
 
   type concrete =
-    | Pext_decl of Constructor_arguments.t * Core_type.t option
-    | Pext_rebind of Longident_loc.t
+    | Pext_decl of constructor_arguments * core_type option
+    | Pext_rebind of longident_loc
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pext_decl :
-    Constructor_arguments.t
-    -> Core_type.t option
+    constructor_arguments
+    -> core_type option
     -> t
   val pext_rebind :
-    Longident_loc.t
+    longident_loc
     -> t
 end
 
@@ -1084,9 +1084,9 @@ and Class_type : sig
   type t = class_type
 
   type concrete =
-    { pcty_desc : Class_type_desc.t
+    { pcty_desc : class_type_desc
     ; pcty_loc : Astlib.Location.t
-    ; pcty_attributes : Attributes.t
+    ; pcty_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -1094,54 +1094,54 @@ and Class_type : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcty_desc:Class_type_desc.t
+    pcty_desc:class_type_desc
     -> pcty_loc:Astlib.Location.t
-    -> pcty_attributes:Attributes.t
+    -> pcty_attributes:attributes
     -> t
   val update :
-    ?pcty_desc:Class_type_desc.t
+    ?pcty_desc:class_type_desc
     -> ?pcty_loc:Astlib.Location.t
-    -> ?pcty_attributes:Attributes.t
+    -> ?pcty_attributes:attributes
     -> t -> t
 
-  val pcty_desc : t -> Class_type_desc.t
+  val pcty_desc : t -> class_type_desc
   val pcty_loc : t -> Astlib.Location.t
-  val pcty_attributes : t -> Attributes.t
+  val pcty_attributes : t -> attributes
 end
 
 and Class_type_desc : sig
   type t = class_type_desc
 
   type concrete =
-    | Pcty_constr of Longident_loc.t * Core_type.t list
-    | Pcty_signature of Class_signature.t
-    | Pcty_arrow of Arg_label.t * Core_type.t * Class_type.t
-    | Pcty_extension of Extension.t
-    | Pcty_open of Override_flag.t * Longident_loc.t * Class_type.t
+    | Pcty_constr of longident_loc * core_type list
+    | Pcty_signature of class_signature
+    | Pcty_arrow of arg_label * core_type * class_type
+    | Pcty_extension of extension
+    | Pcty_open of override_flag * longident_loc * class_type
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pcty_constr :
-    Longident_loc.t
-    -> Core_type.t list
+    longident_loc
+    -> core_type list
     -> t
   val pcty_signature :
-    Class_signature.t
+    class_signature
     -> t
   val pcty_arrow :
-    Arg_label.t
-    -> Core_type.t
-    -> Class_type.t
+    arg_label
+    -> core_type
+    -> class_type
     -> t
   val pcty_extension :
-    Extension.t
+    extension
     -> t
   val pcty_open :
-    Override_flag.t
-    -> Longident_loc.t
-    -> Class_type.t
+    override_flag
+    -> longident_loc
+    -> class_type
     -> t
 end
 
@@ -1149,8 +1149,8 @@ and Class_signature : sig
   type t = class_signature
 
   type concrete =
-    { pcsig_self : Core_type.t
-    ; pcsig_fields : Class_type_field.t list
+    { pcsig_self : core_type
+    ; pcsig_fields : class_type_field list
     }
 
   val of_concrete : concrete -> t
@@ -1158,25 +1158,25 @@ and Class_signature : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcsig_self:Core_type.t
-    -> pcsig_fields:Class_type_field.t list
+    pcsig_self:core_type
+    -> pcsig_fields:class_type_field list
     -> t
   val update :
-    ?pcsig_self:Core_type.t
-    -> ?pcsig_fields:Class_type_field.t list
+    ?pcsig_self:core_type
+    -> ?pcsig_fields:class_type_field list
     -> t -> t
 
-  val pcsig_self : t -> Core_type.t
-  val pcsig_fields : t -> Class_type_field.t list
+  val pcsig_self : t -> core_type
+  val pcsig_fields : t -> class_type_field list
 end
 
 and Class_type_field : sig
   type t = class_type_field
 
   type concrete =
-    { pctf_desc : Class_type_field_desc.t
+    { pctf_desc : class_type_field_desc
     ; pctf_loc : Astlib.Location.t
-    ; pctf_attributes : Attributes.t
+    ; pctf_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -1184,53 +1184,53 @@ and Class_type_field : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pctf_desc:Class_type_field_desc.t
+    pctf_desc:class_type_field_desc
     -> pctf_loc:Astlib.Location.t
-    -> pctf_attributes:Attributes.t
+    -> pctf_attributes:attributes
     -> t
   val update :
-    ?pctf_desc:Class_type_field_desc.t
+    ?pctf_desc:class_type_field_desc
     -> ?pctf_loc:Astlib.Location.t
-    -> ?pctf_attributes:Attributes.t
+    -> ?pctf_attributes:attributes
     -> t -> t
 
-  val pctf_desc : t -> Class_type_field_desc.t
+  val pctf_desc : t -> class_type_field_desc
   val pctf_loc : t -> Astlib.Location.t
-  val pctf_attributes : t -> Attributes.t
+  val pctf_attributes : t -> attributes
 end
 
 and Class_type_field_desc : sig
   type t = class_type_field_desc
 
   type concrete =
-    | Pctf_inherit of Class_type.t
-    | Pctf_val of (string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
-    | Pctf_method of (string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
-    | Pctf_constraint of (Core_type.t * Core_type.t)
-    | Pctf_attribute of Attribute.t
-    | Pctf_extension of Extension.t
+    | Pctf_inherit of class_type
+    | Pctf_val of (string Astlib.Loc.t * mutable_flag * virtual_flag * core_type)
+    | Pctf_method of (string Astlib.Loc.t * private_flag * virtual_flag * core_type)
+    | Pctf_constraint of (core_type * core_type)
+    | Pctf_attribute of attribute
+    | Pctf_extension of extension
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pctf_inherit :
-    Class_type.t
+    class_type
     -> t
   val pctf_val :
-    (string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t)
+    (string Astlib.Loc.t * mutable_flag * virtual_flag * core_type)
     -> t
   val pctf_method :
-    (string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t)
+    (string Astlib.Loc.t * private_flag * virtual_flag * core_type)
     -> t
   val pctf_constraint :
-    (Core_type.t * Core_type.t)
+    (core_type * core_type)
     -> t
   val pctf_attribute :
-    Attribute.t
+    attribute
     -> t
   val pctf_extension :
-    Extension.t
+    extension
     -> t
 end
 
@@ -1238,12 +1238,12 @@ and Class_infos : sig
   type 'a t = 'a class_infos
 
   type 'a concrete =
-    { pci_virt : Virtual_flag.t
-    ; pci_params : (Core_type.t * Variance.t) list
+    { pci_virt : virtual_flag
+    ; pci_params : (core_type * variance) list
     ; pci_name : string Astlib.Loc.t
     ; pci_expr : 'a
     ; pci_loc : Astlib.Location.t
-    ; pci_attributes : Attributes.t
+    ; pci_attributes : attributes
     }
 
   val of_concrete : 'a node concrete -> 'a node t
@@ -1251,61 +1251,61 @@ and Class_infos : sig
   val to_concrete_opt : 'a node t -> 'a node concrete option
 
   val create :
-    pci_virt:Virtual_flag.t
-    -> pci_params:(Core_type.t * Variance.t) list
+    pci_virt:virtual_flag
+    -> pci_params:(core_type * variance) list
     -> pci_name:string Astlib.Loc.t
     -> pci_expr:'a node
     -> pci_loc:Astlib.Location.t
-    -> pci_attributes:Attributes.t
+    -> pci_attributes:attributes
     -> 'a node t
   val update :
-    ?pci_virt:Virtual_flag.t
-    -> ?pci_params:(Core_type.t * Variance.t) list
+    ?pci_virt:virtual_flag
+    -> ?pci_params:(core_type * variance) list
     -> ?pci_name:string Astlib.Loc.t
     -> ?pci_expr:'a node
     -> ?pci_loc:Astlib.Location.t
-    -> ?pci_attributes:Attributes.t
+    -> ?pci_attributes:attributes
     -> 'a node t -> 'a node t
 
-  val pci_virt : 'a node t -> Virtual_flag.t
-  val pci_params : 'a node t -> (Core_type.t * Variance.t) list
+  val pci_virt : 'a node t -> virtual_flag
+  val pci_params : 'a node t -> (core_type * variance) list
   val pci_name : 'a node t -> string Astlib.Loc.t
   val pci_expr : 'a node t -> 'a node
   val pci_loc : 'a node t -> Astlib.Location.t
-  val pci_attributes : 'a node t -> Attributes.t
+  val pci_attributes : 'a node t -> attributes
 end
 
 and Class_description : sig
   type t = class_description
 
-  type concrete = Class_type.t Class_infos.t
+  type concrete = class_type class_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Class_type.t Class_infos.t -> t
+  val create : class_type class_infos -> t
 end
 
 and Class_type_declaration : sig
   type t = class_type_declaration
 
-  type concrete = Class_type.t Class_infos.t
+  type concrete = class_type class_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Class_type.t Class_infos.t -> t
+  val create : class_type class_infos -> t
 end
 
 and Class_expr : sig
   type t = class_expr
 
   type concrete =
-    { pcl_desc : Class_expr_desc.t
+    { pcl_desc : class_expr_desc
     ; pcl_loc : Astlib.Location.t
-    ; pcl_attributes : Attributes.t
+    ; pcl_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -1313,71 +1313,71 @@ and Class_expr : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcl_desc:Class_expr_desc.t
+    pcl_desc:class_expr_desc
     -> pcl_loc:Astlib.Location.t
-    -> pcl_attributes:Attributes.t
+    -> pcl_attributes:attributes
     -> t
   val update :
-    ?pcl_desc:Class_expr_desc.t
+    ?pcl_desc:class_expr_desc
     -> ?pcl_loc:Astlib.Location.t
-    -> ?pcl_attributes:Attributes.t
+    -> ?pcl_attributes:attributes
     -> t -> t
 
-  val pcl_desc : t -> Class_expr_desc.t
+  val pcl_desc : t -> class_expr_desc
   val pcl_loc : t -> Astlib.Location.t
-  val pcl_attributes : t -> Attributes.t
+  val pcl_attributes : t -> attributes
 end
 
 and Class_expr_desc : sig
   type t = class_expr_desc
 
   type concrete =
-    | Pcl_constr of Longident_loc.t * Core_type.t list
-    | Pcl_structure of Class_structure.t
-    | Pcl_fun of Arg_label.t * Expression.t option * Pattern.t * Class_expr.t
-    | Pcl_apply of Class_expr.t * (Arg_label.t * Expression.t) list
-    | Pcl_let of Rec_flag.t * Value_binding.t list * Class_expr.t
-    | Pcl_constraint of Class_expr.t * Class_type.t
-    | Pcl_extension of Extension.t
-    | Pcl_open of Override_flag.t * Longident_loc.t * Class_expr.t
+    | Pcl_constr of longident_loc * core_type list
+    | Pcl_structure of class_structure
+    | Pcl_fun of arg_label * expression option * pattern * class_expr
+    | Pcl_apply of class_expr * (arg_label * expression) list
+    | Pcl_let of rec_flag * value_binding list * class_expr
+    | Pcl_constraint of class_expr * class_type
+    | Pcl_extension of extension
+    | Pcl_open of override_flag * longident_loc * class_expr
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pcl_constr :
-    Longident_loc.t
-    -> Core_type.t list
+    longident_loc
+    -> core_type list
     -> t
   val pcl_structure :
-    Class_structure.t
+    class_structure
     -> t
   val pcl_fun :
-    Arg_label.t
-    -> Expression.t option
-    -> Pattern.t
-    -> Class_expr.t
+    arg_label
+    -> expression option
+    -> pattern
+    -> class_expr
     -> t
   val pcl_apply :
-    Class_expr.t
-    -> (Arg_label.t * Expression.t) list
+    class_expr
+    -> (arg_label * expression) list
     -> t
   val pcl_let :
-    Rec_flag.t
-    -> Value_binding.t list
-    -> Class_expr.t
+    rec_flag
+    -> value_binding list
+    -> class_expr
     -> t
   val pcl_constraint :
-    Class_expr.t
-    -> Class_type.t
+    class_expr
+    -> class_type
     -> t
   val pcl_extension :
-    Extension.t
+    extension
     -> t
   val pcl_open :
-    Override_flag.t
-    -> Longident_loc.t
-    -> Class_expr.t
+    override_flag
+    -> longident_loc
+    -> class_expr
     -> t
 end
 
@@ -1385,8 +1385,8 @@ and Class_structure : sig
   type t = class_structure
 
   type concrete =
-    { pcstr_self : Pattern.t
-    ; pcstr_fields : Class_field.t list
+    { pcstr_self : pattern
+    ; pcstr_fields : class_field list
     }
 
   val of_concrete : concrete -> t
@@ -1394,25 +1394,25 @@ and Class_structure : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcstr_self:Pattern.t
-    -> pcstr_fields:Class_field.t list
+    pcstr_self:pattern
+    -> pcstr_fields:class_field list
     -> t
   val update :
-    ?pcstr_self:Pattern.t
-    -> ?pcstr_fields:Class_field.t list
+    ?pcstr_self:pattern
+    -> ?pcstr_fields:class_field list
     -> t -> t
 
-  val pcstr_self : t -> Pattern.t
-  val pcstr_fields : t -> Class_field.t list
+  val pcstr_self : t -> pattern
+  val pcstr_fields : t -> class_field list
 end
 
 and Class_field : sig
   type t = class_field
 
   type concrete =
-    { pcf_desc : Class_field_desc.t
+    { pcf_desc : class_field_desc
     ; pcf_loc : Astlib.Location.t
-    ; pcf_attributes : Attributes.t
+    ; pcf_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -1420,59 +1420,59 @@ and Class_field : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pcf_desc:Class_field_desc.t
+    pcf_desc:class_field_desc
     -> pcf_loc:Astlib.Location.t
-    -> pcf_attributes:Attributes.t
+    -> pcf_attributes:attributes
     -> t
   val update :
-    ?pcf_desc:Class_field_desc.t
+    ?pcf_desc:class_field_desc
     -> ?pcf_loc:Astlib.Location.t
-    -> ?pcf_attributes:Attributes.t
+    -> ?pcf_attributes:attributes
     -> t -> t
 
-  val pcf_desc : t -> Class_field_desc.t
+  val pcf_desc : t -> class_field_desc
   val pcf_loc : t -> Astlib.Location.t
-  val pcf_attributes : t -> Attributes.t
+  val pcf_attributes : t -> attributes
 end
 
 and Class_field_desc : sig
   type t = class_field_desc
 
   type concrete =
-    | Pcf_inherit of Override_flag.t * Class_expr.t * string Astlib.Loc.t option
-    | Pcf_val of (string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
-    | Pcf_method of (string Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
-    | Pcf_constraint of (Core_type.t * Core_type.t)
-    | Pcf_initializer of Expression.t
-    | Pcf_attribute of Attribute.t
-    | Pcf_extension of Extension.t
+    | Pcf_inherit of override_flag * class_expr * string Astlib.Loc.t option
+    | Pcf_val of (string Astlib.Loc.t * mutable_flag * class_field_kind)
+    | Pcf_method of (string Astlib.Loc.t * private_flag * class_field_kind)
+    | Pcf_constraint of (core_type * core_type)
+    | Pcf_initializer of expression
+    | Pcf_attribute of attribute
+    | Pcf_extension of extension
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pcf_inherit :
-    Override_flag.t
-    -> Class_expr.t
+    override_flag
+    -> class_expr
     -> string Astlib.Loc.t option
     -> t
   val pcf_val :
-    (string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t)
+    (string Astlib.Loc.t * mutable_flag * class_field_kind)
     -> t
   val pcf_method :
-    (string Astlib.Loc.t * Private_flag.t * Class_field_kind.t)
+    (string Astlib.Loc.t * private_flag * class_field_kind)
     -> t
   val pcf_constraint :
-    (Core_type.t * Core_type.t)
+    (core_type * core_type)
     -> t
   val pcf_initializer :
-    Expression.t
+    expression
     -> t
   val pcf_attribute :
-    Attribute.t
+    attribute
     -> t
   val pcf_extension :
-    Extension.t
+    extension
     -> t
 end
 
@@ -1480,41 +1480,41 @@ and Class_field_kind : sig
   type t = class_field_kind
 
   type concrete =
-    | Cfk_virtual of Core_type.t
-    | Cfk_concrete of Override_flag.t * Expression.t
+    | Cfk_virtual of core_type
+    | Cfk_concrete of override_flag * expression
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val cfk_virtual :
-    Core_type.t
+    core_type
     -> t
   val cfk_concrete :
-    Override_flag.t
-    -> Expression.t
+    override_flag
+    -> expression
     -> t
 end
 
 and Class_declaration : sig
   type t = class_declaration
 
-  type concrete = Class_expr.t Class_infos.t
+  type concrete = class_expr class_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Class_expr.t Class_infos.t -> t
+  val create : class_expr class_infos -> t
 end
 
 and Module_type : sig
   type t = module_type
 
   type concrete =
-    { pmty_desc : Module_type_desc.t
+    { pmty_desc : module_type_desc
     ; pmty_loc : Astlib.Location.t
-    ; pmty_attributes : Attributes.t
+    ; pmty_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -1522,80 +1522,80 @@ and Module_type : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pmty_desc:Module_type_desc.t
+    pmty_desc:module_type_desc
     -> pmty_loc:Astlib.Location.t
-    -> pmty_attributes:Attributes.t
+    -> pmty_attributes:attributes
     -> t
   val update :
-    ?pmty_desc:Module_type_desc.t
+    ?pmty_desc:module_type_desc
     -> ?pmty_loc:Astlib.Location.t
-    -> ?pmty_attributes:Attributes.t
+    -> ?pmty_attributes:attributes
     -> t -> t
 
-  val pmty_desc : t -> Module_type_desc.t
+  val pmty_desc : t -> module_type_desc
   val pmty_loc : t -> Astlib.Location.t
-  val pmty_attributes : t -> Attributes.t
+  val pmty_attributes : t -> attributes
 end
 
 and Module_type_desc : sig
   type t = module_type_desc
 
   type concrete =
-    | Pmty_ident of Longident_loc.t
-    | Pmty_signature of Signature.t
-    | Pmty_functor of string Astlib.Loc.t * Module_type.t option * Module_type.t
-    | Pmty_with of Module_type.t * With_constraint.t list
-    | Pmty_typeof of Module_expr.t
-    | Pmty_extension of Extension.t
-    | Pmty_alias of Longident_loc.t
+    | Pmty_ident of longident_loc
+    | Pmty_signature of signature
+    | Pmty_functor of string Astlib.Loc.t * module_type option * module_type
+    | Pmty_with of module_type * with_constraint list
+    | Pmty_typeof of module_expr
+    | Pmty_extension of extension
+    | Pmty_alias of longident_loc
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pmty_ident :
-    Longident_loc.t
+    longident_loc
     -> t
   val pmty_signature :
-    Signature.t
+    signature
     -> t
   val pmty_functor :
     string Astlib.Loc.t
-    -> Module_type.t option
-    -> Module_type.t
+    -> module_type option
+    -> module_type
     -> t
   val pmty_with :
-    Module_type.t
-    -> With_constraint.t list
+    module_type
+    -> with_constraint list
     -> t
   val pmty_typeof :
-    Module_expr.t
+    module_expr
     -> t
   val pmty_extension :
-    Extension.t
+    extension
     -> t
   val pmty_alias :
-    Longident_loc.t
+    longident_loc
     -> t
 end
 
 and Signature : sig
   type t = signature
 
-  type concrete = Signature_item.t list
+  type concrete = signature_item list
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Signature_item.t list -> t
+  val create : signature_item list -> t
 end
 
 and Signature_item : sig
   type t = signature_item
 
   type concrete =
-    { psig_desc : Signature_item_desc.t
+    { psig_desc : signature_item_desc
     ; psig_loc : Astlib.Location.t
     }
 
@@ -1604,15 +1604,15 @@ and Signature_item : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    psig_desc:Signature_item_desc.t
+    psig_desc:signature_item_desc
     -> psig_loc:Astlib.Location.t
     -> t
   val update :
-    ?psig_desc:Signature_item_desc.t
+    ?psig_desc:signature_item_desc
     -> ?psig_loc:Astlib.Location.t
     -> t -> t
 
-  val psig_desc : t -> Signature_item_desc.t
+  val psig_desc : t -> signature_item_desc
   val psig_loc : t -> Astlib.Location.t
 end
 
@@ -1620,64 +1620,64 @@ and Signature_item_desc : sig
   type t = signature_item_desc
 
   type concrete =
-    | Psig_value of Value_description.t
-    | Psig_type of Rec_flag.t * Type_declaration.t list
-    | Psig_typext of Type_extension.t
-    | Psig_exception of Extension_constructor.t
-    | Psig_module of Module_declaration.t
-    | Psig_recmodule of Module_declaration.t list
-    | Psig_modtype of Module_type_declaration.t
-    | Psig_open of Open_description.t
-    | Psig_include of Include_description.t
-    | Psig_class of Class_description.t list
-    | Psig_class_type of Class_type_declaration.t list
-    | Psig_attribute of Attribute.t
-    | Psig_extension of Extension.t * Attributes.t
+    | Psig_value of value_description
+    | Psig_type of rec_flag * type_declaration list
+    | Psig_typext of type_extension
+    | Psig_exception of extension_constructor
+    | Psig_module of module_declaration
+    | Psig_recmodule of module_declaration list
+    | Psig_modtype of module_type_declaration
+    | Psig_open of open_description
+    | Psig_include of include_description
+    | Psig_class of class_description list
+    | Psig_class_type of class_type_declaration list
+    | Psig_attribute of attribute
+    | Psig_extension of extension * attributes
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val psig_value :
-    Value_description.t
+    value_description
     -> t
   val psig_type :
-    Rec_flag.t
-    -> Type_declaration.t list
+    rec_flag
+    -> type_declaration list
     -> t
   val psig_typext :
-    Type_extension.t
+    type_extension
     -> t
   val psig_exception :
-    Extension_constructor.t
+    extension_constructor
     -> t
   val psig_module :
-    Module_declaration.t
+    module_declaration
     -> t
   val psig_recmodule :
-    Module_declaration.t list
+    module_declaration list
     -> t
   val psig_modtype :
-    Module_type_declaration.t
+    module_type_declaration
     -> t
   val psig_open :
-    Open_description.t
+    open_description
     -> t
   val psig_include :
-    Include_description.t
+    include_description
     -> t
   val psig_class :
-    Class_description.t list
+    class_description list
     -> t
   val psig_class_type :
-    Class_type_declaration.t list
+    class_type_declaration list
     -> t
   val psig_attribute :
-    Attribute.t
+    attribute
     -> t
   val psig_extension :
-    Extension.t
-    -> Attributes.t
+    extension
+    -> attributes
     -> t
 end
 
@@ -1686,8 +1686,8 @@ and Module_declaration : sig
 
   type concrete =
     { pmd_name : string Astlib.Loc.t
-    ; pmd_type : Module_type.t
-    ; pmd_attributes : Attributes.t
+    ; pmd_type : module_type
+    ; pmd_attributes : attributes
     ; pmd_loc : Astlib.Location.t
     }
 
@@ -1697,20 +1697,20 @@ and Module_declaration : sig
 
   val create :
     pmd_name:string Astlib.Loc.t
-    -> pmd_type:Module_type.t
-    -> pmd_attributes:Attributes.t
+    -> pmd_type:module_type
+    -> pmd_attributes:attributes
     -> pmd_loc:Astlib.Location.t
     -> t
   val update :
     ?pmd_name:string Astlib.Loc.t
-    -> ?pmd_type:Module_type.t
-    -> ?pmd_attributes:Attributes.t
+    -> ?pmd_type:module_type
+    -> ?pmd_attributes:attributes
     -> ?pmd_loc:Astlib.Location.t
     -> t -> t
 
   val pmd_name : t -> string Astlib.Loc.t
-  val pmd_type : t -> Module_type.t
-  val pmd_attributes : t -> Attributes.t
+  val pmd_type : t -> module_type
+  val pmd_attributes : t -> attributes
   val pmd_loc : t -> Astlib.Location.t
 end
 
@@ -1719,8 +1719,8 @@ and Module_type_declaration : sig
 
   type concrete =
     { pmtd_name : string Astlib.Loc.t
-    ; pmtd_type : Module_type.t option
-    ; pmtd_attributes : Attributes.t
+    ; pmtd_type : module_type option
+    ; pmtd_attributes : attributes
     ; pmtd_loc : Astlib.Location.t
     }
 
@@ -1730,20 +1730,20 @@ and Module_type_declaration : sig
 
   val create :
     pmtd_name:string Astlib.Loc.t
-    -> pmtd_type:Module_type.t option
-    -> pmtd_attributes:Attributes.t
+    -> pmtd_type:module_type option
+    -> pmtd_attributes:attributes
     -> pmtd_loc:Astlib.Location.t
     -> t
   val update :
     ?pmtd_name:string Astlib.Loc.t
-    -> ?pmtd_type:Module_type.t option
-    -> ?pmtd_attributes:Attributes.t
+    -> ?pmtd_type:module_type option
+    -> ?pmtd_attributes:attributes
     -> ?pmtd_loc:Astlib.Location.t
     -> t -> t
 
   val pmtd_name : t -> string Astlib.Loc.t
-  val pmtd_type : t -> Module_type.t option
-  val pmtd_attributes : t -> Attributes.t
+  val pmtd_type : t -> module_type option
+  val pmtd_attributes : t -> attributes
   val pmtd_loc : t -> Astlib.Location.t
 end
 
@@ -1751,10 +1751,10 @@ and Open_description : sig
   type t = open_description
 
   type concrete =
-    { popen_lid : Longident_loc.t
-    ; popen_override : Override_flag.t
+    { popen_lid : longident_loc
+    ; popen_override : override_flag
     ; popen_loc : Astlib.Location.t
-    ; popen_attributes : Attributes.t
+    ; popen_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -1762,22 +1762,22 @@ and Open_description : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    popen_lid:Longident_loc.t
-    -> popen_override:Override_flag.t
+    popen_lid:longident_loc
+    -> popen_override:override_flag
     -> popen_loc:Astlib.Location.t
-    -> popen_attributes:Attributes.t
+    -> popen_attributes:attributes
     -> t
   val update :
-    ?popen_lid:Longident_loc.t
-    -> ?popen_override:Override_flag.t
+    ?popen_lid:longident_loc
+    -> ?popen_override:override_flag
     -> ?popen_loc:Astlib.Location.t
-    -> ?popen_attributes:Attributes.t
+    -> ?popen_attributes:attributes
     -> t -> t
 
-  val popen_lid : t -> Longident_loc.t
-  val popen_override : t -> Override_flag.t
+  val popen_lid : t -> longident_loc
+  val popen_override : t -> override_flag
   val popen_loc : t -> Astlib.Location.t
-  val popen_attributes : t -> Attributes.t
+  val popen_attributes : t -> attributes
 end
 
 and Include_infos : sig
@@ -1786,7 +1786,7 @@ and Include_infos : sig
   type 'a concrete =
     { pincl_mod : 'a
     ; pincl_loc : Astlib.Location.t
-    ; pincl_attributes : Attributes.t
+    ; pincl_attributes : attributes
     }
 
   val of_concrete : 'a node concrete -> 'a node t
@@ -1796,71 +1796,71 @@ and Include_infos : sig
   val create :
     pincl_mod:'a node
     -> pincl_loc:Astlib.Location.t
-    -> pincl_attributes:Attributes.t
+    -> pincl_attributes:attributes
     -> 'a node t
   val update :
     ?pincl_mod:'a node
     -> ?pincl_loc:Astlib.Location.t
-    -> ?pincl_attributes:Attributes.t
+    -> ?pincl_attributes:attributes
     -> 'a node t -> 'a node t
 
   val pincl_mod : 'a node t -> 'a node
   val pincl_loc : 'a node t -> Astlib.Location.t
-  val pincl_attributes : 'a node t -> Attributes.t
+  val pincl_attributes : 'a node t -> attributes
 end
 
 and Include_description : sig
   type t = include_description
 
-  type concrete = Module_type.t Include_infos.t
+  type concrete = module_type include_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Module_type.t Include_infos.t -> t
+  val create : module_type include_infos -> t
 end
 
 and Include_declaration : sig
   type t = include_declaration
 
-  type concrete = Module_expr.t Include_infos.t
+  type concrete = module_expr include_infos
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Module_expr.t Include_infos.t -> t
+  val create : module_expr include_infos -> t
 end
 
 and With_constraint : sig
   type t = with_constraint
 
   type concrete =
-    | Pwith_type of Longident_loc.t * Type_declaration.t
-    | Pwith_module of Longident_loc.t * Longident_loc.t
-    | Pwith_typesubst of Longident_loc.t * Type_declaration.t
-    | Pwith_modsubst of Longident_loc.t * Longident_loc.t
+    | Pwith_type of longident_loc * type_declaration
+    | Pwith_module of longident_loc * longident_loc
+    | Pwith_typesubst of longident_loc * type_declaration
+    | Pwith_modsubst of longident_loc * longident_loc
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pwith_type :
-    Longident_loc.t
-    -> Type_declaration.t
+    longident_loc
+    -> type_declaration
     -> t
   val pwith_module :
-    Longident_loc.t
-    -> Longident_loc.t
+    longident_loc
+    -> longident_loc
     -> t
   val pwith_typesubst :
-    Longident_loc.t
-    -> Type_declaration.t
+    longident_loc
+    -> type_declaration
     -> t
   val pwith_modsubst :
-    Longident_loc.t
-    -> Longident_loc.t
+    longident_loc
+    -> longident_loc
     -> t
 end
 
@@ -1868,9 +1868,9 @@ and Module_expr : sig
   type t = module_expr
 
   type concrete =
-    { pmod_desc : Module_expr_desc.t
+    { pmod_desc : module_expr_desc
     ; pmod_loc : Astlib.Location.t
-    ; pmod_attributes : Attributes.t
+    ; pmod_attributes : attributes
     }
 
   val of_concrete : concrete -> t
@@ -1878,81 +1878,81 @@ and Module_expr : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pmod_desc:Module_expr_desc.t
+    pmod_desc:module_expr_desc
     -> pmod_loc:Astlib.Location.t
-    -> pmod_attributes:Attributes.t
+    -> pmod_attributes:attributes
     -> t
   val update :
-    ?pmod_desc:Module_expr_desc.t
+    ?pmod_desc:module_expr_desc
     -> ?pmod_loc:Astlib.Location.t
-    -> ?pmod_attributes:Attributes.t
+    -> ?pmod_attributes:attributes
     -> t -> t
 
-  val pmod_desc : t -> Module_expr_desc.t
+  val pmod_desc : t -> module_expr_desc
   val pmod_loc : t -> Astlib.Location.t
-  val pmod_attributes : t -> Attributes.t
+  val pmod_attributes : t -> attributes
 end
 
 and Module_expr_desc : sig
   type t = module_expr_desc
 
   type concrete =
-    | Pmod_ident of Longident_loc.t
-    | Pmod_structure of Structure.t
-    | Pmod_functor of string Astlib.Loc.t * Module_type.t option * Module_expr.t
-    | Pmod_apply of Module_expr.t * Module_expr.t
-    | Pmod_constraint of Module_expr.t * Module_type.t
-    | Pmod_unpack of Expression.t
-    | Pmod_extension of Extension.t
+    | Pmod_ident of longident_loc
+    | Pmod_structure of structure
+    | Pmod_functor of string Astlib.Loc.t * module_type option * module_expr
+    | Pmod_apply of module_expr * module_expr
+    | Pmod_constraint of module_expr * module_type
+    | Pmod_unpack of expression
+    | Pmod_extension of extension
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pmod_ident :
-    Longident_loc.t
+    longident_loc
     -> t
   val pmod_structure :
-    Structure.t
+    structure
     -> t
   val pmod_functor :
     string Astlib.Loc.t
-    -> Module_type.t option
-    -> Module_expr.t
+    -> module_type option
+    -> module_expr
     -> t
   val pmod_apply :
-    Module_expr.t
-    -> Module_expr.t
+    module_expr
+    -> module_expr
     -> t
   val pmod_constraint :
-    Module_expr.t
-    -> Module_type.t
+    module_expr
+    -> module_type
     -> t
   val pmod_unpack :
-    Expression.t
+    expression
     -> t
   val pmod_extension :
-    Extension.t
+    extension
     -> t
 end
 
 and Structure : sig
   type t = structure
 
-  type concrete = Structure_item.t list
+  type concrete = structure_item list
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
-  val create : Structure_item.t list -> t
+  val create : structure_item list -> t
 end
 
 and Structure_item : sig
   type t = structure_item
 
   type concrete =
-    { pstr_desc : Structure_item_desc.t
+    { pstr_desc : structure_item_desc
     ; pstr_loc : Astlib.Location.t
     }
 
@@ -1961,15 +1961,15 @@ and Structure_item : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pstr_desc:Structure_item_desc.t
+    pstr_desc:structure_item_desc
     -> pstr_loc:Astlib.Location.t
     -> t
   val update :
-    ?pstr_desc:Structure_item_desc.t
+    ?pstr_desc:structure_item_desc
     -> ?pstr_loc:Astlib.Location.t
     -> t -> t
 
-  val pstr_desc : t -> Structure_item_desc.t
+  val pstr_desc : t -> structure_item_desc
   val pstr_loc : t -> Astlib.Location.t
 end
 
@@ -1977,74 +1977,74 @@ and Structure_item_desc : sig
   type t = structure_item_desc
 
   type concrete =
-    | Pstr_eval of Expression.t * Attributes.t
-    | Pstr_value of Rec_flag.t * Value_binding.t list
-    | Pstr_primitive of Value_description.t
-    | Pstr_type of Rec_flag.t * Type_declaration.t list
-    | Pstr_typext of Type_extension.t
-    | Pstr_exception of Extension_constructor.t
-    | Pstr_module of Module_binding.t
-    | Pstr_recmodule of Module_binding.t list
-    | Pstr_modtype of Module_type_declaration.t
-    | Pstr_open of Open_description.t
-    | Pstr_class of Class_declaration.t list
-    | Pstr_class_type of Class_type_declaration.t list
-    | Pstr_include of Include_declaration.t
-    | Pstr_attribute of Attribute.t
-    | Pstr_extension of Extension.t * Attributes.t
+    | Pstr_eval of expression * attributes
+    | Pstr_value of rec_flag * value_binding list
+    | Pstr_primitive of value_description
+    | Pstr_type of rec_flag * type_declaration list
+    | Pstr_typext of type_extension
+    | Pstr_exception of extension_constructor
+    | Pstr_module of module_binding
+    | Pstr_recmodule of module_binding list
+    | Pstr_modtype of module_type_declaration
+    | Pstr_open of open_description
+    | Pstr_class of class_declaration list
+    | Pstr_class_type of class_type_declaration list
+    | Pstr_include of include_declaration
+    | Pstr_attribute of attribute
+    | Pstr_extension of extension * attributes
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val pstr_eval :
-    Expression.t
-    -> Attributes.t
+    expression
+    -> attributes
     -> t
   val pstr_value :
-    Rec_flag.t
-    -> Value_binding.t list
+    rec_flag
+    -> value_binding list
     -> t
   val pstr_primitive :
-    Value_description.t
+    value_description
     -> t
   val pstr_type :
-    Rec_flag.t
-    -> Type_declaration.t list
+    rec_flag
+    -> type_declaration list
     -> t
   val pstr_typext :
-    Type_extension.t
+    type_extension
     -> t
   val pstr_exception :
-    Extension_constructor.t
+    extension_constructor
     -> t
   val pstr_module :
-    Module_binding.t
+    module_binding
     -> t
   val pstr_recmodule :
-    Module_binding.t list
+    module_binding list
     -> t
   val pstr_modtype :
-    Module_type_declaration.t
+    module_type_declaration
     -> t
   val pstr_open :
-    Open_description.t
+    open_description
     -> t
   val pstr_class :
-    Class_declaration.t list
+    class_declaration list
     -> t
   val pstr_class_type :
-    Class_type_declaration.t list
+    class_type_declaration list
     -> t
   val pstr_include :
-    Include_declaration.t
+    include_declaration
     -> t
   val pstr_attribute :
-    Attribute.t
+    attribute
     -> t
   val pstr_extension :
-    Extension.t
-    -> Attributes.t
+    extension
+    -> attributes
     -> t
 end
 
@@ -2052,9 +2052,9 @@ and Value_binding : sig
   type t = value_binding
 
   type concrete =
-    { pvb_pat : Pattern.t
-    ; pvb_expr : Expression.t
-    ; pvb_attributes : Attributes.t
+    { pvb_pat : pattern
+    ; pvb_expr : expression
+    ; pvb_attributes : attributes
     ; pvb_loc : Astlib.Location.t
     }
 
@@ -2063,21 +2063,21 @@ and Value_binding : sig
   val to_concrete_opt : t -> concrete option
 
   val create :
-    pvb_pat:Pattern.t
-    -> pvb_expr:Expression.t
-    -> pvb_attributes:Attributes.t
+    pvb_pat:pattern
+    -> pvb_expr:expression
+    -> pvb_attributes:attributes
     -> pvb_loc:Astlib.Location.t
     -> t
   val update :
-    ?pvb_pat:Pattern.t
-    -> ?pvb_expr:Expression.t
-    -> ?pvb_attributes:Attributes.t
+    ?pvb_pat:pattern
+    -> ?pvb_expr:expression
+    -> ?pvb_attributes:attributes
     -> ?pvb_loc:Astlib.Location.t
     -> t -> t
 
-  val pvb_pat : t -> Pattern.t
-  val pvb_expr : t -> Expression.t
-  val pvb_attributes : t -> Attributes.t
+  val pvb_pat : t -> pattern
+  val pvb_expr : t -> expression
+  val pvb_attributes : t -> attributes
   val pvb_loc : t -> Astlib.Location.t
 end
 
@@ -2086,8 +2086,8 @@ and Module_binding : sig
 
   type concrete =
     { pmb_name : string Astlib.Loc.t
-    ; pmb_expr : Module_expr.t
-    ; pmb_attributes : Attributes.t
+    ; pmb_expr : module_expr
+    ; pmb_attributes : attributes
     ; pmb_loc : Astlib.Location.t
     }
 
@@ -2097,20 +2097,20 @@ and Module_binding : sig
 
   val create :
     pmb_name:string Astlib.Loc.t
-    -> pmb_expr:Module_expr.t
-    -> pmb_attributes:Attributes.t
+    -> pmb_expr:module_expr
+    -> pmb_attributes:attributes
     -> pmb_loc:Astlib.Location.t
     -> t
   val update :
     ?pmb_name:string Astlib.Loc.t
-    -> ?pmb_expr:Module_expr.t
-    -> ?pmb_attributes:Attributes.t
+    -> ?pmb_expr:module_expr
+    -> ?pmb_attributes:attributes
     -> ?pmb_loc:Astlib.Location.t
     -> t -> t
 
   val pmb_name : t -> string Astlib.Loc.t
-  val pmb_expr : t -> Module_expr.t
-  val pmb_attributes : t -> Attributes.t
+  val pmb_expr : t -> module_expr
+  val pmb_attributes : t -> attributes
   val pmb_loc : t -> Astlib.Location.t
 end
 
@@ -2118,19 +2118,19 @@ and Toplevel_phrase : sig
   type t = toplevel_phrase
 
   type concrete =
-    | Ptop_def of Structure.t
-    | Ptop_dir of string * Directive_argument.t
+    | Ptop_def of structure
+    | Ptop_dir of string * directive_argument
 
   val of_concrete : concrete -> t
   val to_concrete : t -> concrete
   val to_concrete_opt : t -> concrete option
 
   val ptop_def :
-    Structure.t
+    structure
     -> t
   val ptop_dir :
     string
-    -> Directive_argument.t
+    -> directive_argument
     -> t
 end
 
@@ -2141,7 +2141,7 @@ and Directive_argument : sig
     | Pdir_none
     | Pdir_string of string
     | Pdir_int of string * char option
-    | Pdir_ident of Longident.t
+    | Pdir_ident of longident
     | Pdir_bool of bool
 
   val of_concrete : concrete -> t
@@ -2157,7 +2157,7 @@ and Directive_argument : sig
     -> char option
     -> t
   val pdir_ident :
-    Longident.t
+    longident
     -> t
   val pdir_bool :
     bool

--- a/ast/viewer_unstable_for_testing.mli
+++ b/ast/viewer_unstable_for_testing.mli
@@ -2,864 +2,863 @@ open Viewlib
 
 (*$ Ppx_ast_cinaps.print_viewer_mli (Astlib.Version.of_string "unstable_for_testing") *)
 open Versions
-open Unstable_for_testing
 include module type of Viewer_common
 
-val pdir_bool'const : (bool, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+val pdir_bool'const : (bool, 'i, 'o) View.t -> (directive_argument, 'i, 'o) View.t
 
-val pdir_ident'const : (Longident.t, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+val pdir_ident'const : (longident, 'i, 'o) View.t -> (directive_argument, 'i, 'o) View.t
 
-val pdir_int'const : ((char option * string), 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+val pdir_int'const : ((char option * string), 'i, 'o) View.t -> (directive_argument, 'i, 'o) View.t
 
-val pdir_string'const : (string, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+val pdir_string'const : (string, 'i, 'o) View.t -> (directive_argument, 'i, 'o) View.t
 
-val pdir_none'const : (Directive_argument.t, 'a, 'a) View.t
+val pdir_none'const : (directive_argument, 'a, 'a) View.t
 
-val ptop_dir'const : ((Directive_argument.t * string), 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+val ptop_dir'const : ((directive_argument * string), 'i, 'o) View.t -> (toplevel_phrase, 'i, 'o) View.t
 
-val ptop_def'const : (Structure.t, 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+val ptop_def'const : (structure, 'i, 'o) View.t -> (toplevel_phrase, 'i, 'o) View.t
 
-val pmb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
+val pmb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_binding, 'i, 'o) View.t
 
-val pmb_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
+val pmb_attributes'match : (attributes, 'i, 'o) View.t -> (module_binding, 'i, 'o) View.t
 
-val pmb_expr'match : (Module_expr.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
+val pmb_expr'match : (module_expr, 'i, 'o) View.t -> (module_binding, 'i, 'o) View.t
 
-val pmb_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
+val pmb_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (module_binding, 'i, 'o) View.t
 
-val pvb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
+val pvb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (value_binding, 'i, 'o) View.t
 
-val pvb_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
+val pvb_attributes'match : (attributes, 'i, 'o) View.t -> (value_binding, 'i, 'o) View.t
 
-val pvb_expr'match : (Expression.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
+val pvb_expr'match : (expression, 'i, 'o) View.t -> (value_binding, 'i, 'o) View.t
 
-val pvb_pat'match : (Pattern.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
+val pvb_pat'match : (pattern, 'i, 'o) View.t -> (value_binding, 'i, 'o) View.t
 
-val pstr_extension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_extension'const : ((attributes * extension), 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strextension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strextension'const : ((attributes * extension), 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_attribute'const : (attribute, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strattribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strattribute'const : (attribute, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_include'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_include'const : (include_declaration, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strinclude'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strinclude'const : (include_declaration, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_class_type'const : (class_type_declaration list, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strclass_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strclass_type'const : (class_type_declaration list, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_class'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_class'const : (class_declaration list, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strclass'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strclass'const : (class_declaration list, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_open'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_open'const : (open_description, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val stropen'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val stropen'const : (open_description, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_modtype'const : (module_type_declaration, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strmodtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strmodtype'const : (module_type_declaration, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_recmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_recmodule'const : (module_binding list, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strrecmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strrecmodule'const : (module_binding list, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_module'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_module'const : (module_binding, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strmodule'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strmodule'const : (module_binding, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_exception'const : (extension_constructor, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strexception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strexception'const : (extension_constructor, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_typext'const : (type_extension, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strtypext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strtypext'const : (type_extension, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_type'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_type'const : ((type_declaration list * rec_flag), 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strtype'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strtype'const : ((type_declaration list * rec_flag), 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_primitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_primitive'const : (value_description, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strprimitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strprimitive'const : (value_description, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_value'const : ((Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_value'const : ((value_binding list * rec_flag), 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strvalue'const : ((Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strvalue'const : ((value_binding list * rec_flag), 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_eval'const : ((Attributes.t * Expression.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_eval'const : ((attributes * expression), 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val streval'const : ((Attributes.t * Expression.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val streval'const : ((attributes * expression), 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val pstr_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_desc'match : (Structure_item_desc.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
-val structure'const: (Structure_item.t list, 'i, 'o) View.t -> (Structure.t, 'i, 'o) View.t
+val pstr_desc'match : (structure_item_desc, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
+val structure'const: (structure_item list, 'i, 'o) View.t -> (structure, 'i, 'o) View.t
 
-val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_extension'const : (extension, 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meextension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val meextension'const : (extension, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_unpack'const : (expression, 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meunpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val meunpack'const : (expression, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_constraint'const : ((Module_type.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_constraint'const : ((module_type * module_expr), 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meconstraint'const : ((Module_type.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val meconstraint'const : ((module_type * module_expr), 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_apply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_apply'const : ((module_expr * module_expr), 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meapply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val meapply'const : ((module_expr * module_expr), 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_functor'const : ((Module_expr.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_functor'const : ((module_expr * module_type option * string Astlib.Loc.t), 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val mefunctor'const : ((Module_expr.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val mefunctor'const : ((module_expr * module_type option * string Astlib.Loc.t), 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_structure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_structure'const : (structure, 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val mestructure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val mestructure'const : (structure, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_ident'const : (longident_loc, 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val meident'const : (longident_loc, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val pmod_attributes'match : (attributes, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val pmod_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_desc'match : (Module_expr_desc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val pmod_desc'match : (module_expr_desc, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pwith_modsubst'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+val pwith_modsubst'const : ((longident_loc * longident_loc), 'i, 'o) View.t -> (with_constraint, 'i, 'o) View.t
 
-val pwith_typesubst'const : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+val pwith_typesubst'const : ((type_declaration * longident_loc), 'i, 'o) View.t -> (with_constraint, 'i, 'o) View.t
 
-val pwith_module'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+val pwith_module'const : ((longident_loc * longident_loc), 'i, 'o) View.t -> (with_constraint, 'i, 'o) View.t
 
-val pwith_type'const : ((Type_declaration.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
-val include_declaration'const: (Module_expr.t Include_infos.t, 'i, 'o) View.t -> (Include_declaration.t, 'i, 'o) View.t
-val include_description'const: (Module_type.t Include_infos.t, 'i, 'o) View.t -> (Include_description.t, 'i, 'o) View.t
+val pwith_type'const : ((type_declaration * longident_loc), 'i, 'o) View.t -> (with_constraint, 'i, 'o) View.t
+val include_declaration'const: (module_expr include_infos, 'i, 'o) View.t -> (include_declaration, 'i, 'o) View.t
+val include_description'const: (module_type include_infos, 'i, 'o) View.t -> (include_description, 'i, 'o) View.t
 
-val pincl_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
+val pincl_attributes'match : (attributes, 'i, 'o) View.t -> ('a node include_infos, 'i, 'o) View.t
 
-val pincl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
+val pincl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node include_infos, 'i, 'o) View.t
 
-val pincl_mod'match : ('a node, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
+val pincl_mod'match : ('a node, 'i, 'o) View.t -> ('a node include_infos, 'i, 'o) View.t
 
-val popen_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Open_description.t, 'i, 'o) View.t
+val popen_attributes'match : (attributes, 'i, 'o) View.t -> (open_description, 'i, 'o) View.t
 
-val popen_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Open_description.t, 'i, 'o) View.t
+val popen_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (open_description, 'i, 'o) View.t
 
-val popen_override'match : (Override_flag.t, 'i, 'o) View.t -> (Open_description.t, 'i, 'o) View.t
+val popen_override'match : (override_flag, 'i, 'o) View.t -> (open_description, 'i, 'o) View.t
 
-val popen_lid'match : (Longident_loc.t, 'i, 'o) View.t -> (Open_description.t, 'i, 'o) View.t
+val popen_lid'match : (longident_loc, 'i, 'o) View.t -> (open_description, 'i, 'o) View.t
 
-val pmtd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_type_declaration.t, 'i, 'o) View.t
+val pmtd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_type_declaration, 'i, 'o) View.t
 
-val pmtd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_type_declaration.t, 'i, 'o) View.t
+val pmtd_attributes'match : (attributes, 'i, 'o) View.t -> (module_type_declaration, 'i, 'o) View.t
 
-val pmtd_type'match : (Module_type.t option, 'i, 'o) View.t -> (Module_type_declaration.t, 'i, 'o) View.t
+val pmtd_type'match : (module_type option, 'i, 'o) View.t -> (module_type_declaration, 'i, 'o) View.t
 
-val pmtd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_type_declaration.t, 'i, 'o) View.t
+val pmtd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (module_type_declaration, 'i, 'o) View.t
 
-val pmd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
+val pmd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_declaration, 'i, 'o) View.t
 
-val pmd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
+val pmd_attributes'match : (attributes, 'i, 'o) View.t -> (module_declaration, 'i, 'o) View.t
 
-val pmd_type'match : (Module_type.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
+val pmd_type'match : (module_type, 'i, 'o) View.t -> (module_declaration, 'i, 'o) View.t
 
-val pmd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
+val pmd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (module_declaration, 'i, 'o) View.t
 
-val psig_extension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_extension'const : ((attributes * extension), 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigextension'const : ((Attributes.t * Extension.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigextension'const : ((attributes * extension), 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_attribute'const : (attribute, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigattribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigattribute'const : (attribute, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_class_type'const : (class_type_declaration list, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigclass_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigclass_type'const : (class_type_declaration list, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_class'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_class'const : (class_description list, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigclass'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigclass'const : (class_description list, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_include'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_include'const : (include_description, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val siginclude'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val siginclude'const : (include_description, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_open'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_open'const : (open_description, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigopen'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigopen'const : (open_description, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_modtype'const : (module_type_declaration, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigmodtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigmodtype'const : (module_type_declaration, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_recmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_recmodule'const : (module_declaration list, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigrecmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigrecmodule'const : (module_declaration list, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_module'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_module'const : (module_declaration, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigmodule'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigmodule'const : (module_declaration, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_exception'const : (extension_constructor, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigexception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigexception'const : (extension_constructor, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_typext'const : (type_extension, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigtypext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigtypext'const : (type_extension, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_type'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_type'const : ((type_declaration list * rec_flag), 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigtype'const : ((Type_declaration.t list * Rec_flag.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigtype'const : ((type_declaration list * rec_flag), 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_value'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_value'const : (value_description, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigvalue'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigvalue'const : (value_description, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val psig_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_desc'match : (Signature_item_desc.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
-val signature'const: (Signature_item.t list, 'i, 'o) View.t -> (Signature.t, 'i, 'o) View.t
+val psig_desc'match : (signature_item_desc, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
+val signature'const: (signature_item list, 'i, 'o) View.t -> (signature, 'i, 'o) View.t
 
-val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_alias'const : (longident_loc, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtalias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtalias'const : (longident_loc, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_extension'const : (extension, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtextension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtextension'const : (extension, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_typeof'const : (module_expr, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mttypeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mttypeof'const : (module_expr, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_with'const : ((With_constraint.t list * Module_type.t), 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_with'const : ((with_constraint list * module_type), 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtwith'const : ((With_constraint.t list * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtwith'const : ((with_constraint list * module_type), 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_functor'const : ((Module_type.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_functor'const : ((module_type * module_type option * string Astlib.Loc.t), 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtfunctor'const : ((Module_type.t * Module_type.t option * string Astlib.Loc.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtfunctor'const : ((module_type * module_type option * string Astlib.Loc.t), 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_signature'const : (Signature.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_signature'const : (signature, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtsignature'const : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtsignature'const : (signature, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_ident'const : (longident_loc, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtident'const : (longident_loc, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val pmty_attributes'match : (attributes, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val pmty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_desc'match : (Module_type_desc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val class_declaration'const: (Class_expr.t Class_infos.t, 'i, 'o) View.t -> (Class_declaration.t, 'i, 'o) View.t
+val pmty_desc'match : (module_type_desc, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
+val class_declaration'const: (class_expr class_infos, 'i, 'o) View.t -> (class_declaration, 'i, 'o) View.t
 
-val cfk_concrete'const : ((Expression.t * Override_flag.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+val cfk_concrete'const : ((expression * override_flag), 'i, 'o) View.t -> (class_field_kind, 'i, 'o) View.t
 
-val cfk_virtual'const : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+val cfk_virtual'const : (core_type, 'i, 'o) View.t -> (class_field_kind, 'i, 'o) View.t
 
-val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_extension'const : (extension, 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfextension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfextension'const : (extension, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_attribute'const : (attribute, 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfattribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfattribute'const : (attribute, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_initializer'const : (expression, 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfinitializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfinitializer'const : (expression, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_constraint'const : ((core_type * core_type), 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfconstraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfconstraint'const : ((core_type * core_type), 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_method'const : ((Class_field_kind.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_method'const : ((class_field_kind * private_flag * string Astlib.Loc.t), 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfmethod'const : ((Class_field_kind.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfmethod'const : ((class_field_kind * private_flag * string Astlib.Loc.t), 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_val'const : ((Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_val'const : ((class_field_kind * mutable_flag * string Astlib.Loc.t), 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfval'const : ((Class_field_kind.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfval'const : ((class_field_kind * mutable_flag * string Astlib.Loc.t), 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_inherit'const : ((string Astlib.Loc.t option * Class_expr.t * Override_flag.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_inherit'const : ((string Astlib.Loc.t option * class_expr * override_flag), 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfinherit'const : ((string Astlib.Loc.t option * Class_expr.t * Override_flag.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfinherit'const : ((string Astlib.Loc.t option * class_expr * override_flag), 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_attributes'match : (attributes, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_desc'match : (Class_field_desc.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_desc'match : (class_field_desc, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcstr_fields'match : (Class_field.t list, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
+val pcstr_fields'match : (class_field list, 'i, 'o) View.t -> (class_structure, 'i, 'o) View.t
 
-val pcstr_self'match : (Pattern.t, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
+val pcstr_self'match : (pattern, 'i, 'o) View.t -> (class_structure, 'i, 'o) View.t
 
-val pcl_open'const : ((Class_expr.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_open'const : ((class_expr * longident_loc * override_flag), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceopen'const : ((Class_expr.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceopen'const : ((class_expr * longident_loc * override_flag), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_extension'const : (extension, 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceextension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceextension'const : (extension, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_constraint'const : ((Class_type.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_constraint'const : ((class_type * class_expr), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceconstraint'const : ((Class_type.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceconstraint'const : ((class_type * class_expr), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_let'const : ((Class_expr.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_let'const : ((class_expr * value_binding list * rec_flag), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val celet'const : ((Class_expr.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val celet'const : ((class_expr * value_binding list * rec_flag), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_apply'const : (((Expression.t * Arg_label.t) list * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_apply'const : (((expression * arg_label) list * class_expr), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceapply'const : (((Expression.t * Arg_label.t) list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceapply'const : (((expression * arg_label) list * class_expr), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_fun'const : ((Class_expr.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_fun'const : ((class_expr * pattern * expression option * arg_label), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val cefun'const : ((Class_expr.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val cefun'const : ((class_expr * pattern * expression option * arg_label), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_structure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_structure'const : (class_structure, 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val cestructure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val cestructure'const : (class_structure, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_constr'const : ((core_type list * longident_loc), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceconstr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceconstr'const : ((core_type list * longident_loc), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val pcl_attributes'match : (attributes, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val pcl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_desc'match : (Class_expr_desc.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
-val class_type_declaration'const: (Class_type.t Class_infos.t, 'i, 'o) View.t -> (Class_type_declaration.t, 'i, 'o) View.t
-val class_description'const: (Class_type.t Class_infos.t, 'i, 'o) View.t -> (Class_description.t, 'i, 'o) View.t
+val pcl_desc'match : (class_expr_desc, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
+val class_type_declaration'const: (class_type class_infos, 'i, 'o) View.t -> (class_type_declaration, 'i, 'o) View.t
+val class_description'const: (class_type class_infos, 'i, 'o) View.t -> (class_description, 'i, 'o) View.t
 
-val pci_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_attributes'match : (attributes, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_expr'match : ('a node, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_expr'match : ('a node, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_params'match : ((Variance.t * Core_type.t) list, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_params'match : ((variance * core_type) list, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_virt'match : (Virtual_flag.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_virt'match : (virtual_flag, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_extension'const : (extension, 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfextension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfextension'const : (extension, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_attribute'const : (attribute, 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfattribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfattribute'const : (attribute, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_constraint'const : ((core_type * core_type), 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfconstraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfconstraint'const : ((core_type * core_type), 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_method'const : ((Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_method'const : ((core_type * virtual_flag * private_flag * string Astlib.Loc.t), 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfmethod'const : ((Core_type.t * Virtual_flag.t * Private_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfmethod'const : ((core_type * virtual_flag * private_flag * string Astlib.Loc.t), 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_val'const : ((Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_val'const : ((core_type * virtual_flag * mutable_flag * string Astlib.Loc.t), 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfval'const : ((Core_type.t * Virtual_flag.t * Mutable_flag.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfval'const : ((core_type * virtual_flag * mutable_flag * string Astlib.Loc.t), 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_inherit'const : (class_type, 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfinherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfinherit'const : (class_type, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_attributes'match : (attributes, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_desc'match : (Class_type_field_desc.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_desc'match : (class_type_field_desc, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pcsig_fields'match : (Class_type_field.t list, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
+val pcsig_fields'match : (class_type_field list, 'i, 'o) View.t -> (class_signature, 'i, 'o) View.t
 
-val pcsig_self'match : (Core_type.t, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
+val pcsig_self'match : (core_type, 'i, 'o) View.t -> (class_signature, 'i, 'o) View.t
 
-val pcty_open'const : ((Class_type.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_open'const : ((class_type * longident_loc * override_flag), 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctopen'const : ((Class_type.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctopen'const : ((class_type * longident_loc * override_flag), 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_extension'const : (extension, 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctextension'const : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctextension'const : (extension, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_arrow'const : ((Class_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_arrow'const : ((class_type * core_type * arg_label), 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctarrow'const : ((Class_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctarrow'const : ((class_type * core_type * arg_label), 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_signature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_signature'const : (class_signature, 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctsignature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctsignature'const : (class_signature, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_constr'const : ((core_type list * longident_loc), 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctconstr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctconstr'const : ((core_type list * longident_loc), 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val pcty_attributes'match : (attributes, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val pcty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_desc'match : (Class_type_desc.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val pcty_desc'match : (class_type_desc, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pext_rebind'const : (Longident_loc.t, 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+val pext_rebind'const : (longident_loc, 'i, 'o) View.t -> (extension_constructor_kind, 'i, 'o) View.t
 
-val pext_decl'const : ((Core_type.t option * Constructor_arguments.t), 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+val pext_decl'const : ((core_type option * constructor_arguments), 'i, 'o) View.t -> (extension_constructor_kind, 'i, 'o) View.t
 
-val pext_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
+val pext_attributes'match : (attributes, 'i, 'o) View.t -> (extension_constructor, 'i, 'o) View.t
 
-val pext_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
+val pext_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (extension_constructor, 'i, 'o) View.t
 
-val pext_kind'match : (Extension_constructor_kind.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
+val pext_kind'match : (extension_constructor_kind, 'i, 'o) View.t -> (extension_constructor, 'i, 'o) View.t
 
-val pext_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
+val pext_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (extension_constructor, 'i, 'o) View.t
 
-val ptyext_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_attributes'match : (attributes, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val ptyext_private'match : (Private_flag.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_private'match : (private_flag, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val ptyext_constructors'match : (Extension_constructor.t list, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_constructors'match : (extension_constructor list, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val ptyext_params'match : ((Variance.t * Core_type.t) list, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_params'match : ((variance * core_type) list, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val ptyext_path'match : (Longident_loc.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_path'match : (longident_loc, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val pcstr_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+val pcstr_record'const : (label_declaration list, 'i, 'o) View.t -> (constructor_arguments, 'i, 'o) View.t
 
-val pcstr_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+val pcstr_tuple'const : (core_type list, 'i, 'o) View.t -> (constructor_arguments, 'i, 'o) View.t
 
-val pcd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_attributes'match : (attributes, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pcd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pcd_res'match : (Core_type.t option, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_res'match : (core_type option, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pcd_args'match : (Constructor_arguments.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_args'match : (constructor_arguments, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pcd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pld_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_attributes'match : (attributes, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val pld_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val pld_type'match : (Core_type.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_type'match : (core_type, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val pld_mutable'match : (Mutable_flag.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_mutable'match : (mutable_flag, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val pld_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val ptype_open'const : (Type_kind.t, 'a, 'a) View.t
+val ptype_open'const : (type_kind, 'a, 'a) View.t
 
-val ptype_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+val ptype_record'const : (label_declaration list, 'i, 'o) View.t -> (type_kind, 'i, 'o) View.t
 
-val ptype_variant'const : (Constructor_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+val ptype_variant'const : (constructor_declaration list, 'i, 'o) View.t -> (type_kind, 'i, 'o) View.t
 
-val ptype_abstract'const : (Type_kind.t, 'a, 'a) View.t
+val ptype_abstract'const : (type_kind, 'a, 'a) View.t
 
-val ptype_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_attributes'match : (attributes, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_manifest'match : (Core_type.t option, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_manifest'match : (core_type option, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_private'match : (Private_flag.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_private'match : (private_flag, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_kind'match : (Type_kind.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_kind'match : (type_kind, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_cstrs'match : ((Astlib.Location.t * Core_type.t * Core_type.t) list, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_cstrs'match : ((Astlib.Location.t * core_type * core_type) list, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_params'match : ((Variance.t * Core_type.t) list, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_params'match : ((variance * core_type) list, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val pval_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val pval_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_attributes'match : (attributes, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val pval_prim'match : (string list, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_prim'match : (string list, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val pval_type'match : (Core_type.t, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_type'match : (core_type, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val pval_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val pc_rhs'match : (Expression.t, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
+val pc_rhs'match : (expression, 'i, 'o) View.t -> (case, 'i, 'o) View.t
 
-val pc_guard'match : (Expression.t option, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
+val pc_guard'match : (expression option, 'i, 'o) View.t -> (case, 'i, 'o) View.t
 
-val pc_lhs'match : (Pattern.t, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
+val pc_lhs'match : (pattern, 'i, 'o) View.t -> (case, 'i, 'o) View.t
 
-val pexp_unreachable'const : (Expression_desc.t, 'a, 'a) View.t
+val pexp_unreachable'const : (expression_desc, 'a, 'a) View.t
 
-val eunreachable'const : (Expression.t, 'a, 'a) View.t
+val eunreachable'const : (expression, 'a, 'a) View.t
 
-val pexp_extension'const : (Extension.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_extension'const : (extension, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eextension'const : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eextension'const : (extension, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_open'const : ((Expression.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_open'const : ((expression * longident_loc * override_flag), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eopen'const : ((Expression.t * Longident_loc.t * Override_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eopen'const : ((expression * longident_loc * override_flag), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_pack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_pack'const : (module_expr, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val epack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val epack'const : (module_expr, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_newtype'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_newtype'const : ((expression * string Astlib.Loc.t), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val enewtype'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val enewtype'const : ((expression * string Astlib.Loc.t), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_object'const : (Class_structure.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_object'const : (class_structure, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eobject'const : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eobject'const : (class_structure, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_poly'const : ((Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_poly'const : ((core_type option * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val epoly'const : ((Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val epoly'const : ((core_type option * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_lazy'const : (Expression.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_lazy'const : (expression, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val elazy'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val elazy'const : (expression, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_assert'const : (expression, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eassert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eassert'const : (expression, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_letexception'const : ((Expression.t * Extension_constructor.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_letexception'const : ((expression * extension_constructor), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eletexception'const : ((Expression.t * Extension_constructor.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eletexception'const : ((expression * extension_constructor), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_letmodule'const : ((Expression.t * Module_expr.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_letmodule'const : ((expression * module_expr * string Astlib.Loc.t), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eletmodule'const : ((Expression.t * Module_expr.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eletmodule'const : ((expression * module_expr * string Astlib.Loc.t), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_override'const : ((Expression.t * string Astlib.Loc.t) list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_override'const : ((expression * string Astlib.Loc.t) list, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eoverride'const : ((Expression.t * string Astlib.Loc.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eoverride'const : ((expression * string Astlib.Loc.t) list, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_setinstvar'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_setinstvar'const : ((expression * string Astlib.Loc.t), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val esetinstvar'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val esetinstvar'const : ((expression * string Astlib.Loc.t), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_new'const : (longident_loc, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val enew'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val enew'const : (longident_loc, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_send'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_send'const : ((string Astlib.Loc.t * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val esend'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val esend'const : ((string Astlib.Loc.t * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_coerce'const : ((Core_type.t * Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_coerce'const : ((core_type * core_type option * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val ecoerce'const : ((Core_type.t * Core_type.t option * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val ecoerce'const : ((core_type * core_type option * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_constraint'const : ((Core_type.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_constraint'const : ((core_type * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val econstraint'const : ((Core_type.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val econstraint'const : ((core_type * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_for'const : ((Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_for'const : ((expression * direction_flag * expression * expression * pattern), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val efor'const : ((Expression.t * Direction_flag.t * Expression.t * Expression.t * Pattern.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val efor'const : ((expression * direction_flag * expression * expression * pattern), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_while'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_while'const : ((expression * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val ewhile'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val ewhile'const : ((expression * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_sequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_sequence'const : ((expression * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val esequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val esequence'const : ((expression * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_ifthenelse'const : ((Expression.t option * Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_ifthenelse'const : ((expression option * expression * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eifthenelse'const : ((Expression.t option * Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eifthenelse'const : ((expression option * expression * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_array'const : (Expression.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_array'const : (expression list, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val earray'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val earray'const : (expression list, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_setfield'const : ((expression * longident_loc * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val esetfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val esetfield'const : ((expression * longident_loc * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_field'const : ((Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_field'const : ((longident_loc * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val efield'const : ((Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val efield'const : ((longident_loc * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_record'const : ((Expression.t option * (Expression.t * Longident_loc.t) list), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_record'const : ((expression option * (expression * longident_loc) list), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val erecord'const : ((Expression.t option * (Expression.t * Longident_loc.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val erecord'const : ((expression option * (expression * longident_loc) list), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_variant'const : ((Expression.t option * string), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_variant'const : ((expression option * string), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val evariant'const : ((Expression.t option * string), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val evariant'const : ((expression option * string), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_construct'const : ((Expression.t option * Longident_loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_construct'const : ((expression option * longident_loc), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val econstruct'const : ((Expression.t option * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val econstruct'const : ((expression option * longident_loc), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_tuple'const : (expression list, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val etuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val etuple'const : (expression list, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_try'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_try'const : ((case list * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val etry'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val etry'const : ((case list * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_match'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_match'const : ((case list * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val ematch'const : ((Case.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val ematch'const : ((case list * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_apply'const : (((Expression.t * Arg_label.t) list * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_apply'const : (((expression * arg_label) list * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eapply'const : (((Expression.t * Arg_label.t) list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eapply'const : (((expression * arg_label) list * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_fun'const : ((Expression.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_fun'const : ((expression * pattern * expression option * arg_label), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val efun'const : ((Expression.t * Pattern.t * Expression.t option * Arg_label.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val efun'const : ((expression * pattern * expression option * arg_label), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_function'const : (Case.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_function'const : (case list, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val efunction'const : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val efunction'const : (case list, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_let'const : ((Expression.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_let'const : ((expression * value_binding list * rec_flag), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val elet'const : ((Expression.t * Value_binding.t list * Rec_flag.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val elet'const : ((expression * value_binding list * rec_flag), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_constant'const : (Constant.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_constant'const : (constant, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val econstant'const : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val econstant'const : (constant, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_ident'const : (longident_loc, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eident'const : (longident_loc, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_attributes'match : (attributes, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_desc'match : (Expression_desc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_desc'match : (expression_desc, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val ppat_open'const : ((Pattern.t * Longident_loc.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_open'const : ((pattern * longident_loc), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val popen'const : ((Pattern.t * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val popen'const : ((pattern * longident_loc), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_extension'const : (Extension.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_extension'const : (extension, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pextension'const : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pextension'const : (extension, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_exception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_exception'const : (pattern, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pexception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pexception'const : (pattern, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val punpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val punpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_lazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_lazy'const : (pattern, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val plazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val plazy'const : (pattern, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_type'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_type'const : (longident_loc, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val ptype'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ptype'const : (longident_loc, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_constraint'const : ((Core_type.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_constraint'const : ((core_type * pattern), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pconstraint'const : ((Core_type.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pconstraint'const : ((core_type * pattern), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_or'const : ((pattern * pattern), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val por'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val por'const : ((pattern * pattern), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_array'const : (pattern list, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val parray'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val parray'const : (pattern list, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_record'const : ((Closed_flag.t * (Pattern.t * Longident_loc.t) list), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_record'const : ((closed_flag * (pattern * longident_loc) list), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val precord'const : ((Closed_flag.t * (Pattern.t * Longident_loc.t) list), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val precord'const : ((closed_flag * (pattern * longident_loc) list), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_variant'const : ((Pattern.t option * string), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_variant'const : ((pattern option * string), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pvariant'const : ((Pattern.t option * string), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pvariant'const : ((pattern option * string), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_construct'const : ((Pattern.t option * Longident_loc.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_construct'const : ((pattern option * longident_loc), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pconstruct'const : ((Pattern.t option * Longident_loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pconstruct'const : ((pattern option * longident_loc), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_tuple'const : (pattern list, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val ptuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ptuple'const : (pattern list, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_interval'const : ((constant * constant), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pinterval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pinterval'const : ((constant * constant), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_constant'const : (Constant.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_constant'const : (constant, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pconstant'const : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pconstant'const : (constant, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_alias'const : ((string Astlib.Loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_alias'const : ((string Astlib.Loc.t * pattern), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val palias'const : ((string Astlib.Loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val palias'const : ((string Astlib.Loc.t * pattern), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pvar'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pvar'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_any'const : (Pattern_desc.t, 'a, 'a) View.t
+val ppat_any'const : (pattern_desc, 'a, 'a) View.t
 
-val pany'const : (Pattern.t, 'a, 'a) View.t
+val pany'const : (pattern, 'a, 'a) View.t
 
-val ppat_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ppat_attributes'match : (attributes, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ppat_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_desc'match : (Pattern_desc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ppat_desc'match : (pattern_desc, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val oinherit'const : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+val oinherit'const : (core_type, 'i, 'o) View.t -> (object_field, 'i, 'o) View.t
 
-val otag'const : ((Core_type.t * Attributes.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+val otag'const : ((core_type * attributes * string Astlib.Loc.t), 'i, 'o) View.t -> (object_field, 'i, 'o) View.t
 
-val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+val rinherit'const : (core_type, 'i, 'o) View.t -> (row_field, 'i, 'o) View.t
 
-val rtag'const : ((Core_type.t list * bool * Attributes.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
-val package_type'const: (((Core_type.t * Longident_loc.t) list * Longident_loc.t), 'i, 'o) View.t -> (Package_type.t, 'i, 'o) View.t
+val rtag'const : ((core_type list * bool * attributes * string Astlib.Loc.t), 'i, 'o) View.t -> (row_field, 'i, 'o) View.t
+val package_type'const: (((core_type * longident_loc) list * longident_loc), 'i, 'o) View.t -> (package_type, 'i, 'o) View.t
 
-val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_extension'const : (extension, 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val textension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val textension'const : (extension, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_package'const : (package_type, 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tpackage'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tpackage'const : (package_type, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_poly'const : ((Core_type.t * string Astlib.Loc.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_poly'const : ((core_type * string Astlib.Loc.t list), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tpoly'const : ((Core_type.t * string Astlib.Loc.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tpoly'const : ((core_type * string Astlib.Loc.t list), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_variant'const : ((string list option * Closed_flag.t * Row_field.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_variant'const : ((string list option * closed_flag * row_field list), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tvariant'const : ((string list option * Closed_flag.t * Row_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tvariant'const : ((string list option * closed_flag * row_field list), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_alias'const : ((string * Core_type.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_alias'const : ((string * core_type), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val talias'const : ((string * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val talias'const : ((string * core_type), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_class'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_class'const : ((core_type list * longident_loc), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tclass'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tclass'const : ((core_type list * longident_loc), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_object'const : ((Closed_flag.t * Object_field.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_object'const : ((closed_flag * object_field list), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tobject'const : ((Closed_flag.t * Object_field.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tobject'const : ((closed_flag * object_field list), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_constr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_constr'const : ((core_type list * longident_loc), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tconstr'const : ((Core_type.t list * Longident_loc.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tconstr'const : ((core_type list * longident_loc), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_tuple'const : (core_type list, 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val ttuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ttuple'const : (core_type list, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_arrow'const : ((Core_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_arrow'const : ((core_type * core_type * arg_label), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tarrow'const : ((Core_type.t * Core_type.t * Arg_label.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tarrow'const : ((core_type * core_type * arg_label), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_var'const : (string, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_var'const : (string, 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tvar'const : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tvar'const : (string, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_any'const : (Core_type_desc.t, 'a, 'a) View.t
+val ptyp_any'const : (core_type_desc, 'a, 'a) View.t
 
-val tany'const : (Core_type.t, 'a, 'a) View.t
+val tany'const : (core_type, 'a, 'a) View.t
 
-val ptyp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ptyp_attributes'match : (attributes, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ptyp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_desc'match : (Core_type_desc.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ptyp_desc'match : (core_type_desc, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val pPat'const : ((Expression.t option * Pattern.t), 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+val pPat'const : ((expression option * pattern), 'i, 'o) View.t -> (payload, 'i, 'o) View.t
 
-val pTyp'const : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+val pTyp'const : (core_type, 'i, 'o) View.t -> (payload, 'i, 'o) View.t
 
-val pSig'const : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+val pSig'const : (signature, 'i, 'o) View.t -> (payload, 'i, 'o) View.t
 
-val pStr'const : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
-val attributes'const: (Attribute.t list, 'i, 'o) View.t -> (Attributes.t, 'i, 'o) View.t
-val extension'const: ((Payload.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Extension.t, 'i, 'o) View.t
-val attribute'const: ((Payload.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Attribute.t, 'i, 'o) View.t
+val pStr'const : (structure, 'i, 'o) View.t -> (payload, 'i, 'o) View.t
+val attributes'const: (attribute list, 'i, 'o) View.t -> (attributes, 'i, 'o) View.t
+val extension'const: ((payload * string Astlib.Loc.t), 'i, 'o) View.t -> (extension, 'i, 'o) View.t
+val attribute'const: ((payload * string Astlib.Loc.t), 'i, 'o) View.t -> (attribute, 'i, 'o) View.t
 
-val pconst_float'const : ((char option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+val pconst_float'const : ((char option * string), 'i, 'o) View.t -> (constant, 'i, 'o) View.t
 
-val pconst_string'const : ((string option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+val pconst_string'const : ((string option * string), 'i, 'o) View.t -> (constant, 'i, 'o) View.t
 
-val pconst_char'const : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+val pconst_char'const : (char, 'i, 'o) View.t -> (constant, 'i, 'o) View.t
 
-val pconst_integer'const : ((char option * string), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+val pconst_integer'const : ((char option * string), 'i, 'o) View.t -> (constant, 'i, 'o) View.t
 
-val invariant'const : (Variance.t, 'a, 'a) View.t
+val invariant'const : (variance, 'a, 'a) View.t
 
-val contravariant'const : (Variance.t, 'a, 'a) View.t
+val contravariant'const : (variance, 'a, 'a) View.t
 
-val covariant'const : (Variance.t, 'a, 'a) View.t
+val covariant'const : (variance, 'a, 'a) View.t
 
-val optional'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+val optional'const : (string, 'i, 'o) View.t -> (arg_label, 'i, 'o) View.t
 
-val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+val labelled'const : (string, 'i, 'o) View.t -> (arg_label, 'i, 'o) View.t
 
-val nolabel'const : (Arg_label.t, 'a, 'a) View.t
+val nolabel'const : (arg_label, 'a, 'a) View.t
 
-val open'const : (Closed_flag.t, 'a, 'a) View.t
+val open'const : (closed_flag, 'a, 'a) View.t
 
-val closed'const : (Closed_flag.t, 'a, 'a) View.t
+val closed'const : (closed_flag, 'a, 'a) View.t
 
-val fresh'const : (Override_flag.t, 'a, 'a) View.t
+val fresh'const : (override_flag, 'a, 'a) View.t
 
-val override'const : (Override_flag.t, 'a, 'a) View.t
+val override'const : (override_flag, 'a, 'a) View.t
 
-val concrete'const : (Virtual_flag.t, 'a, 'a) View.t
+val concrete'const : (virtual_flag, 'a, 'a) View.t
 
-val virtual'const : (Virtual_flag.t, 'a, 'a) View.t
+val virtual'const : (virtual_flag, 'a, 'a) View.t
 
-val mutable'const : (Mutable_flag.t, 'a, 'a) View.t
+val mutable'const : (mutable_flag, 'a, 'a) View.t
 
-val immutable'const : (Mutable_flag.t, 'a, 'a) View.t
+val immutable'const : (mutable_flag, 'a, 'a) View.t
 
-val public'const : (Private_flag.t, 'a, 'a) View.t
+val public'const : (private_flag, 'a, 'a) View.t
 
-val private'const : (Private_flag.t, 'a, 'a) View.t
+val private'const : (private_flag, 'a, 'a) View.t
 
-val downto'const : (Direction_flag.t, 'a, 'a) View.t
+val downto'const : (direction_flag, 'a, 'a) View.t
 
-val upto'const : (Direction_flag.t, 'a, 'a) View.t
+val upto'const : (direction_flag, 'a, 'a) View.t
 
-val recursive'const : (Rec_flag.t, 'a, 'a) View.t
+val recursive'const : (rec_flag, 'a, 'a) View.t
 
-val nonrecursive'const : (Rec_flag.t, 'a, 'a) View.t
-val longident_loc'const: (Longident.t Astlib.Loc.t, 'i, 'o) View.t -> (Longident_loc.t, 'i, 'o) View.t
+val nonrecursive'const : (rec_flag, 'a, 'a) View.t
+val longident_loc'const: (longident Astlib.Loc.t, 'i, 'o) View.t -> (longident_loc, 'i, 'o) View.t
 
-val lapply'const : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+val lapply'const : ((longident * longident), 'i, 'o) View.t -> (longident, 'i, 'o) View.t
 
-val ldot'const : ((string * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+val ldot'const : ((string * longident), 'i, 'o) View.t -> (longident, 'i, 'o) View.t
 
-val lident'const : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+val lident'const : (string, 'i, 'o) View.t -> (longident, 'i, 'o) View.t
 (*$*)

--- a/ast/viewer_v4_07.mli
+++ b/ast/viewer_v4_07.mli
@@ -2,864 +2,863 @@ open Viewlib
 
 (*$ Ppx_ast_cinaps.print_viewer_mli (Astlib.Version.of_string "v4_07") *)
 open Versions
-open V4_07
 include module type of Viewer_common
 
-val lident'const : (string, 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+val lident'const : (string, 'i, 'o) View.t -> (longident, 'i, 'o) View.t
 
-val ldot'const : ((Longident.t * string), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
+val ldot'const : ((longident * string), 'i, 'o) View.t -> (longident, 'i, 'o) View.t
 
-val lapply'const : ((Longident.t * Longident.t), 'i, 'o) View.t -> (Longident.t, 'i, 'o) View.t
-val longident_loc'const: (Longident.t Astlib.Loc.t, 'i, 'o) View.t -> (Longident_loc.t, 'i, 'o) View.t
+val lapply'const : ((longident * longident), 'i, 'o) View.t -> (longident, 'i, 'o) View.t
+val longident_loc'const: (longident Astlib.Loc.t, 'i, 'o) View.t -> (longident_loc, 'i, 'o) View.t
 
-val nonrecursive'const : (Rec_flag.t, 'a, 'a) View.t
+val nonrecursive'const : (rec_flag, 'a, 'a) View.t
 
-val recursive'const : (Rec_flag.t, 'a, 'a) View.t
+val recursive'const : (rec_flag, 'a, 'a) View.t
 
-val upto'const : (Direction_flag.t, 'a, 'a) View.t
+val upto'const : (direction_flag, 'a, 'a) View.t
 
-val downto'const : (Direction_flag.t, 'a, 'a) View.t
+val downto'const : (direction_flag, 'a, 'a) View.t
 
-val private'const : (Private_flag.t, 'a, 'a) View.t
+val private'const : (private_flag, 'a, 'a) View.t
 
-val public'const : (Private_flag.t, 'a, 'a) View.t
+val public'const : (private_flag, 'a, 'a) View.t
 
-val immutable'const : (Mutable_flag.t, 'a, 'a) View.t
+val immutable'const : (mutable_flag, 'a, 'a) View.t
 
-val mutable'const : (Mutable_flag.t, 'a, 'a) View.t
+val mutable'const : (mutable_flag, 'a, 'a) View.t
 
-val virtual'const : (Virtual_flag.t, 'a, 'a) View.t
+val virtual'const : (virtual_flag, 'a, 'a) View.t
 
-val concrete'const : (Virtual_flag.t, 'a, 'a) View.t
+val concrete'const : (virtual_flag, 'a, 'a) View.t
 
-val override'const : (Override_flag.t, 'a, 'a) View.t
+val override'const : (override_flag, 'a, 'a) View.t
 
-val fresh'const : (Override_flag.t, 'a, 'a) View.t
+val fresh'const : (override_flag, 'a, 'a) View.t
 
-val closed'const : (Closed_flag.t, 'a, 'a) View.t
+val closed'const : (closed_flag, 'a, 'a) View.t
 
-val open'const : (Closed_flag.t, 'a, 'a) View.t
+val open'const : (closed_flag, 'a, 'a) View.t
 
-val nolabel'const : (Arg_label.t, 'a, 'a) View.t
+val nolabel'const : (arg_label, 'a, 'a) View.t
 
-val labelled'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+val labelled'const : (string, 'i, 'o) View.t -> (arg_label, 'i, 'o) View.t
 
-val optional'const : (string, 'i, 'o) View.t -> (Arg_label.t, 'i, 'o) View.t
+val optional'const : (string, 'i, 'o) View.t -> (arg_label, 'i, 'o) View.t
 
-val covariant'const : (Variance.t, 'a, 'a) View.t
+val covariant'const : (variance, 'a, 'a) View.t
 
-val contravariant'const : (Variance.t, 'a, 'a) View.t
+val contravariant'const : (variance, 'a, 'a) View.t
 
-val invariant'const : (Variance.t, 'a, 'a) View.t
+val invariant'const : (variance, 'a, 'a) View.t
 
-val pconst_integer'const : ((string * char option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+val pconst_integer'const : ((string * char option), 'i, 'o) View.t -> (constant, 'i, 'o) View.t
 
-val pconst_char'const : (char, 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+val pconst_char'const : (char, 'i, 'o) View.t -> (constant, 'i, 'o) View.t
 
-val pconst_string'const : ((string * string option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
+val pconst_string'const : ((string * string option), 'i, 'o) View.t -> (constant, 'i, 'o) View.t
 
-val pconst_float'const : ((string * char option), 'i, 'o) View.t -> (Constant.t, 'i, 'o) View.t
-val attribute'const: ((string Astlib.Loc.t * Payload.t), 'i, 'o) View.t -> (Attribute.t, 'i, 'o) View.t
-val extension'const: ((string Astlib.Loc.t * Payload.t), 'i, 'o) View.t -> (Extension.t, 'i, 'o) View.t
-val attributes'const: (Attribute.t list, 'i, 'o) View.t -> (Attributes.t, 'i, 'o) View.t
+val pconst_float'const : ((string * char option), 'i, 'o) View.t -> (constant, 'i, 'o) View.t
+val attribute'const: ((string Astlib.Loc.t * payload), 'i, 'o) View.t -> (attribute, 'i, 'o) View.t
+val extension'const: ((string Astlib.Loc.t * payload), 'i, 'o) View.t -> (extension, 'i, 'o) View.t
+val attributes'const: (attribute list, 'i, 'o) View.t -> (attributes, 'i, 'o) View.t
 
-val pStr'const : (Structure.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+val pStr'const : (structure, 'i, 'o) View.t -> (payload, 'i, 'o) View.t
 
-val pSig'const : (Signature.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+val pSig'const : (signature, 'i, 'o) View.t -> (payload, 'i, 'o) View.t
 
-val pTyp'const : (Core_type.t, 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+val pTyp'const : (core_type, 'i, 'o) View.t -> (payload, 'i, 'o) View.t
 
-val pPat'const : ((Pattern.t * Expression.t option), 'i, 'o) View.t -> (Payload.t, 'i, 'o) View.t
+val pPat'const : ((pattern * expression option), 'i, 'o) View.t -> (payload, 'i, 'o) View.t
 
-val ptyp_desc'match : (Core_type_desc.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ptyp_desc'match : (core_type_desc, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ptyp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ptyp_attributes'match : (attributes, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_any'const : (Core_type_desc.t, 'a, 'a) View.t
+val ptyp_any'const : (core_type_desc, 'a, 'a) View.t
 
-val tany'const : (Core_type.t, 'a, 'a) View.t
+val tany'const : (core_type, 'a, 'a) View.t
 
-val ptyp_var'const : (string, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_var'const : (string, 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tvar'const : (string, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tvar'const : (string, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_arrow'const : ((Arg_label.t * Core_type.t * Core_type.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_arrow'const : ((arg_label * core_type * core_type), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tarrow'const : ((Arg_label.t * Core_type.t * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tarrow'const : ((arg_label * core_type * core_type), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_tuple'const : (core_type list, 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val ttuple'const : (Core_type.t list, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val ttuple'const : (core_type list, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_constr'const : ((longident_loc * core_type list), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tconstr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tconstr'const : ((longident_loc * core_type list), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_object'const : ((Object_field.t list * Closed_flag.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_object'const : ((object_field list * closed_flag), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tobject'const : ((Object_field.t list * Closed_flag.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tobject'const : ((object_field list * closed_flag), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_class'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_class'const : ((longident_loc * core_type list), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tclass'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tclass'const : ((longident_loc * core_type list), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_alias'const : ((Core_type.t * string), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_alias'const : ((core_type * string), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val talias'const : ((Core_type.t * string), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val talias'const : ((core_type * string), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_variant'const : ((Row_field.t list * Closed_flag.t * string list option), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_variant'const : ((row_field list * closed_flag * string list option), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tvariant'const : ((Row_field.t list * Closed_flag.t * string list option), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tvariant'const : ((row_field list * closed_flag * string list option), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_poly'const : ((string Astlib.Loc.t list * Core_type.t), 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_poly'const : ((string Astlib.Loc.t list * core_type), 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tpoly'const : ((string Astlib.Loc.t list * Core_type.t), 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tpoly'const : ((string Astlib.Loc.t list * core_type), 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_package'const : (Package_type.t, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_package'const : (package_type, 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val tpackage'const : (Package_type.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
+val tpackage'const : (package_type, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
 
-val ptyp_extension'const : (Extension.t, 'i, 'o) View.t -> (Core_type_desc.t, 'i, 'o) View.t
+val ptyp_extension'const : (extension, 'i, 'o) View.t -> (core_type_desc, 'i, 'o) View.t
 
-val textension'const : (Extension.t, 'i, 'o) View.t -> (Core_type.t, 'i, 'o) View.t
-val package_type'const: ((Longident_loc.t * (Longident_loc.t * Core_type.t) list), 'i, 'o) View.t -> (Package_type.t, 'i, 'o) View.t
+val textension'const : (extension, 'i, 'o) View.t -> (core_type, 'i, 'o) View.t
+val package_type'const: ((longident_loc * (longident_loc * core_type) list), 'i, 'o) View.t -> (package_type, 'i, 'o) View.t
 
-val rtag'const : ((string Astlib.Loc.t * Attributes.t * bool * Core_type.t list), 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+val rtag'const : ((string Astlib.Loc.t * attributes * bool * core_type list), 'i, 'o) View.t -> (row_field, 'i, 'o) View.t
 
-val rinherit'const : (Core_type.t, 'i, 'o) View.t -> (Row_field.t, 'i, 'o) View.t
+val rinherit'const : (core_type, 'i, 'o) View.t -> (row_field, 'i, 'o) View.t
 
-val otag'const : ((string Astlib.Loc.t * Attributes.t * Core_type.t), 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+val otag'const : ((string Astlib.Loc.t * attributes * core_type), 'i, 'o) View.t -> (object_field, 'i, 'o) View.t
 
-val oinherit'const : (Core_type.t, 'i, 'o) View.t -> (Object_field.t, 'i, 'o) View.t
+val oinherit'const : (core_type, 'i, 'o) View.t -> (object_field, 'i, 'o) View.t
 
-val ppat_desc'match : (Pattern_desc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ppat_desc'match : (pattern_desc, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ppat_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ppat_attributes'match : (attributes, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_any'const : (Pattern_desc.t, 'a, 'a) View.t
+val ppat_any'const : (pattern_desc, 'a, 'a) View.t
 
-val pany'const : (Pattern.t, 'a, 'a) View.t
+val pany'const : (pattern, 'a, 'a) View.t
 
-val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_var'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pvar'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pvar'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_alias'const : ((Pattern.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_alias'const : ((pattern * string Astlib.Loc.t), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val palias'const : ((Pattern.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val palias'const : ((pattern * string Astlib.Loc.t), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_constant'const : (Constant.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_constant'const : (constant, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pconstant'const : (Constant.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pconstant'const : (constant, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_interval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_interval'const : ((constant * constant), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pinterval'const : ((Constant.t * Constant.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pinterval'const : ((constant * constant), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_tuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_tuple'const : (pattern list, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val ptuple'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ptuple'const : (pattern list, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_construct'const : ((Longident_loc.t * Pattern.t option), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_construct'const : ((longident_loc * pattern option), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pconstruct'const : ((Longident_loc.t * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pconstruct'const : ((longident_loc * pattern option), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_variant'const : ((string * Pattern.t option), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_variant'const : ((string * pattern option), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pvariant'const : ((string * Pattern.t option), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pvariant'const : ((string * pattern option), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_record'const : (((Longident_loc.t * Pattern.t) list * Closed_flag.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_record'const : (((longident_loc * pattern) list * closed_flag), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val precord'const : (((Longident_loc.t * Pattern.t) list * Closed_flag.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val precord'const : (((longident_loc * pattern) list * closed_flag), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_array'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_array'const : (pattern list, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val parray'const : (Pattern.t list, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val parray'const : (pattern list, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_or'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_or'const : ((pattern * pattern), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val por'const : ((Pattern.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val por'const : ((pattern * pattern), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_constraint'const : ((Pattern.t * Core_type.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_constraint'const : ((pattern * core_type), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pconstraint'const : ((Pattern.t * Core_type.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pconstraint'const : ((pattern * core_type), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_type'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_type'const : (longident_loc, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val ptype'const : (Longident_loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val ptype'const : (longident_loc, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_lazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_lazy'const : (pattern, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val plazy'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val plazy'const : (pattern, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_unpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val punpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val punpack'const : (string Astlib.Loc.t, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_exception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_exception'const : (pattern, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pexception'const : (Pattern.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pexception'const : (pattern, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_extension'const : (Extension.t, 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_extension'const : (extension, 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val pextension'const : (Extension.t, 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val pextension'const : (extension, 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val ppat_open'const : ((Longident_loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern_desc.t, 'i, 'o) View.t
+val ppat_open'const : ((longident_loc * pattern), 'i, 'o) View.t -> (pattern_desc, 'i, 'o) View.t
 
-val popen'const : ((Longident_loc.t * Pattern.t), 'i, 'o) View.t -> (Pattern.t, 'i, 'o) View.t
+val popen'const : ((longident_loc * pattern), 'i, 'o) View.t -> (pattern, 'i, 'o) View.t
 
-val pexp_desc'match : (Expression_desc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_desc'match : (expression_desc, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val pexp_attributes'match : (attributes, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_ident'const : (longident_loc, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eident'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eident'const : (longident_loc, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_constant'const : (Constant.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_constant'const : (constant, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val econstant'const : (Constant.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val econstant'const : (constant, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_let'const : ((Rec_flag.t * Value_binding.t list * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_let'const : ((rec_flag * value_binding list * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val elet'const : ((Rec_flag.t * Value_binding.t list * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val elet'const : ((rec_flag * value_binding list * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_function'const : (Case.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_function'const : (case list, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val efunction'const : (Case.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val efunction'const : (case list, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_fun'const : ((Arg_label.t * Expression.t option * Pattern.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_fun'const : ((arg_label * expression option * pattern * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val efun'const : ((Arg_label.t * Expression.t option * Pattern.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val efun'const : ((arg_label * expression option * pattern * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_apply'const : ((Expression.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_apply'const : ((expression * (arg_label * expression) list), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eapply'const : ((Expression.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eapply'const : ((expression * (arg_label * expression) list), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_match'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_match'const : ((expression * case list), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val ematch'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val ematch'const : ((expression * case list), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_try'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_try'const : ((expression * case list), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val etry'const : ((Expression.t * Case.t list), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val etry'const : ((expression * case list), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_tuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_tuple'const : (expression list, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val etuple'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val etuple'const : (expression list, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_construct'const : ((Longident_loc.t * Expression.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_construct'const : ((longident_loc * expression option), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val econstruct'const : ((Longident_loc.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val econstruct'const : ((longident_loc * expression option), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_variant'const : ((string * Expression.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_variant'const : ((string * expression option), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val evariant'const : ((string * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val evariant'const : ((string * expression option), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_record'const : (((Longident_loc.t * Expression.t) list * Expression.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_record'const : (((longident_loc * expression) list * expression option), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val erecord'const : (((Longident_loc.t * Expression.t) list * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val erecord'const : (((longident_loc * expression) list * expression option), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_field'const : ((Expression.t * Longident_loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_field'const : ((expression * longident_loc), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val efield'const : ((Expression.t * Longident_loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val efield'const : ((expression * longident_loc), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_setfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_setfield'const : ((expression * longident_loc * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val esetfield'const : ((Expression.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val esetfield'const : ((expression * longident_loc * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_array'const : (Expression.t list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_array'const : (expression list, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val earray'const : (Expression.t list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val earray'const : (expression list, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_ifthenelse'const : ((Expression.t * Expression.t * Expression.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_ifthenelse'const : ((expression * expression * expression option), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eifthenelse'const : ((Expression.t * Expression.t * Expression.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eifthenelse'const : ((expression * expression * expression option), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_sequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_sequence'const : ((expression * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val esequence'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val esequence'const : ((expression * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_while'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_while'const : ((expression * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val ewhile'const : ((Expression.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val ewhile'const : ((expression * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_for'const : ((Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_for'const : ((pattern * expression * expression * direction_flag * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val efor'const : ((Pattern.t * Expression.t * Expression.t * Direction_flag.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val efor'const : ((pattern * expression * expression * direction_flag * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_constraint'const : ((Expression.t * Core_type.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_constraint'const : ((expression * core_type), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val econstraint'const : ((Expression.t * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val econstraint'const : ((expression * core_type), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_coerce'const : ((Expression.t * Core_type.t option * Core_type.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_coerce'const : ((expression * core_type option * core_type), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val ecoerce'const : ((Expression.t * Core_type.t option * Core_type.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val ecoerce'const : ((expression * core_type option * core_type), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_send'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_send'const : ((expression * string Astlib.Loc.t), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val esend'const : ((Expression.t * string Astlib.Loc.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val esend'const : ((expression * string Astlib.Loc.t), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_new'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_new'const : (longident_loc, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val enew'const : (Longident_loc.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val enew'const : (longident_loc, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_setinstvar'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_setinstvar'const : ((string Astlib.Loc.t * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val esetinstvar'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val esetinstvar'const : ((string Astlib.Loc.t * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_override'const : ((string Astlib.Loc.t * Expression.t) list, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_override'const : ((string Astlib.Loc.t * expression) list, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eoverride'const : ((string Astlib.Loc.t * Expression.t) list, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eoverride'const : ((string Astlib.Loc.t * expression) list, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_letmodule'const : ((string Astlib.Loc.t * Module_expr.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_letmodule'const : ((string Astlib.Loc.t * module_expr * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eletmodule'const : ((string Astlib.Loc.t * Module_expr.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eletmodule'const : ((string Astlib.Loc.t * module_expr * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_letexception'const : ((Extension_constructor.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_letexception'const : ((extension_constructor * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eletexception'const : ((Extension_constructor.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eletexception'const : ((extension_constructor * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_assert'const : (Expression.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_assert'const : (expression, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eassert'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eassert'const : (expression, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_lazy'const : (Expression.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_lazy'const : (expression, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val elazy'const : (Expression.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val elazy'const : (expression, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_poly'const : ((Expression.t * Core_type.t option), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_poly'const : ((expression * core_type option), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val epoly'const : ((Expression.t * Core_type.t option), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val epoly'const : ((expression * core_type option), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_object'const : (Class_structure.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_object'const : (class_structure, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eobject'const : (Class_structure.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eobject'const : (class_structure, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_newtype'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_newtype'const : ((string Astlib.Loc.t * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val enewtype'const : ((string Astlib.Loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val enewtype'const : ((string Astlib.Loc.t * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_pack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_pack'const : (module_expr, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val epack'const : (Module_expr.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val epack'const : (module_expr, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_open'const : ((Override_flag.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_open'const : ((override_flag * longident_loc * expression), 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eopen'const : ((Override_flag.t * Longident_loc.t * Expression.t), 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eopen'const : ((override_flag * longident_loc * expression), 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_extension'const : (Extension.t, 'i, 'o) View.t -> (Expression_desc.t, 'i, 'o) View.t
+val pexp_extension'const : (extension, 'i, 'o) View.t -> (expression_desc, 'i, 'o) View.t
 
-val eextension'const : (Extension.t, 'i, 'o) View.t -> (Expression.t, 'i, 'o) View.t
+val eextension'const : (extension, 'i, 'o) View.t -> (expression, 'i, 'o) View.t
 
-val pexp_unreachable'const : (Expression_desc.t, 'a, 'a) View.t
+val pexp_unreachable'const : (expression_desc, 'a, 'a) View.t
 
-val eunreachable'const : (Expression.t, 'a, 'a) View.t
+val eunreachable'const : (expression, 'a, 'a) View.t
 
-val pc_lhs'match : (Pattern.t, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
+val pc_lhs'match : (pattern, 'i, 'o) View.t -> (case, 'i, 'o) View.t
 
-val pc_guard'match : (Expression.t option, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
+val pc_guard'match : (expression option, 'i, 'o) View.t -> (case, 'i, 'o) View.t
 
-val pc_rhs'match : (Expression.t, 'i, 'o) View.t -> (Case.t, 'i, 'o) View.t
+val pc_rhs'match : (expression, 'i, 'o) View.t -> (case, 'i, 'o) View.t
 
-val pval_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val pval_type'match : (Core_type.t, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_type'match : (core_type, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val pval_prim'match : (string list, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_prim'match : (string list, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val pval_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_attributes'match : (attributes, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val pval_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Value_description.t, 'i, 'o) View.t
+val pval_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (value_description, 'i, 'o) View.t
 
-val ptype_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_params'match : ((Core_type.t * Variance.t) list, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_params'match : ((core_type * variance) list, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_cstrs'match : ((Core_type.t * Core_type.t * Astlib.Location.t) list, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_cstrs'match : ((core_type * core_type * Astlib.Location.t) list, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_kind'match : (Type_kind.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_kind'match : (type_kind, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_private'match : (Private_flag.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_private'match : (private_flag, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_manifest'match : (Core_type.t option, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_manifest'match : (core_type option, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_attributes'match : (attributes, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Type_declaration.t, 'i, 'o) View.t
+val ptype_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (type_declaration, 'i, 'o) View.t
 
-val ptype_abstract'const : (Type_kind.t, 'a, 'a) View.t
+val ptype_abstract'const : (type_kind, 'a, 'a) View.t
 
-val ptype_variant'const : (Constructor_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+val ptype_variant'const : (constructor_declaration list, 'i, 'o) View.t -> (type_kind, 'i, 'o) View.t
 
-val ptype_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Type_kind.t, 'i, 'o) View.t
+val ptype_record'const : (label_declaration list, 'i, 'o) View.t -> (type_kind, 'i, 'o) View.t
 
-val ptype_open'const : (Type_kind.t, 'a, 'a) View.t
+val ptype_open'const : (type_kind, 'a, 'a) View.t
 
-val pld_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val pld_mutable'match : (Mutable_flag.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_mutable'match : (mutable_flag, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val pld_type'match : (Core_type.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_type'match : (core_type, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val pld_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val pld_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Label_declaration.t, 'i, 'o) View.t
+val pld_attributes'match : (attributes, 'i, 'o) View.t -> (label_declaration, 'i, 'o) View.t
 
-val pcd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pcd_args'match : (Constructor_arguments.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_args'match : (constructor_arguments, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pcd_res'match : (Core_type.t option, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_res'match : (core_type option, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pcd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pcd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Constructor_declaration.t, 'i, 'o) View.t
+val pcd_attributes'match : (attributes, 'i, 'o) View.t -> (constructor_declaration, 'i, 'o) View.t
 
-val pcstr_tuple'const : (Core_type.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+val pcstr_tuple'const : (core_type list, 'i, 'o) View.t -> (constructor_arguments, 'i, 'o) View.t
 
-val pcstr_record'const : (Label_declaration.t list, 'i, 'o) View.t -> (Constructor_arguments.t, 'i, 'o) View.t
+val pcstr_record'const : (label_declaration list, 'i, 'o) View.t -> (constructor_arguments, 'i, 'o) View.t
 
-val ptyext_path'match : (Longident_loc.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_path'match : (longident_loc, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val ptyext_params'match : ((Core_type.t * Variance.t) list, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_params'match : ((core_type * variance) list, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val ptyext_constructors'match : (Extension_constructor.t list, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_constructors'match : (extension_constructor list, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val ptyext_private'match : (Private_flag.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_private'match : (private_flag, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val ptyext_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Type_extension.t, 'i, 'o) View.t
+val ptyext_attributes'match : (attributes, 'i, 'o) View.t -> (type_extension, 'i, 'o) View.t
 
-val pext_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
+val pext_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (extension_constructor, 'i, 'o) View.t
 
-val pext_kind'match : (Extension_constructor_kind.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
+val pext_kind'match : (extension_constructor_kind, 'i, 'o) View.t -> (extension_constructor, 'i, 'o) View.t
 
-val pext_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
+val pext_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (extension_constructor, 'i, 'o) View.t
 
-val pext_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Extension_constructor.t, 'i, 'o) View.t
+val pext_attributes'match : (attributes, 'i, 'o) View.t -> (extension_constructor, 'i, 'o) View.t
 
-val pext_decl'const : ((Constructor_arguments.t * Core_type.t option), 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+val pext_decl'const : ((constructor_arguments * core_type option), 'i, 'o) View.t -> (extension_constructor_kind, 'i, 'o) View.t
 
-val pext_rebind'const : (Longident_loc.t, 'i, 'o) View.t -> (Extension_constructor_kind.t, 'i, 'o) View.t
+val pext_rebind'const : (longident_loc, 'i, 'o) View.t -> (extension_constructor_kind, 'i, 'o) View.t
 
-val pcty_desc'match : (Class_type_desc.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val pcty_desc'match : (class_type_desc, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val pcty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val pcty_attributes'match : (attributes, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_constr'const : ((longident_loc * core_type list), 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctconstr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctconstr'const : ((longident_loc * core_type list), 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_signature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_signature'const : (class_signature, 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctsignature'const : (Class_signature.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctsignature'const : (class_signature, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_arrow'const : ((Arg_label.t * Core_type.t * Class_type.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_arrow'const : ((arg_label * core_type * class_type), 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctarrow'const : ((Arg_label.t * Core_type.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctarrow'const : ((arg_label * core_type * class_type), 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_extension'const : (extension, 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctextension'const : (Extension.t, 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctextension'const : (extension, 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcty_open'const : ((Override_flag.t * Longident_loc.t * Class_type.t), 'i, 'o) View.t -> (Class_type_desc.t, 'i, 'o) View.t
+val pcty_open'const : ((override_flag * longident_loc * class_type), 'i, 'o) View.t -> (class_type_desc, 'i, 'o) View.t
 
-val ctopen'const : ((Override_flag.t * Longident_loc.t * Class_type.t), 'i, 'o) View.t -> (Class_type.t, 'i, 'o) View.t
+val ctopen'const : ((override_flag * longident_loc * class_type), 'i, 'o) View.t -> (class_type, 'i, 'o) View.t
 
-val pcsig_self'match : (Core_type.t, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
+val pcsig_self'match : (core_type, 'i, 'o) View.t -> (class_signature, 'i, 'o) View.t
 
-val pcsig_fields'match : (Class_type_field.t list, 'i, 'o) View.t -> (Class_signature.t, 'i, 'o) View.t
+val pcsig_fields'match : (class_type_field list, 'i, 'o) View.t -> (class_signature, 'i, 'o) View.t
 
-val pctf_desc'match : (Class_type_field_desc.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_desc'match : (class_type_field_desc, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val pctf_attributes'match : (attributes, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_inherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_inherit'const : (class_type, 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfinherit'const : (Class_type.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfinherit'const : (class_type, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_val'const : ((string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_val'const : ((string Astlib.Loc.t * mutable_flag * virtual_flag * core_type), 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfval'const : ((string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfval'const : ((string Astlib.Loc.t * mutable_flag * virtual_flag * core_type), 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_method'const : ((string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_method'const : ((string Astlib.Loc.t * private_flag * virtual_flag * core_type), 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfmethod'const : ((string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfmethod'const : ((string Astlib.Loc.t * private_flag * virtual_flag * core_type), 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_constraint'const : ((core_type * core_type), 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfconstraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfconstraint'const : ((core_type * core_type), 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_attribute'const : (attribute, 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfattribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfattribute'const : (attribute, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pctf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field_desc.t, 'i, 'o) View.t
+val pctf_extension'const : (extension, 'i, 'o) View.t -> (class_type_field_desc, 'i, 'o) View.t
 
-val ctfextension'const : (Extension.t, 'i, 'o) View.t -> (Class_type_field.t, 'i, 'o) View.t
+val ctfextension'const : (extension, 'i, 'o) View.t -> (class_type_field, 'i, 'o) View.t
 
-val pci_virt'match : (Virtual_flag.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_virt'match : (virtual_flag, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_params'match : ((Core_type.t * Variance.t) list, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_params'match : ((core_type * variance) list, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_expr'match : ('a node, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_expr'match : ('a node, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
+val pci_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
 
-val pci_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Class_infos.t, 'i, 'o) View.t
-val class_description'const: (Class_type.t Class_infos.t, 'i, 'o) View.t -> (Class_description.t, 'i, 'o) View.t
-val class_type_declaration'const: (Class_type.t Class_infos.t, 'i, 'o) View.t -> (Class_type_declaration.t, 'i, 'o) View.t
+val pci_attributes'match : (attributes, 'i, 'o) View.t -> ('a node class_infos, 'i, 'o) View.t
+val class_description'const: (class_type class_infos, 'i, 'o) View.t -> (class_description, 'i, 'o) View.t
+val class_type_declaration'const: (class_type class_infos, 'i, 'o) View.t -> (class_type_declaration, 'i, 'o) View.t
 
-val pcl_desc'match : (Class_expr_desc.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val pcl_desc'match : (class_expr_desc, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val pcl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val pcl_attributes'match : (attributes, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_constr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_constr'const : ((longident_loc * core_type list), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceconstr'const : ((Longident_loc.t * Core_type.t list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceconstr'const : ((longident_loc * core_type list), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_structure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_structure'const : (class_structure, 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val cestructure'const : (Class_structure.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val cestructure'const : (class_structure, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_fun'const : ((Arg_label.t * Expression.t option * Pattern.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_fun'const : ((arg_label * expression option * pattern * class_expr), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val cefun'const : ((Arg_label.t * Expression.t option * Pattern.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val cefun'const : ((arg_label * expression option * pattern * class_expr), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_apply'const : ((Class_expr.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_apply'const : ((class_expr * (arg_label * expression) list), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceapply'const : ((Class_expr.t * (Arg_label.t * Expression.t) list), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceapply'const : ((class_expr * (arg_label * expression) list), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_let'const : ((Rec_flag.t * Value_binding.t list * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_let'const : ((rec_flag * value_binding list * class_expr), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val celet'const : ((Rec_flag.t * Value_binding.t list * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val celet'const : ((rec_flag * value_binding list * class_expr), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_constraint'const : ((Class_expr.t * Class_type.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_constraint'const : ((class_expr * class_type), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceconstraint'const : ((Class_expr.t * Class_type.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceconstraint'const : ((class_expr * class_type), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_extension'const : (extension, 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceextension'const : (Extension.t, 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceextension'const : (extension, 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcl_open'const : ((Override_flag.t * Longident_loc.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr_desc.t, 'i, 'o) View.t
+val pcl_open'const : ((override_flag * longident_loc * class_expr), 'i, 'o) View.t -> (class_expr_desc, 'i, 'o) View.t
 
-val ceopen'const : ((Override_flag.t * Longident_loc.t * Class_expr.t), 'i, 'o) View.t -> (Class_expr.t, 'i, 'o) View.t
+val ceopen'const : ((override_flag * longident_loc * class_expr), 'i, 'o) View.t -> (class_expr, 'i, 'o) View.t
 
-val pcstr_self'match : (Pattern.t, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
+val pcstr_self'match : (pattern, 'i, 'o) View.t -> (class_structure, 'i, 'o) View.t
 
-val pcstr_fields'match : (Class_field.t list, 'i, 'o) View.t -> (Class_structure.t, 'i, 'o) View.t
+val pcstr_fields'match : (class_field list, 'i, 'o) View.t -> (class_structure, 'i, 'o) View.t
 
-val pcf_desc'match : (Class_field_desc.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_desc'match : (class_field_desc, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val pcf_attributes'match : (attributes, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_inherit'const : ((Override_flag.t * Class_expr.t * string Astlib.Loc.t option), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_inherit'const : ((override_flag * class_expr * string Astlib.Loc.t option), 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfinherit'const : ((Override_flag.t * Class_expr.t * string Astlib.Loc.t option), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfinherit'const : ((override_flag * class_expr * string Astlib.Loc.t option), 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_val'const : ((string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_val'const : ((string Astlib.Loc.t * mutable_flag * class_field_kind), 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfval'const : ((string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfval'const : ((string Astlib.Loc.t * mutable_flag * class_field_kind), 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_method'const : ((string Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_method'const : ((string Astlib.Loc.t * private_flag * class_field_kind), 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfmethod'const : ((string Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfmethod'const : ((string Astlib.Loc.t * private_flag * class_field_kind), 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_constraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_constraint'const : ((core_type * core_type), 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfconstraint'const : ((Core_type.t * Core_type.t), 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfconstraint'const : ((core_type * core_type), 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_initializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_initializer'const : (expression, 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfinitializer'const : (Expression.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfinitializer'const : (expression, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_attribute'const : (attribute, 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfattribute'const : (Attribute.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfattribute'const : (attribute, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val pcf_extension'const : (Extension.t, 'i, 'o) View.t -> (Class_field_desc.t, 'i, 'o) View.t
+val pcf_extension'const : (extension, 'i, 'o) View.t -> (class_field_desc, 'i, 'o) View.t
 
-val cfextension'const : (Extension.t, 'i, 'o) View.t -> (Class_field.t, 'i, 'o) View.t
+val cfextension'const : (extension, 'i, 'o) View.t -> (class_field, 'i, 'o) View.t
 
-val cfk_virtual'const : (Core_type.t, 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
+val cfk_virtual'const : (core_type, 'i, 'o) View.t -> (class_field_kind, 'i, 'o) View.t
 
-val cfk_concrete'const : ((Override_flag.t * Expression.t), 'i, 'o) View.t -> (Class_field_kind.t, 'i, 'o) View.t
-val class_declaration'const: (Class_expr.t Class_infos.t, 'i, 'o) View.t -> (Class_declaration.t, 'i, 'o) View.t
+val cfk_concrete'const : ((override_flag * expression), 'i, 'o) View.t -> (class_field_kind, 'i, 'o) View.t
+val class_declaration'const: (class_expr class_infos, 'i, 'o) View.t -> (class_declaration, 'i, 'o) View.t
 
-val pmty_desc'match : (Module_type_desc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val pmty_desc'match : (module_type_desc, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val pmty_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val pmty_attributes'match : (attributes, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_ident'const : (longident_loc, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtident'const : (longident_loc, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_signature'const : (Signature.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_signature'const : (signature, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtsignature'const : (Signature.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtsignature'const : (signature, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_functor'const : ((string Astlib.Loc.t * Module_type.t option * Module_type.t), 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_functor'const : ((string Astlib.Loc.t * module_type option * module_type), 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtfunctor'const : ((string Astlib.Loc.t * Module_type.t option * Module_type.t), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtfunctor'const : ((string Astlib.Loc.t * module_type option * module_type), 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_with'const : ((Module_type.t * With_constraint.t list), 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_with'const : ((module_type * with_constraint list), 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtwith'const : ((Module_type.t * With_constraint.t list), 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtwith'const : ((module_type * with_constraint list), 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_typeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_typeof'const : (module_expr, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mttypeof'const : (Module_expr.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mttypeof'const : (module_expr, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_extension'const : (extension, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtextension'const : (Extension.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
+val mtextension'const : (extension, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
 
-val pmty_alias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type_desc.t, 'i, 'o) View.t
+val pmty_alias'const : (longident_loc, 'i, 'o) View.t -> (module_type_desc, 'i, 'o) View.t
 
-val mtalias'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_type.t, 'i, 'o) View.t
-val signature'const: (Signature_item.t list, 'i, 'o) View.t -> (Signature.t, 'i, 'o) View.t
+val mtalias'const : (longident_loc, 'i, 'o) View.t -> (module_type, 'i, 'o) View.t
+val signature'const: (signature_item list, 'i, 'o) View.t -> (signature, 'i, 'o) View.t
 
-val psig_desc'match : (Signature_item_desc.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val psig_desc'match : (signature_item_desc, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val psig_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_value'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_value'const : (value_description, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigvalue'const : (Value_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigvalue'const : (value_description, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_type'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_type'const : ((rec_flag * type_declaration list), 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigtype'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigtype'const : ((rec_flag * type_declaration list), 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_typext'const : (type_extension, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigtypext'const : (Type_extension.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigtypext'const : (type_extension, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_exception'const : (extension_constructor, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigexception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigexception'const : (extension_constructor, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_module'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_module'const : (module_declaration, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigmodule'const : (Module_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigmodule'const : (module_declaration, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_recmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_recmodule'const : (module_declaration list, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigrecmodule'const : (Module_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigrecmodule'const : (module_declaration list, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_modtype'const : (module_type_declaration, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigmodtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigmodtype'const : (module_type_declaration, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_open'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_open'const : (open_description, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigopen'const : (Open_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigopen'const : (open_description, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_include'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_include'const : (include_description, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val siginclude'const : (Include_description.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val siginclude'const : (include_description, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_class'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_class'const : (class_description list, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigclass'const : (Class_description.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigclass'const : (class_description list, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_class_type'const : (class_type_declaration list, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigclass_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigclass_type'const : (class_type_declaration list, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_attribute'const : (attribute, 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigattribute'const : (Attribute.t, 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigattribute'const : (attribute, 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val psig_extension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Signature_item_desc.t, 'i, 'o) View.t
+val psig_extension'const : ((extension * attributes), 'i, 'o) View.t -> (signature_item_desc, 'i, 'o) View.t
 
-val sigextension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Signature_item.t, 'i, 'o) View.t
+val sigextension'const : ((extension * attributes), 'i, 'o) View.t -> (signature_item, 'i, 'o) View.t
 
-val pmd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
+val pmd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (module_declaration, 'i, 'o) View.t
 
-val pmd_type'match : (Module_type.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
+val pmd_type'match : (module_type, 'i, 'o) View.t -> (module_declaration, 'i, 'o) View.t
 
-val pmd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
+val pmd_attributes'match : (attributes, 'i, 'o) View.t -> (module_declaration, 'i, 'o) View.t
 
-val pmd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_declaration.t, 'i, 'o) View.t
+val pmd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_declaration, 'i, 'o) View.t
 
-val pmtd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_type_declaration.t, 'i, 'o) View.t
+val pmtd_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (module_type_declaration, 'i, 'o) View.t
 
-val pmtd_type'match : (Module_type.t option, 'i, 'o) View.t -> (Module_type_declaration.t, 'i, 'o) View.t
+val pmtd_type'match : (module_type option, 'i, 'o) View.t -> (module_type_declaration, 'i, 'o) View.t
 
-val pmtd_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_type_declaration.t, 'i, 'o) View.t
+val pmtd_attributes'match : (attributes, 'i, 'o) View.t -> (module_type_declaration, 'i, 'o) View.t
 
-val pmtd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_type_declaration.t, 'i, 'o) View.t
+val pmtd_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_type_declaration, 'i, 'o) View.t
 
-val popen_lid'match : (Longident_loc.t, 'i, 'o) View.t -> (Open_description.t, 'i, 'o) View.t
+val popen_lid'match : (longident_loc, 'i, 'o) View.t -> (open_description, 'i, 'o) View.t
 
-val popen_override'match : (Override_flag.t, 'i, 'o) View.t -> (Open_description.t, 'i, 'o) View.t
+val popen_override'match : (override_flag, 'i, 'o) View.t -> (open_description, 'i, 'o) View.t
 
-val popen_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Open_description.t, 'i, 'o) View.t
+val popen_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (open_description, 'i, 'o) View.t
 
-val popen_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Open_description.t, 'i, 'o) View.t
+val popen_attributes'match : (attributes, 'i, 'o) View.t -> (open_description, 'i, 'o) View.t
 
-val pincl_mod'match : ('a node, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
+val pincl_mod'match : ('a node, 'i, 'o) View.t -> ('a node include_infos, 'i, 'o) View.t
 
-val pincl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
+val pincl_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> ('a node include_infos, 'i, 'o) View.t
 
-val pincl_attributes'match : (Attributes.t, 'i, 'o) View.t -> ('a node Include_infos.t, 'i, 'o) View.t
-val include_description'const: (Module_type.t Include_infos.t, 'i, 'o) View.t -> (Include_description.t, 'i, 'o) View.t
-val include_declaration'const: (Module_expr.t Include_infos.t, 'i, 'o) View.t -> (Include_declaration.t, 'i, 'o) View.t
+val pincl_attributes'match : (attributes, 'i, 'o) View.t -> ('a node include_infos, 'i, 'o) View.t
+val include_description'const: (module_type include_infos, 'i, 'o) View.t -> (include_description, 'i, 'o) View.t
+val include_declaration'const: (module_expr include_infos, 'i, 'o) View.t -> (include_declaration, 'i, 'o) View.t
 
-val pwith_type'const : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+val pwith_type'const : ((longident_loc * type_declaration), 'i, 'o) View.t -> (with_constraint, 'i, 'o) View.t
 
-val pwith_module'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+val pwith_module'const : ((longident_loc * longident_loc), 'i, 'o) View.t -> (with_constraint, 'i, 'o) View.t
 
-val pwith_typesubst'const : ((Longident_loc.t * Type_declaration.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+val pwith_typesubst'const : ((longident_loc * type_declaration), 'i, 'o) View.t -> (with_constraint, 'i, 'o) View.t
 
-val pwith_modsubst'const : ((Longident_loc.t * Longident_loc.t), 'i, 'o) View.t -> (With_constraint.t, 'i, 'o) View.t
+val pwith_modsubst'const : ((longident_loc * longident_loc), 'i, 'o) View.t -> (with_constraint, 'i, 'o) View.t
 
-val pmod_desc'match : (Module_expr_desc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val pmod_desc'match : (module_expr_desc, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val pmod_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val pmod_attributes'match : (attributes, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_ident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_ident'const : (longident_loc, 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meident'const : (Longident_loc.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val meident'const : (longident_loc, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_structure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_structure'const : (structure, 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val mestructure'const : (Structure.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val mestructure'const : (structure, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_functor'const : ((string Astlib.Loc.t * Module_type.t option * Module_expr.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_functor'const : ((string Astlib.Loc.t * module_type option * module_expr), 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val mefunctor'const : ((string Astlib.Loc.t * Module_type.t option * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val mefunctor'const : ((string Astlib.Loc.t * module_type option * module_expr), 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_apply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_apply'const : ((module_expr * module_expr), 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meapply'const : ((Module_expr.t * Module_expr.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val meapply'const : ((module_expr * module_expr), 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_constraint'const : ((Module_expr.t * Module_type.t), 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_constraint'const : ((module_expr * module_type), 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meconstraint'const : ((Module_expr.t * Module_type.t), 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val meconstraint'const : ((module_expr * module_type), 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_unpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_unpack'const : (expression, 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meunpack'const : (Expression.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
+val meunpack'const : (expression, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
 
-val pmod_extension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr_desc.t, 'i, 'o) View.t
+val pmod_extension'const : (extension, 'i, 'o) View.t -> (module_expr_desc, 'i, 'o) View.t
 
-val meextension'const : (Extension.t, 'i, 'o) View.t -> (Module_expr.t, 'i, 'o) View.t
-val structure'const: (Structure_item.t list, 'i, 'o) View.t -> (Structure.t, 'i, 'o) View.t
+val meextension'const : (extension, 'i, 'o) View.t -> (module_expr, 'i, 'o) View.t
+val structure'const: (structure_item list, 'i, 'o) View.t -> (structure, 'i, 'o) View.t
 
-val pstr_desc'match : (Structure_item_desc.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val pstr_desc'match : (structure_item_desc, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val pstr_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_eval'const : ((Expression.t * Attributes.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_eval'const : ((expression * attributes), 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val streval'const : ((Expression.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val streval'const : ((expression * attributes), 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_value'const : ((Rec_flag.t * Value_binding.t list), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_value'const : ((rec_flag * value_binding list), 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strvalue'const : ((Rec_flag.t * Value_binding.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strvalue'const : ((rec_flag * value_binding list), 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_primitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_primitive'const : (value_description, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strprimitive'const : (Value_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strprimitive'const : (value_description, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_type'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_type'const : ((rec_flag * type_declaration list), 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strtype'const : ((Rec_flag.t * Type_declaration.t list), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strtype'const : ((rec_flag * type_declaration list), 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_typext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_typext'const : (type_extension, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strtypext'const : (Type_extension.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strtypext'const : (type_extension, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_exception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_exception'const : (extension_constructor, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strexception'const : (Extension_constructor.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strexception'const : (extension_constructor, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_module'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_module'const : (module_binding, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strmodule'const : (Module_binding.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strmodule'const : (module_binding, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_recmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_recmodule'const : (module_binding list, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strrecmodule'const : (Module_binding.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strrecmodule'const : (module_binding list, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_modtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_modtype'const : (module_type_declaration, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strmodtype'const : (Module_type_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strmodtype'const : (module_type_declaration, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_open'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_open'const : (open_description, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val stropen'const : (Open_description.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val stropen'const : (open_description, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_class'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_class'const : (class_declaration list, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strclass'const : (Class_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strclass'const : (class_declaration list, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_class_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_class_type'const : (class_type_declaration list, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strclass_type'const : (Class_type_declaration.t list, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strclass_type'const : (class_type_declaration list, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_include'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_include'const : (include_declaration, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strinclude'const : (Include_declaration.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strinclude'const : (include_declaration, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_attribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_attribute'const : (attribute, 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strattribute'const : (Attribute.t, 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strattribute'const : (attribute, 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pstr_extension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Structure_item_desc.t, 'i, 'o) View.t
+val pstr_extension'const : ((extension * attributes), 'i, 'o) View.t -> (structure_item_desc, 'i, 'o) View.t
 
-val strextension'const : ((Extension.t * Attributes.t), 'i, 'o) View.t -> (Structure_item.t, 'i, 'o) View.t
+val strextension'const : ((extension * attributes), 'i, 'o) View.t -> (structure_item, 'i, 'o) View.t
 
-val pvb_pat'match : (Pattern.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
+val pvb_pat'match : (pattern, 'i, 'o) View.t -> (value_binding, 'i, 'o) View.t
 
-val pvb_expr'match : (Expression.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
+val pvb_expr'match : (expression, 'i, 'o) View.t -> (value_binding, 'i, 'o) View.t
 
-val pvb_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
+val pvb_attributes'match : (attributes, 'i, 'o) View.t -> (value_binding, 'i, 'o) View.t
 
-val pvb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Value_binding.t, 'i, 'o) View.t
+val pvb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (value_binding, 'i, 'o) View.t
 
-val pmb_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
+val pmb_name'match : (string Astlib.Loc.t, 'i, 'o) View.t -> (module_binding, 'i, 'o) View.t
 
-val pmb_expr'match : (Module_expr.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
+val pmb_expr'match : (module_expr, 'i, 'o) View.t -> (module_binding, 'i, 'o) View.t
 
-val pmb_attributes'match : (Attributes.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
+val pmb_attributes'match : (attributes, 'i, 'o) View.t -> (module_binding, 'i, 'o) View.t
 
-val pmb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (Module_binding.t, 'i, 'o) View.t
+val pmb_loc'match : (Astlib.Location.t, 'i, 'o) View.t -> (module_binding, 'i, 'o) View.t
 
-val ptop_def'const : (Structure.t, 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+val ptop_def'const : (structure, 'i, 'o) View.t -> (toplevel_phrase, 'i, 'o) View.t
 
-val ptop_dir'const : ((string * Directive_argument.t), 'i, 'o) View.t -> (Toplevel_phrase.t, 'i, 'o) View.t
+val ptop_dir'const : ((string * directive_argument), 'i, 'o) View.t -> (toplevel_phrase, 'i, 'o) View.t
 
-val pdir_none'const : (Directive_argument.t, 'a, 'a) View.t
+val pdir_none'const : (directive_argument, 'a, 'a) View.t
 
-val pdir_string'const : (string, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+val pdir_string'const : (string, 'i, 'o) View.t -> (directive_argument, 'i, 'o) View.t
 
-val pdir_int'const : ((string * char option), 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+val pdir_int'const : ((string * char option), 'i, 'o) View.t -> (directive_argument, 'i, 'o) View.t
 
-val pdir_ident'const : (Longident.t, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+val pdir_ident'const : (longident, 'i, 'o) View.t -> (directive_argument, 'i, 'o) View.t
 
-val pdir_bool'const : (bool, 'i, 'o) View.t -> (Directive_argument.t, 'i, 'o) View.t
+val pdir_bool'const : (bool, 'i, 'o) View.t -> (directive_argument, 'i, 'o) View.t
 (*$*)

--- a/bootstrap/runner/ppx_bootstrap_runner.ml
+++ b/bootstrap/runner/ppx_bootstrap_runner.ml
@@ -1,4 +1,5 @@
 open! Stdppx
+open Ppx_ast
 open Ppx_ast.V4_07
 
 module Kind = struct

--- a/metaquot/expander/ppx_metaquot_expander.ml
+++ b/metaquot/expander/ppx_metaquot_expander.ml
@@ -1,4 +1,5 @@
 open! Stdppx
+open Ppx_ast
 open Ppx_ast.V4_07
 module Conversion = Ppx_ast.Conversion
 module Traverse_builtins = Ppx_ast.Traverse_builtins

--- a/metaquot_lifters/ppx_metaquot_lifters.ml
+++ b/metaquot_lifters/ppx_metaquot_lifters.ml
@@ -1,4 +1,5 @@
 open Stdppx
+open Ppx_ast
 open Ppx_ast.V4_07
 module Traverse_builtins = Ppx_ast.Traverse_builtins
 module Expr = Expression_desc

--- a/src/ast_builder.ml
+++ b/src/ast_builder.ml
@@ -1,5 +1,6 @@
 open! Import
-include Ast
+include Ppx_ast
+include Current_ast
 
 let esequence ~loc el =
   match el with

--- a/src/ast_builder.mli
+++ b/src/ast_builder.mli
@@ -1,5 +1,7 @@
 (** Helpers for build OCaml AST fragments *)
 
+(* TODO: remove in favor of Ppx_ast's versioned builders *)
+
 open! Import
 
 (** This module is similar to the [Ast_helper] module distrubuted with OCaml but uses
@@ -145,12 +147,12 @@ val nonrec_type_declaration :
       since type constructors are always applied. *)
 val unapplied_type_constr_conv :
   loc:Location.t
-  -> Longident.t Loc.t -> f:(string -> string) -> expression
+  -> longident Loc.t -> f:(string -> string) -> expression
 val type_constr_conv :
   loc:Location.t
-  -> Longident.t Loc.t -> f:(string -> string) -> expression list -> expression
+  -> longident Loc.t -> f:(string -> string) -> expression list -> expression
 
-val include_infos : loc:Location.t -> 'a node -> 'a node Include_infos.t
+val include_infos : loc:Location.t -> 'a node -> 'a node include_infos
 
 (** Tries to simplify [fun v1 v2 .. -> f v1 v2 ..] into [f]. Only works when [f] is a
       path, not an arbitrary expression as that would change the meaning of
@@ -184,7 +186,7 @@ module Located : sig
   val mk : loc:Location.t -> 'a -> 'a Loc.t
 
   val map        : 'a Loc.t -> f:('a -> 'b) -> 'b Loc.t
-  val map_lident : string Loc.t -> Longident_loc.t
+  val map_lident : string Loc.t -> longident_loc
 
-  val lident : loc:Location.t -> string -> Longident_loc.t
+  val lident : loc:Location.t -> string -> longident_loc
 end

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -1,4 +1,5 @@
 open! Import
+open Current_ast
 
 include Ast_pattern0
 

--- a/src/ast_pattern_generated.ml
+++ b/src/ast_pattern_generated.ml
@@ -1,4 +1,5 @@
 open! Import
+open Current_ast
 open Ast_pattern0
 
 (*$ Ppxlib_cinaps_helpers.generate_ast_pattern_impl () *)

--- a/src/ast_pattern_generated.mli
+++ b/src/ast_pattern_generated.mli
@@ -6,13 +6,13 @@ val lident :
   -> (longident, 't0, 't1) Ast_pattern0.t
 
 val ldot :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
   -> (string, 't1, 't2) Ast_pattern0.t
   -> (longident, 't0, 't2) Ast_pattern0.t
 
 val lapply :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Longident.t, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (longident, 't1, 't2) Ast_pattern0.t
   -> (longident, 't0, 't2) Ast_pattern0.t
 
 val labelled :
@@ -43,20 +43,20 @@ val pconst_float :
   -> (constant, 't0, 't2) Ast_pattern0.t
 
 val pstr :
-  (Structure_item.t list, 't0, 't1) Ast_pattern0.t
+  (structure_item list, 't0, 't1) Ast_pattern0.t
   -> (payload, 't0, 't1) Ast_pattern0.t
 
 val psig :
-  (Signature_item.t list, 't0, 't1) Ast_pattern0.t
+  (signature_item list, 't0, 't1) Ast_pattern0.t
   -> (payload, 't0, 't1) Ast_pattern0.t
 
 val ptyp :
-  (Core_type.t, 't0, 't1) Ast_pattern0.t
+  (core_type, 't0, 't1) Ast_pattern0.t
   -> (payload, 't0, 't1) Ast_pattern0.t
 
 val ppat :
-  (Pattern.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t option, 't1, 't2) Ast_pattern0.t
+  (pattern, 't0, 't1) Ast_pattern0.t
+  -> (expression option, 't1, 't2) Ast_pattern0.t
   -> (payload, 't0, 't2) Ast_pattern0.t
 
 val ptyp_var :
@@ -64,52 +64,52 @@ val ptyp_var :
   -> (core_type, 't0, 't1) Ast_pattern0.t
 
 val ptyp_arrow :
-  (Arg_label.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t, 't1, 't2) Ast_pattern0.t
-  -> (Core_type.t, 't2, 't3) Ast_pattern0.t
+  (arg_label, 't0, 't1) Ast_pattern0.t
+  -> (core_type, 't1, 't2) Ast_pattern0.t
+  -> (core_type, 't2, 't3) Ast_pattern0.t
   -> (core_type, 't0, 't3) Ast_pattern0.t
 
 val ptyp_tuple :
-  (Core_type.t list, 't0, 't1) Ast_pattern0.t
+  (core_type list, 't0, 't1) Ast_pattern0.t
   -> (core_type, 't0, 't1) Ast_pattern0.t
 
 val ptyp_constr :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t list, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (core_type list, 't1, 't2) Ast_pattern0.t
   -> (core_type, 't0, 't2) Ast_pattern0.t
 
 val ptyp_object :
-  (Object_field.t list, 't0, 't1) Ast_pattern0.t
-  -> (Closed_flag.t, 't1, 't2) Ast_pattern0.t
+  (object_field list, 't0, 't1) Ast_pattern0.t
+  -> (closed_flag, 't1, 't2) Ast_pattern0.t
   -> (core_type, 't0, 't2) Ast_pattern0.t
 
 val ptyp_class :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t list, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (core_type list, 't1, 't2) Ast_pattern0.t
   -> (core_type, 't0, 't2) Ast_pattern0.t
 
 val ptyp_alias :
-  (Core_type.t, 't0, 't1) Ast_pattern0.t
+  (core_type, 't0, 't1) Ast_pattern0.t
   -> (string, 't1, 't2) Ast_pattern0.t
   -> (core_type, 't0, 't2) Ast_pattern0.t
 
 val ptyp_variant :
-  (Row_field.t list, 't0, 't1) Ast_pattern0.t
-  -> (Closed_flag.t, 't1, 't2) Ast_pattern0.t
+  (row_field list, 't0, 't1) Ast_pattern0.t
+  -> (closed_flag, 't1, 't2) Ast_pattern0.t
   -> (string list option, 't2, 't3) Ast_pattern0.t
   -> (core_type, 't0, 't3) Ast_pattern0.t
 
 val ptyp_poly :
   (string Astlib.Loc.t list, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t, 't1, 't2) Ast_pattern0.t
+  -> (core_type, 't1, 't2) Ast_pattern0.t
   -> (core_type, 't0, 't2) Ast_pattern0.t
 
 val ptyp_package :
-  ((Longident_loc.t * (Longident_loc.t * Core_type.t) list), 't0, 't1) Ast_pattern0.t
+  ((longident_loc * (longident_loc * core_type) list), 't0, 't1) Ast_pattern0.t
   -> (core_type, 't0, 't1) Ast_pattern0.t
 
 val ptyp_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (core_type, 't0, 't1) Ast_pattern0.t
 
 val ptyp_loc :
@@ -117,28 +117,28 @@ val ptyp_loc :
   -> (core_type, 't1, 't2) Ast_pattern0.t
 
 val ptyp_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (core_type, 't1, 't2) Ast_pattern0.t
 
 val rtag :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  -> (attribute list, 't1, 't2) Ast_pattern0.t
   -> (bool, 't2, 't3) Ast_pattern0.t
-  -> (Core_type.t list, 't3, 't4) Ast_pattern0.t
+  -> (core_type list, 't3, 't4) Ast_pattern0.t
   -> (row_field, 't0, 't4) Ast_pattern0.t
 
 val rinherit :
-  (Core_type.t, 't0, 't1) Ast_pattern0.t
+  (core_type, 't0, 't1) Ast_pattern0.t
   -> (row_field, 't0, 't1) Ast_pattern0.t
 
 val otag :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Attribute.t list, 't1, 't2) Ast_pattern0.t
-  -> (Core_type.t, 't2, 't3) Ast_pattern0.t
+  -> (attribute list, 't1, 't2) Ast_pattern0.t
+  -> (core_type, 't2, 't3) Ast_pattern0.t
   -> (object_field, 't0, 't3) Ast_pattern0.t
 
 val oinherit :
-  (Core_type.t, 't0, 't1) Ast_pattern0.t
+  (core_type, 't0, 't1) Ast_pattern0.t
   -> (object_field, 't0, 't1) Ast_pattern0.t
 
 val ppat_var :
@@ -146,58 +146,58 @@ val ppat_var :
   -> (pattern, 't0, 't1) Ast_pattern0.t
 
 val ppat_alias :
-  (Pattern.t, 't0, 't1) Ast_pattern0.t
+  (pattern, 't0, 't1) Ast_pattern0.t
   -> (string, 't1, 't2) Ast_pattern0.t
   -> (pattern, 't0, 't2) Ast_pattern0.t
 
 val ppat_constant :
-  (Constant.t, 't0, 't1) Ast_pattern0.t
+  (constant, 't0, 't1) Ast_pattern0.t
   -> (pattern, 't0, 't1) Ast_pattern0.t
 
 val ppat_interval :
-  (Constant.t, 't0, 't1) Ast_pattern0.t
-  -> (Constant.t, 't1, 't2) Ast_pattern0.t
+  (constant, 't0, 't1) Ast_pattern0.t
+  -> (constant, 't1, 't2) Ast_pattern0.t
   -> (pattern, 't0, 't2) Ast_pattern0.t
 
 val ppat_tuple :
-  (Pattern.t list, 't0, 't1) Ast_pattern0.t
+  (pattern list, 't0, 't1) Ast_pattern0.t
   -> (pattern, 't0, 't1) Ast_pattern0.t
 
 val ppat_construct :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Pattern.t option, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (pattern option, 't1, 't2) Ast_pattern0.t
   -> (pattern, 't0, 't2) Ast_pattern0.t
 
 val ppat_variant :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Pattern.t option, 't1, 't2) Ast_pattern0.t
+  -> (pattern option, 't1, 't2) Ast_pattern0.t
   -> (pattern, 't0, 't2) Ast_pattern0.t
 
 val ppat_record :
-  ((Longident_loc.t * Pattern.t) list, 't0, 't1) Ast_pattern0.t
-  -> (Closed_flag.t, 't1, 't2) Ast_pattern0.t
+  ((longident_loc * pattern) list, 't0, 't1) Ast_pattern0.t
+  -> (closed_flag, 't1, 't2) Ast_pattern0.t
   -> (pattern, 't0, 't2) Ast_pattern0.t
 
 val ppat_array :
-  (Pattern.t list, 't0, 't1) Ast_pattern0.t
+  (pattern list, 't0, 't1) Ast_pattern0.t
   -> (pattern, 't0, 't1) Ast_pattern0.t
 
 val ppat_or :
-  (Pattern.t, 't0, 't1) Ast_pattern0.t
-  -> (Pattern.t, 't1, 't2) Ast_pattern0.t
+  (pattern, 't0, 't1) Ast_pattern0.t
+  -> (pattern, 't1, 't2) Ast_pattern0.t
   -> (pattern, 't0, 't2) Ast_pattern0.t
 
 val ppat_constraint :
-  (Pattern.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t, 't1, 't2) Ast_pattern0.t
+  (pattern, 't0, 't1) Ast_pattern0.t
+  -> (core_type, 't1, 't2) Ast_pattern0.t
   -> (pattern, 't0, 't2) Ast_pattern0.t
 
 val ppat_type :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
   -> (pattern, 't0, 't1) Ast_pattern0.t
 
 val ppat_lazy :
-  (Pattern.t, 't0, 't1) Ast_pattern0.t
+  (pattern, 't0, 't1) Ast_pattern0.t
   -> (pattern, 't0, 't1) Ast_pattern0.t
 
 val ppat_unpack :
@@ -205,16 +205,16 @@ val ppat_unpack :
   -> (pattern, 't0, 't1) Ast_pattern0.t
 
 val ppat_exception :
-  (Pattern.t, 't0, 't1) Ast_pattern0.t
+  (pattern, 't0, 't1) Ast_pattern0.t
   -> (pattern, 't0, 't1) Ast_pattern0.t
 
 val ppat_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (pattern, 't0, 't1) Ast_pattern0.t
 
 val ppat_open :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Pattern.t, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (pattern, 't1, 't2) Ast_pattern0.t
   -> (pattern, 't0, 't2) Ast_pattern0.t
 
 val ppat_loc :
@@ -222,181 +222,181 @@ val ppat_loc :
   -> (pattern, 't1, 't2) Ast_pattern0.t
 
 val ppat_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (pattern, 't1, 't2) Ast_pattern0.t
 
 val pexp_ident :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_constant :
-  (Constant.t, 't0, 't1) Ast_pattern0.t
+  (constant, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_let :
-  (Rec_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Value_binding.t list, 't1, 't2) Ast_pattern0.t
-  -> (Expression.t, 't2, 't3) Ast_pattern0.t
+  (rec_flag, 't0, 't1) Ast_pattern0.t
+  -> (value_binding list, 't1, 't2) Ast_pattern0.t
+  -> (expression, 't2, 't3) Ast_pattern0.t
   -> (expression, 't0, 't3) Ast_pattern0.t
 
 val pexp_function :
-  (Case.t list, 't0, 't1) Ast_pattern0.t
+  (case list, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_fun :
-  (Arg_label.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t option, 't1, 't2) Ast_pattern0.t
-  -> (Pattern.t, 't2, 't3) Ast_pattern0.t
-  -> (Expression.t, 't3, 't4) Ast_pattern0.t
+  (arg_label, 't0, 't1) Ast_pattern0.t
+  -> (expression option, 't1, 't2) Ast_pattern0.t
+  -> (pattern, 't2, 't3) Ast_pattern0.t
+  -> (expression, 't3, 't4) Ast_pattern0.t
   -> (expression, 't0, 't4) Ast_pattern0.t
 
 val pexp_apply :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> ((Arg_label.t * Expression.t) list, 't1, 't2) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> ((arg_label * expression) list, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_match :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Case.t list, 't1, 't2) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (case list, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_try :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Case.t list, 't1, 't2) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (case list, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_tuple :
-  (Expression.t list, 't0, 't1) Ast_pattern0.t
+  (expression list, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_construct :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t option, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (expression option, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_variant :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t option, 't1, 't2) Ast_pattern0.t
+  -> (expression option, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_record :
-  ((Longident_loc.t * Expression.t) list, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t option, 't1, 't2) Ast_pattern0.t
+  ((longident_loc * expression) list, 't0, 't1) Ast_pattern0.t
+  -> (expression option, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_field :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Longident.t, 't1, 't2) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (longident, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_setfield :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Longident.t, 't1, 't2) Ast_pattern0.t
-  -> (Expression.t, 't2, 't3) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (longident, 't1, 't2) Ast_pattern0.t
+  -> (expression, 't2, 't3) Ast_pattern0.t
   -> (expression, 't0, 't3) Ast_pattern0.t
 
 val pexp_array :
-  (Expression.t list, 't0, 't1) Ast_pattern0.t
+  (expression list, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_ifthenelse :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t, 't1, 't2) Ast_pattern0.t
-  -> (Expression.t option, 't2, 't3) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (expression, 't1, 't2) Ast_pattern0.t
+  -> (expression option, 't2, 't3) Ast_pattern0.t
   -> (expression, 't0, 't3) Ast_pattern0.t
 
 val pexp_sequence :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t, 't1, 't2) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (expression, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_while :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t, 't1, 't2) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (expression, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_for :
-  (Pattern.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t, 't1, 't2) Ast_pattern0.t
-  -> (Expression.t, 't2, 't3) Ast_pattern0.t
-  -> (Direction_flag.t, 't3, 't4) Ast_pattern0.t
-  -> (Expression.t, 't4, 't5) Ast_pattern0.t
+  (pattern, 't0, 't1) Ast_pattern0.t
+  -> (expression, 't1, 't2) Ast_pattern0.t
+  -> (expression, 't2, 't3) Ast_pattern0.t
+  -> (direction_flag, 't3, 't4) Ast_pattern0.t
+  -> (expression, 't4, 't5) Ast_pattern0.t
   -> (expression, 't0, 't5) Ast_pattern0.t
 
 val pexp_constraint :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t, 't1, 't2) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (core_type, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_coerce :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t option, 't1, 't2) Ast_pattern0.t
-  -> (Core_type.t, 't2, 't3) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (core_type option, 't1, 't2) Ast_pattern0.t
+  -> (core_type, 't2, 't3) Ast_pattern0.t
   -> (expression, 't0, 't3) Ast_pattern0.t
 
 val pexp_send :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
   -> (string, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_new :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_setinstvar :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t, 't1, 't2) Ast_pattern0.t
+  -> (expression, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_override :
-  ((string Astlib.Loc.t * Expression.t) list, 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * expression) list, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_letmodule :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Module_expr.t, 't1, 't2) Ast_pattern0.t
-  -> (Expression.t, 't2, 't3) Ast_pattern0.t
+  -> (module_expr, 't1, 't2) Ast_pattern0.t
+  -> (expression, 't2, 't3) Ast_pattern0.t
   -> (expression, 't0, 't3) Ast_pattern0.t
 
 val pexp_letexception :
-  (Extension_constructor.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t, 't1, 't2) Ast_pattern0.t
+  (extension_constructor, 't0, 't1) Ast_pattern0.t
+  -> (expression, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_assert :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_lazy :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_poly :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t option, 't1, 't2) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (core_type option, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_object :
-  (Class_structure.t, 't0, 't1) Ast_pattern0.t
+  (class_structure, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_newtype :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t, 't1, 't2) Ast_pattern0.t
+  -> (expression, 't1, 't2) Ast_pattern0.t
   -> (expression, 't0, 't2) Ast_pattern0.t
 
 val pexp_pack :
-  (Module_expr.t, 't0, 't1) Ast_pattern0.t
+  (module_expr, 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_open :
-  (Override_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Longident.t, 't1, 't2) Ast_pattern0.t
-  -> (Expression.t, 't2, 't3) Ast_pattern0.t
+  (override_flag, 't0, 't1) Ast_pattern0.t
+  -> (longident, 't1, 't2) Ast_pattern0.t
+  -> (expression, 't2, 't3) Ast_pattern0.t
   -> (expression, 't0, 't3) Ast_pattern0.t
 
 val pexp_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (expression, 't0, 't1) Ast_pattern0.t
 
 val pexp_loc :
@@ -404,11 +404,11 @@ val pexp_loc :
   -> (expression, 't1, 't2) Ast_pattern0.t
 
 val pexp_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (expression, 't1, 't2) Ast_pattern0.t
 
 val pval_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (value_description, 't1, 't2) Ast_pattern0.t
 
 val pval_loc :
@@ -416,7 +416,7 @@ val pval_loc :
   -> (value_description, 't1, 't2) Ast_pattern0.t
 
 val ptype_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (type_declaration, 't1, 't2) Ast_pattern0.t
 
 val ptype_loc :
@@ -424,11 +424,11 @@ val ptype_loc :
   -> (type_declaration, 't1, 't2) Ast_pattern0.t
 
 val ptype_variant :
-  (Constructor_declaration.t list, 't0, 't1) Ast_pattern0.t
+  (constructor_declaration list, 't0, 't1) Ast_pattern0.t
   -> (type_kind, 't0, 't1) Ast_pattern0.t
 
 val ptype_record :
-  (Label_declaration.t list, 't0, 't1) Ast_pattern0.t
+  (label_declaration list, 't0, 't1) Ast_pattern0.t
   -> (type_kind, 't0, 't1) Ast_pattern0.t
 
 val pld_loc :
@@ -436,7 +436,7 @@ val pld_loc :
   -> (label_declaration, 't1, 't2) Ast_pattern0.t
 
 val pld_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (label_declaration, 't1, 't2) Ast_pattern0.t
 
 val pcd_loc :
@@ -444,19 +444,19 @@ val pcd_loc :
   -> (constructor_declaration, 't1, 't2) Ast_pattern0.t
 
 val pcd_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (constructor_declaration, 't1, 't2) Ast_pattern0.t
 
 val pcstr_tuple :
-  (Core_type.t list, 't0, 't1) Ast_pattern0.t
+  (core_type list, 't0, 't1) Ast_pattern0.t
   -> (constructor_arguments, 't0, 't1) Ast_pattern0.t
 
 val pcstr_record :
-  (Label_declaration.t list, 't0, 't1) Ast_pattern0.t
+  (label_declaration list, 't0, 't1) Ast_pattern0.t
   -> (constructor_arguments, 't0, 't1) Ast_pattern0.t
 
 val ptyext_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (type_extension, 't1, 't2) Ast_pattern0.t
 
 val pext_loc :
@@ -464,41 +464,41 @@ val pext_loc :
   -> (extension_constructor, 't1, 't2) Ast_pattern0.t
 
 val pext_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (extension_constructor, 't1, 't2) Ast_pattern0.t
 
 val pext_decl :
-  (Constructor_arguments.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t option, 't1, 't2) Ast_pattern0.t
+  (constructor_arguments, 't0, 't1) Ast_pattern0.t
+  -> (core_type option, 't1, 't2) Ast_pattern0.t
   -> (extension_constructor_kind, 't0, 't2) Ast_pattern0.t
 
 val pext_rebind :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
   -> (extension_constructor_kind, 't0, 't1) Ast_pattern0.t
 
 val pcty_constr :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t list, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (core_type list, 't1, 't2) Ast_pattern0.t
   -> (class_type, 't0, 't2) Ast_pattern0.t
 
 val pcty_signature :
-  (Class_signature.t, 't0, 't1) Ast_pattern0.t
+  (class_signature, 't0, 't1) Ast_pattern0.t
   -> (class_type, 't0, 't1) Ast_pattern0.t
 
 val pcty_arrow :
-  (Arg_label.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t, 't1, 't2) Ast_pattern0.t
-  -> (Class_type.t, 't2, 't3) Ast_pattern0.t
+  (arg_label, 't0, 't1) Ast_pattern0.t
+  -> (core_type, 't1, 't2) Ast_pattern0.t
+  -> (class_type, 't2, 't3) Ast_pattern0.t
   -> (class_type, 't0, 't3) Ast_pattern0.t
 
 val pcty_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (class_type, 't0, 't1) Ast_pattern0.t
 
 val pcty_open :
-  (Override_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Longident.t, 't1, 't2) Ast_pattern0.t
-  -> (Class_type.t, 't2, 't3) Ast_pattern0.t
+  (override_flag, 't0, 't1) Ast_pattern0.t
+  -> (longident, 't1, 't2) Ast_pattern0.t
+  -> (class_type, 't2, 't3) Ast_pattern0.t
   -> (class_type, 't0, 't3) Ast_pattern0.t
 
 val pcty_loc :
@@ -506,31 +506,31 @@ val pcty_loc :
   -> (class_type, 't1, 't2) Ast_pattern0.t
 
 val pcty_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (class_type, 't1, 't2) Ast_pattern0.t
 
 val pctf_inherit :
-  (Class_type.t, 't0, 't1) Ast_pattern0.t
+  (class_type, 't0, 't1) Ast_pattern0.t
   -> (class_type_field, 't0, 't1) Ast_pattern0.t
 
 val pctf_val :
-  ((string Astlib.Loc.t * Mutable_flag.t * Virtual_flag.t * Core_type.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * mutable_flag * virtual_flag * core_type), 't0, 't1) Ast_pattern0.t
   -> (class_type_field, 't0, 't1) Ast_pattern0.t
 
 val pctf_method :
-  ((string Astlib.Loc.t * Private_flag.t * Virtual_flag.t * Core_type.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * private_flag * virtual_flag * core_type), 't0, 't1) Ast_pattern0.t
   -> (class_type_field, 't0, 't1) Ast_pattern0.t
 
 val pctf_constraint :
-  ((Core_type.t * Core_type.t), 't0, 't1) Ast_pattern0.t
+  ((core_type * core_type), 't0, 't1) Ast_pattern0.t
   -> (class_type_field, 't0, 't1) Ast_pattern0.t
 
 val pctf_attribute :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (class_type_field, 't0, 't1) Ast_pattern0.t
 
 val pctf_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (class_type_field, 't0, 't1) Ast_pattern0.t
 
 val pctf_loc :
@@ -538,7 +538,7 @@ val pctf_loc :
   -> (class_type_field, 't1, 't2) Ast_pattern0.t
 
 val pctf_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (class_type_field, 't1, 't2) Ast_pattern0.t
 
 val pci_loc :
@@ -546,49 +546,49 @@ val pci_loc :
   -> ('a node class_infos, 't1, 't2) Ast_pattern0.t
 
 val pci_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> ('a node class_infos, 't1, 't2) Ast_pattern0.t
 
 val pcl_constr :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Core_type.t list, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (core_type list, 't1, 't2) Ast_pattern0.t
   -> (class_expr, 't0, 't2) Ast_pattern0.t
 
 val pcl_structure :
-  (Class_structure.t, 't0, 't1) Ast_pattern0.t
+  (class_structure, 't0, 't1) Ast_pattern0.t
   -> (class_expr, 't0, 't1) Ast_pattern0.t
 
 val pcl_fun :
-  (Arg_label.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t option, 't1, 't2) Ast_pattern0.t
-  -> (Pattern.t, 't2, 't3) Ast_pattern0.t
-  -> (Class_expr.t, 't3, 't4) Ast_pattern0.t
+  (arg_label, 't0, 't1) Ast_pattern0.t
+  -> (expression option, 't1, 't2) Ast_pattern0.t
+  -> (pattern, 't2, 't3) Ast_pattern0.t
+  -> (class_expr, 't3, 't4) Ast_pattern0.t
   -> (class_expr, 't0, 't4) Ast_pattern0.t
 
 val pcl_apply :
-  (Class_expr.t, 't0, 't1) Ast_pattern0.t
-  -> ((Arg_label.t * Expression.t) list, 't1, 't2) Ast_pattern0.t
+  (class_expr, 't0, 't1) Ast_pattern0.t
+  -> ((arg_label * expression) list, 't1, 't2) Ast_pattern0.t
   -> (class_expr, 't0, 't2) Ast_pattern0.t
 
 val pcl_let :
-  (Rec_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Value_binding.t list, 't1, 't2) Ast_pattern0.t
-  -> (Class_expr.t, 't2, 't3) Ast_pattern0.t
+  (rec_flag, 't0, 't1) Ast_pattern0.t
+  -> (value_binding list, 't1, 't2) Ast_pattern0.t
+  -> (class_expr, 't2, 't3) Ast_pattern0.t
   -> (class_expr, 't0, 't3) Ast_pattern0.t
 
 val pcl_constraint :
-  (Class_expr.t, 't0, 't1) Ast_pattern0.t
-  -> (Class_type.t, 't1, 't2) Ast_pattern0.t
+  (class_expr, 't0, 't1) Ast_pattern0.t
+  -> (class_type, 't1, 't2) Ast_pattern0.t
   -> (class_expr, 't0, 't2) Ast_pattern0.t
 
 val pcl_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (class_expr, 't0, 't1) Ast_pattern0.t
 
 val pcl_open :
-  (Override_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Longident.t, 't1, 't2) Ast_pattern0.t
-  -> (Class_expr.t, 't2, 't3) Ast_pattern0.t
+  (override_flag, 't0, 't1) Ast_pattern0.t
+  -> (longident, 't1, 't2) Ast_pattern0.t
+  -> (class_expr, 't2, 't3) Ast_pattern0.t
   -> (class_expr, 't0, 't3) Ast_pattern0.t
 
 val pcl_loc :
@@ -596,37 +596,37 @@ val pcl_loc :
   -> (class_expr, 't1, 't2) Ast_pattern0.t
 
 val pcl_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (class_expr, 't1, 't2) Ast_pattern0.t
 
 val pcf_inherit :
-  (Override_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Class_expr.t, 't1, 't2) Ast_pattern0.t
+  (override_flag, 't0, 't1) Ast_pattern0.t
+  -> (class_expr, 't1, 't2) Ast_pattern0.t
   -> (string Astlib.Loc.t option, 't2, 't3) Ast_pattern0.t
   -> (class_field, 't0, 't3) Ast_pattern0.t
 
 val pcf_val :
-  ((string Astlib.Loc.t * Mutable_flag.t * Class_field_kind.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * mutable_flag * class_field_kind), 't0, 't1) Ast_pattern0.t
   -> (class_field, 't0, 't1) Ast_pattern0.t
 
 val pcf_method :
-  ((string Astlib.Loc.t * Private_flag.t * Class_field_kind.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * private_flag * class_field_kind), 't0, 't1) Ast_pattern0.t
   -> (class_field, 't0, 't1) Ast_pattern0.t
 
 val pcf_constraint :
-  ((Core_type.t * Core_type.t), 't0, 't1) Ast_pattern0.t
+  ((core_type * core_type), 't0, 't1) Ast_pattern0.t
   -> (class_field, 't0, 't1) Ast_pattern0.t
 
 val pcf_initializer :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
   -> (class_field, 't0, 't1) Ast_pattern0.t
 
 val pcf_attribute :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (class_field, 't0, 't1) Ast_pattern0.t
 
 val pcf_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (class_field, 't0, 't1) Ast_pattern0.t
 
 val pcf_loc :
@@ -634,47 +634,47 @@ val pcf_loc :
   -> (class_field, 't1, 't2) Ast_pattern0.t
 
 val pcf_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (class_field, 't1, 't2) Ast_pattern0.t
 
 val cfk_virtual :
-  (Core_type.t, 't0, 't1) Ast_pattern0.t
+  (core_type, 't0, 't1) Ast_pattern0.t
   -> (class_field_kind, 't0, 't1) Ast_pattern0.t
 
 val cfk_concrete :
-  (Override_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Expression.t, 't1, 't2) Ast_pattern0.t
+  (override_flag, 't0, 't1) Ast_pattern0.t
+  -> (expression, 't1, 't2) Ast_pattern0.t
   -> (class_field_kind, 't0, 't2) Ast_pattern0.t
 
 val pmty_ident :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
   -> (module_type, 't0, 't1) Ast_pattern0.t
 
 val pmty_signature :
-  (Signature_item.t list, 't0, 't1) Ast_pattern0.t
+  (signature_item list, 't0, 't1) Ast_pattern0.t
   -> (module_type, 't0, 't1) Ast_pattern0.t
 
 val pmty_functor :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Module_type.t option, 't1, 't2) Ast_pattern0.t
-  -> (Module_type.t, 't2, 't3) Ast_pattern0.t
+  -> (module_type option, 't1, 't2) Ast_pattern0.t
+  -> (module_type, 't2, 't3) Ast_pattern0.t
   -> (module_type, 't0, 't3) Ast_pattern0.t
 
 val pmty_with :
-  (Module_type.t, 't0, 't1) Ast_pattern0.t
-  -> (With_constraint.t list, 't1, 't2) Ast_pattern0.t
+  (module_type, 't0, 't1) Ast_pattern0.t
+  -> (with_constraint list, 't1, 't2) Ast_pattern0.t
   -> (module_type, 't0, 't2) Ast_pattern0.t
 
 val pmty_typeof :
-  (Module_expr.t, 't0, 't1) Ast_pattern0.t
+  (module_expr, 't0, 't1) Ast_pattern0.t
   -> (module_type, 't0, 't1) Ast_pattern0.t
 
 val pmty_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (module_type, 't0, 't1) Ast_pattern0.t
 
 val pmty_alias :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
   -> (module_type, 't0, 't1) Ast_pattern0.t
 
 val pmty_loc :
@@ -682,61 +682,61 @@ val pmty_loc :
   -> (module_type, 't1, 't2) Ast_pattern0.t
 
 val pmty_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (module_type, 't1, 't2) Ast_pattern0.t
 
 val psig_value :
-  (Value_description.t, 't0, 't1) Ast_pattern0.t
+  (value_description, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_type :
-  (Rec_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Type_declaration.t list, 't1, 't2) Ast_pattern0.t
+  (rec_flag, 't0, 't1) Ast_pattern0.t
+  -> (type_declaration list, 't1, 't2) Ast_pattern0.t
   -> (signature_item, 't0, 't2) Ast_pattern0.t
 
 val psig_typext :
-  (Type_extension.t, 't0, 't1) Ast_pattern0.t
+  (type_extension, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_exception :
-  (Extension_constructor.t, 't0, 't1) Ast_pattern0.t
+  (extension_constructor, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_module :
-  (Module_declaration.t, 't0, 't1) Ast_pattern0.t
+  (module_declaration, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_recmodule :
-  (Module_declaration.t list, 't0, 't1) Ast_pattern0.t
+  (module_declaration list, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_modtype :
-  (Module_type_declaration.t, 't0, 't1) Ast_pattern0.t
+  (module_type_declaration, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_open :
-  (Open_description.t, 't0, 't1) Ast_pattern0.t
+  (open_description, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_include :
-  (Module_type.t Include_infos.t, 't0, 't1) Ast_pattern0.t
+  (module_type include_infos, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_class :
-  (Class_description.t list, 't0, 't1) Ast_pattern0.t
+  (class_description list, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_class_type :
-  (Class_type_declaration.t list, 't0, 't1) Ast_pattern0.t
+  (class_type_declaration list, 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_attribute :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (signature_item, 't0, 't1) Ast_pattern0.t
 
 val psig_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
-  -> (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
+  -> (attribute list, 't1, 't2) Ast_pattern0.t
   -> (signature_item, 't0, 't2) Ast_pattern0.t
 
 val psig_loc :
@@ -744,7 +744,7 @@ val psig_loc :
   -> (signature_item, 't1, 't2) Ast_pattern0.t
 
 val pmd_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (module_declaration, 't1, 't2) Ast_pattern0.t
 
 val pmd_loc :
@@ -752,7 +752,7 @@ val pmd_loc :
   -> (module_declaration, 't1, 't2) Ast_pattern0.t
 
 val pmtd_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (module_type_declaration, 't1, 't2) Ast_pattern0.t
 
 val pmtd_loc :
@@ -764,7 +764,7 @@ val popen_loc :
   -> (open_description, 't1, 't2) Ast_pattern0.t
 
 val popen_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (open_description, 't1, 't2) Ast_pattern0.t
 
 val pincl_loc :
@@ -772,59 +772,59 @@ val pincl_loc :
   -> ('a node include_infos, 't1, 't2) Ast_pattern0.t
 
 val pincl_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> ('a node include_infos, 't1, 't2) Ast_pattern0.t
 
 val pwith_type :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Type_declaration.t, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (type_declaration, 't1, 't2) Ast_pattern0.t
   -> (with_constraint, 't0, 't2) Ast_pattern0.t
 
 val pwith_module :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Longident.t, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (longident, 't1, 't2) Ast_pattern0.t
   -> (with_constraint, 't0, 't2) Ast_pattern0.t
 
 val pwith_typesubst :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Type_declaration.t, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (type_declaration, 't1, 't2) Ast_pattern0.t
   -> (with_constraint, 't0, 't2) Ast_pattern0.t
 
 val pwith_modsubst :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
-  -> (Longident.t, 't1, 't2) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
+  -> (longident, 't1, 't2) Ast_pattern0.t
   -> (with_constraint, 't0, 't2) Ast_pattern0.t
 
 val pmod_ident :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
   -> (module_expr, 't0, 't1) Ast_pattern0.t
 
 val pmod_structure :
-  (Structure_item.t list, 't0, 't1) Ast_pattern0.t
+  (structure_item list, 't0, 't1) Ast_pattern0.t
   -> (module_expr, 't0, 't1) Ast_pattern0.t
 
 val pmod_functor :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Module_type.t option, 't1, 't2) Ast_pattern0.t
-  -> (Module_expr.t, 't2, 't3) Ast_pattern0.t
+  -> (module_type option, 't1, 't2) Ast_pattern0.t
+  -> (module_expr, 't2, 't3) Ast_pattern0.t
   -> (module_expr, 't0, 't3) Ast_pattern0.t
 
 val pmod_apply :
-  (Module_expr.t, 't0, 't1) Ast_pattern0.t
-  -> (Module_expr.t, 't1, 't2) Ast_pattern0.t
+  (module_expr, 't0, 't1) Ast_pattern0.t
+  -> (module_expr, 't1, 't2) Ast_pattern0.t
   -> (module_expr, 't0, 't2) Ast_pattern0.t
 
 val pmod_constraint :
-  (Module_expr.t, 't0, 't1) Ast_pattern0.t
-  -> (Module_type.t, 't1, 't2) Ast_pattern0.t
+  (module_expr, 't0, 't1) Ast_pattern0.t
+  -> (module_type, 't1, 't2) Ast_pattern0.t
   -> (module_expr, 't0, 't2) Ast_pattern0.t
 
 val pmod_unpack :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
   -> (module_expr, 't0, 't1) Ast_pattern0.t
 
 val pmod_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (module_expr, 't0, 't1) Ast_pattern0.t
 
 val pmod_loc :
@@ -832,71 +832,71 @@ val pmod_loc :
   -> (module_expr, 't1, 't2) Ast_pattern0.t
 
 val pmod_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (module_expr, 't1, 't2) Ast_pattern0.t
 
 val pstr_eval :
-  (Expression.t, 't0, 't1) Ast_pattern0.t
-  -> (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (expression, 't0, 't1) Ast_pattern0.t
+  -> (attribute list, 't1, 't2) Ast_pattern0.t
   -> (structure_item, 't0, 't2) Ast_pattern0.t
 
 val pstr_value :
-  (Rec_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Value_binding.t list, 't1, 't2) Ast_pattern0.t
+  (rec_flag, 't0, 't1) Ast_pattern0.t
+  -> (value_binding list, 't1, 't2) Ast_pattern0.t
   -> (structure_item, 't0, 't2) Ast_pattern0.t
 
 val pstr_primitive :
-  (Value_description.t, 't0, 't1) Ast_pattern0.t
+  (value_description, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_type :
-  (Rec_flag.t, 't0, 't1) Ast_pattern0.t
-  -> (Type_declaration.t list, 't1, 't2) Ast_pattern0.t
+  (rec_flag, 't0, 't1) Ast_pattern0.t
+  -> (type_declaration list, 't1, 't2) Ast_pattern0.t
   -> (structure_item, 't0, 't2) Ast_pattern0.t
 
 val pstr_typext :
-  (Type_extension.t, 't0, 't1) Ast_pattern0.t
+  (type_extension, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_exception :
-  (Extension_constructor.t, 't0, 't1) Ast_pattern0.t
+  (extension_constructor, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_module :
-  (Module_binding.t, 't0, 't1) Ast_pattern0.t
+  (module_binding, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_recmodule :
-  (Module_binding.t list, 't0, 't1) Ast_pattern0.t
+  (module_binding list, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_modtype :
-  (Module_type_declaration.t, 't0, 't1) Ast_pattern0.t
+  (module_type_declaration, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_open :
-  (Open_description.t, 't0, 't1) Ast_pattern0.t
+  (open_description, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_class :
-  (Class_declaration.t list, 't0, 't1) Ast_pattern0.t
+  (class_declaration list, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_class_type :
-  (Class_type_declaration.t list, 't0, 't1) Ast_pattern0.t
+  (class_type_declaration list, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_include :
-  (Module_expr.t Include_infos.t, 't0, 't1) Ast_pattern0.t
+  (module_expr include_infos, 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_attribute :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
   -> (structure_item, 't0, 't1) Ast_pattern0.t
 
 val pstr_extension :
-  ((string Astlib.Loc.t * Payload.t), 't0, 't1) Ast_pattern0.t
-  -> (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  ((string Astlib.Loc.t * payload), 't0, 't1) Ast_pattern0.t
+  -> (attribute list, 't1, 't2) Ast_pattern0.t
   -> (structure_item, 't0, 't2) Ast_pattern0.t
 
 val pstr_loc :
@@ -904,7 +904,7 @@ val pstr_loc :
   -> (structure_item, 't1, 't2) Ast_pattern0.t
 
 val pvb_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (value_binding, 't1, 't2) Ast_pattern0.t
 
 val pvb_loc :
@@ -912,7 +912,7 @@ val pvb_loc :
   -> (value_binding, 't1, 't2) Ast_pattern0.t
 
 val pmb_attributes :
-  (Attribute.t list, 't1, 't2) Ast_pattern0.t
+  (attribute list, 't1, 't2) Ast_pattern0.t
   -> (module_binding, 't1, 't2) Ast_pattern0.t
 
 val pmb_loc :
@@ -920,12 +920,12 @@ val pmb_loc :
   -> (module_binding, 't1, 't2) Ast_pattern0.t
 
 val ptop_def :
-  (Structure_item.t list, 't0, 't1) Ast_pattern0.t
+  (structure_item list, 't0, 't1) Ast_pattern0.t
   -> (toplevel_phrase, 't0, 't1) Ast_pattern0.t
 
 val ptop_dir :
   (string, 't0, 't1) Ast_pattern0.t
-  -> (Directive_argument.t, 't1, 't2) Ast_pattern0.t
+  -> (directive_argument, 't1, 't2) Ast_pattern0.t
   -> (toplevel_phrase, 't0, 't2) Ast_pattern0.t
 
 val pdir_string :
@@ -938,7 +938,7 @@ val pdir_int :
   -> (directive_argument, 't0, 't2) Ast_pattern0.t
 
 val pdir_ident :
-  (Longident.t, 't0, 't1) Ast_pattern0.t
+  (longident, 't0, 't1) Ast_pattern0.t
   -> (directive_argument, 't0, 't1) Ast_pattern0.t
 
 val pdir_bool :

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -1,33 +1,34 @@
 open! Import
+open Current_ast
 
 class map = object
   inherit Traverse_builtins.map
-  inherit Ast.Virtual.map
+  inherit Virtual.map
 end
 
 class iter = object
   inherit Traverse_builtins.iter
-  inherit Ast.Virtual.iter
+  inherit Virtual.iter
 end
 
 class ['acc] fold = object
   inherit ['acc] Traverse_builtins.fold
-  inherit ['acc] Ast.Virtual.fold
+  inherit ['acc] Virtual.fold
 end
 
 class ['acc] fold_map = object
   inherit ['acc] Traverse_builtins.fold_map
-  inherit ['acc] Ast.Virtual.fold_map
+  inherit ['acc] Virtual.fold_map
 end
 
 class ['ctx] map_with_context = object
   inherit ['ctx] Traverse_builtins.map_with_context
-  inherit ['ctx] Ast.Virtual.map_with_context
+  inherit ['ctx] Virtual.map_with_context
 end
 
 class virtual ['res] lift = object
   inherit ['res] Traverse_builtins.lift
-  inherit ['res] Ast.Virtual.lift
+  inherit ['res] Virtual.lift
 end
 
 let enter name path = if String.is_empty path then name else path ^ "." ^ name
@@ -138,7 +139,7 @@ class map_with_expansion_context = object (self)
 end
 
 class sexp_of = object
-  inherit [Sexp.t] Ast.Virtual.lift
+  inherit [Sexp.t] Virtual.lift
 
   method int       = Sexp.Encoder.int
   method string    = Sexp.Encoder.string

--- a/src/ast_traverse.mli
+++ b/src/ast_traverse.mli
@@ -1,6 +1,9 @@
 (** AST traversal classes *)
 
+(* TODO: remove in favor of Ppx_ast's versioned traversals *)
+
 open! Import
+open Current_ast
 
 (** To use these classes, inherit from them and override the methods corresponding to the
     types from [Parsetree] you want to process. For instance to collect all the string
@@ -29,27 +32,27 @@ open! Import
 
 class map : object
   inherit Traverse_builtins.map
-  inherit Ast.Virtual.map
+  inherit Virtual.map
 end
 
 class iter : object
   inherit Traverse_builtins.iter
-  inherit Ast.Virtual.iter
+  inherit Virtual.iter
 end
 
 class ['acc] fold : object
   inherit ['acc] Traverse_builtins.fold
-  inherit ['acc] Ast.Virtual.fold
+  inherit ['acc] Virtual.fold
 end
 
 class ['acc] fold_map : object
   inherit ['acc] Traverse_builtins.fold_map
-  inherit ['acc] Ast.Virtual.fold_map
+  inherit ['acc] Virtual.fold_map
 end
 
 class ['ctx] map_with_context : object
   inherit ['ctx] Traverse_builtins.map_with_context
-  inherit ['ctx] Ast.Virtual.map_with_context
+  inherit ['ctx] Virtual.map_with_context
 end
 
 class map_with_path : [string] map_with_context
@@ -58,12 +61,12 @@ class map_with_expansion_context : [Expansion_context.Base.t] map_with_context
 
 class virtual ['res] lift : object
   inherit ['res] Traverse_builtins.lift
-  inherit ['res] Ast.Virtual.lift
+  inherit ['res] Virtual.lift
 end
 
 class sexp_of : object
   inherit [Sexp.t] Traverse_builtins.std_lifters
-  inherit [Sexp.t] Ast.Virtual.lift
+  inherit [Sexp.t] Virtual.lift
 end
 
 val sexp_of : sexp_of

--- a/src/attr.ml
+++ b/src/attr.ml
@@ -1,4 +1,5 @@
 open! Import
+open Current_ast
 
 let poly_equal a b =
   let module Poly = struct

--- a/src/cinaps/ppxlib_cinaps_helpers.ml
+++ b/src/cinaps/ppxlib_cinaps_helpers.ml
@@ -113,7 +113,7 @@ module Generate_ast_patterns = struct
             ~field_name:None
             ~on_clause)
 
-  let string_of_ty ty = Grammar.string_of_ty ~internal:false ty
+  let string_of_ty ty = Grammar.string_of_ty ~nodify:false ty
 
   let print_arrow inputs output =
     Ml.print_arrow inputs ~f:Fn.id output

--- a/src/cinaps/ppxlib_cinaps_helpers.ml
+++ b/src/cinaps/ppxlib_cinaps_helpers.ml
@@ -21,6 +21,11 @@ let str_to_sig =
   fun s ->
     print_string (Str.global_substitute re map s)
 
+let define_current_ast () =
+  Print.newline ();
+  Print.println "module Current_ast = Ppx_ast.%s"
+    (Ml.module_name (Astlib.Version.to_string Astlib.current_version))
+
 module Generate_ast_patterns = struct
   let current_grammar () =
     Astlib.History.find_grammar Astlib.history ~version:Astlib.current_version

--- a/src/cinaps/ppxlib_cinaps_helpers.mli
+++ b/src/cinaps/ppxlib_cinaps_helpers.mli
@@ -1,3 +1,4 @@
 val str_to_sig : string -> unit
 val generate_ast_pattern_impl : unit -> unit
 val generate_ast_pattern_intf : unit -> unit
+val define_current_ast : unit -> unit

--- a/src/code_matcher.ml
+++ b/src/code_matcher.ml
@@ -1,4 +1,5 @@
 open! Import
+open Current_ast
 
 (* TODO: make the "deriving." depend on the matching attribute name. *)
 let end_marker_sig =

--- a/src/common.ml
+++ b/src/common.ml
@@ -1,4 +1,5 @@
 open! Import
+open Current_ast
 open Ast_builder
 
 let lident x = Longident.lident x
@@ -152,7 +153,7 @@ let assert_no_attributes_in = object
 end
 
 let attribute_of_warning loc s =
-  Ast.Attribute.create
+  Attribute.create
     ({ loc; txt = "ocaml.ppwarning" },
      Payload.pStr
        (Structure.create [pstr_eval ~loc (estring ~loc s) (Attributes.create [])]))

--- a/src/common.mli
+++ b/src/common.mli
@@ -1,6 +1,6 @@
 open! Import
 
-val lident : string -> Longident.t
+val lident : string -> longident
 
 val core_type_of_type_declaration : type_declaration -> core_type
 
@@ -36,13 +36,13 @@ class type_is_recursive : rec_flag -> type_declaration list -> object
 
     method return_true : unit -> unit
 
-    method go : unit -> Rec_flag.t
+    method go : unit -> rec_flag
   end
 
 (** [really_recursive rec_flag tds = (new type_is_recursive rec_flag tds)#go ()] *)
 val really_recursive : rec_flag -> type_declaration list -> rec_flag
 
-val loc_of_payload   : _ Loc.t * Payload.t -> Location.t
+val loc_of_payload   : _ Loc.t * payload -> Location.t
 val loc_of_attribute : attribute -> Location.t
 
 (** convert multi-arg function applications into a cascade of 1-arg applications *)

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -1,5 +1,6 @@
 (*$ open Ppxlib_cinaps_helpers $*)
 open! Import
+open Current_ast
 open Common
 
 module E  = Ext

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -64,7 +64,7 @@ module Rule : sig
   type ('a, 'b, 'c, 'd) attr_group_inline =
     ('b, 'c) Attr.t
     -> (ctxt:Expansion_context.Deriver.t
-        -> Rec_flag.t
+        -> rec_flag
         -> 'b list
         -> 'c option list
         -> 'd)

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -1,4 +1,5 @@
 open Import
+open Current_ast
 open Ast_builder
 
 (* [do_insert_unused_warning_attribute] -- If true, generated code

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1,5 +1,6 @@
 (*$ open Ppxlib_cinaps_helpers $*)
 open Import
+open Current_ast
 open Utils
 
 module Arg = Arg

--- a/src/ext.ml
+++ b/src/ext.ml
@@ -1,4 +1,5 @@
 open! Import
+open Current_ast
 open Common
 
 type (_, _) equality = Eq : ('a, 'a) equality | Ne : (_, _) equality

--- a/src/ext.mli
+++ b/src/ext.mli
@@ -67,7 +67,7 @@ val declare_with_path_arg
   :  string
   -> 'context Context.t
   -> (payload, 'a, 'context) Ast_pattern.t
-  -> (loc:Location.t -> path:string -> arg:Longident.t Loc.t option -> 'a)
+  -> (loc:Location.t -> path:string -> arg:longident Loc.t option -> 'a)
   -> t
 
 (** Inline the result of the expansion into its parent. Only works for these contexts:
@@ -88,7 +88,7 @@ val declare_inline_with_path_arg
   :  string
   -> 'context Context.t
   -> (payload, 'a, 'context list) Ast_pattern.t
-  -> (loc:Location.t -> path:string -> arg:Longident.t Loc.t option -> 'a)
+  -> (loc:Location.t -> path:string -> arg:longident Loc.t option -> 'a)
   -> t
 
 val of_bootstrap_extension : Ppx_bootstrap.Extension.t -> t
@@ -137,7 +137,7 @@ module Expert : sig
     :  string
     -> 'context Context.t
     -> (payload, 'a, 'b) Ast_pattern.t
-    -> (arg:Longident.t Loc.t option -> 'a)
+    -> (arg:longident Loc.t option -> 'a)
     -> ('context, 'b) t
 
   val convert : (_, 'a) t list -> loc:Location.t -> extension -> 'a option

--- a/src/file_path.ml
+++ b/src/file_path.ml
@@ -1,4 +1,5 @@
 open! Import
+open Current_ast
 
 let get_default_path (loc : Location.t) =
   let fname = loc.loc_start.pos_fname in

--- a/src/ignore_unused_warning.ml
+++ b/src/ignore_unused_warning.ml
@@ -1,4 +1,5 @@
 open Import
+open Current_ast
 open Ast_builder
 
 let underscore_binding exp =

--- a/src/import.ml
+++ b/src/import.ml
@@ -1,7 +1,9 @@
 include Stdppx
 include Ppx_ast
-module Ast = V4_07
-include Ast
+
+(*$ Ppxlib_cinaps_helpers.define_current_ast () *)
+module Current_ast = Ppx_ast.V4_07
+(*$*)
 
 (* This is not re-exported by Base and we can't use [%here] in ppx *)
 external __FILE__ : string = "%loc_FILE"

--- a/src/longid.ml
+++ b/src/longid.ml
@@ -1,4 +1,5 @@
 open! Import
+open Current_ast
 
 module Concrete = struct
   type t =

--- a/src/merlin_helpers.ml
+++ b/src/merlin_helpers.ml
@@ -1,12 +1,13 @@
 open! Import
+open Current_ast
 
 let mknoloc txt : _ Loc.t = { txt; loc = Location.none }
 
 let hide_attribute =
-  Ast.Attribute.create (mknoloc "merlin.hide", Payload.pStr (Structure.create []))
+  Attribute.create (mknoloc "merlin.hide", Payload.pStr (Structure.create []))
 
 let focus_attribute =
-  Ast.Attribute.create (mknoloc "merlin.focus", Payload.pStr (Structure.create []))
+  Attribute.create (mknoloc "merlin.focus", Payload.pStr (Structure.create []))
 
 let cons attr attributes =
   Attributes.create (attr :: Attributes.to_concrete attributes)

--- a/src/ppx.ml
+++ b/src/ppx.ml
@@ -22,10 +22,9 @@ include struct
           )
 end (** @inline *)
 
-(** Includes the overrides from Ppx_ast_deprecated, as well as all the Ast definitions since we
-    need them in every single ppx *)
+(** Includes the overrides from Ppx_ast, as well as all the Ast definitions since we need
+    them in every single ppx *)
 include Ppx_ast
-include Import.Ast
 
 module Ast_builder         = Ast_builder
 module Ast_pattern         = Ast_pattern

--- a/src/quoter.ml
+++ b/src/quoter.ml
@@ -1,4 +1,5 @@
 open Import
+open Current_ast
 
 type t =
   { mutable next_id : int

--- a/test/deriving/inline/foo-deriver/a_ppx_foo_deriver.ml
+++ b/test/deriving/inline/foo-deriver/a_ppx_foo_deriver.ml
@@ -1,4 +1,5 @@
 open Ppx
+open V4_07
 
 (*
    [[@@deriving foo]] expands to:

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -3,6 +3,7 @@
 
 open Base
 open Ppx
+open V4_07
 
 let () = Driver.enable_checks ()
 

--- a/test/driver/transformations/test.ml
+++ b/test/driver/transformations/test.ml
@@ -3,6 +3,7 @@
 
 open Base
 open Ppx
+open V4_07
 
 (* Linters *)
 


### PR DESCRIPTION
Changed interfaces to refer to unversioned type names instead of the names from v4.07. Removed the automatic inclusion of v4.07 from Ppx_ast and Ppx_ast.Import.

This is a fairly pervasive change, but it's also quite formulaic.