### PR TITLE
Moved Pprintast from Ppx_ast_deprecated to Ppx

### DIFF
--- a/ast_deprecated/dune
+++ b/ast_deprecated/dune
@@ -16,7 +16,6 @@
   location_helper
   parse
   parser
-  pprintast
   ppx_ast_deprecated
   syntaxerr
   warn)

--- a/ast_deprecated/ppx_ast_deprecated.ml
+++ b/ast_deprecated/ppx_ast_deprecated.ml
@@ -10,7 +10,6 @@ module Lexer          = Lexer
 module Parse          = Parse
 module Parser         = Parser
 module Parsetree      = Parsetree
-module Pprintast      = Pprintast
 module Select_ast     = Select_ast
 module Selected_ast   = Selected_ast
 module Syntaxerr      = Syntaxerr

--- a/src/pprintast.ml
+++ b/src/pprintast.ml
@@ -21,13 +21,15 @@
 (* Extensive Rewrite: Hongbo Zhang: University of Pennsylvania *)
 (* TODO more fine-grained precedence pretty-printing *)
 
-open Import
+[@@@warning "-9"]
+
+open Ppx_ast_deprecated.Import_for_core
 open Asttypes
 open Format
-open Location
-open Longident
+open Ocaml_common.Location
+open Ocaml_common.Longident
 open Parsetree
-open Ast_helper
+open Ppx_ast_deprecated.Ast_helper
 
 let prefix_symbols  = [ '!'; '?'; '~' ] ;;
 let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';

--- a/src/pprintast.mli
+++ b/src/pprintast.mli
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Import
+open Ppx_ast_deprecated.Import_for_core
 
 type space_formatter = (unit, Format.formatter, unit) format
 

--- a/src/reconcile.ml
+++ b/src/reconcile.ml
@@ -1,6 +1,5 @@
 open! Import
 open Utils
-module Pprintast = Ppx_ast_deprecated.Pprintast
 
 module Context = struct
   type 'a t =


### PR DESCRIPTION
This is step one of converting it to use `Ppx_ast`. Moving it first gives us a better diff when we update it.